### PR TITLE
Fix font family not applying to PDF body text

### DIFF
--- a/src/components/editor/DocumentTypeSelector.tsx
+++ b/src/components/editor/DocumentTypeSelector.tsx
@@ -378,7 +378,7 @@ export function DocumentTypeSelector() {
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="times">Times New Roman</SelectItem>
-                <SelectItem value="courier">Courier</SelectItem>
+                <SelectItem value="courier">Courier New</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -403,57 +403,69 @@ const VariableExtension = VariableNode.extend({
 });
 
 // Convert editor content to {{VARIABLE}} text format with LaTeX formatting
+// Each ProseMirror paragraph becomes a line separated by \n
 function editorToText(editor: ReturnType<typeof useEditor>): string {
   if (!editor) return '';
-  let result = '';
+  const paragraphs: string[] = [];
 
-  editor.state.doc.descendants((node) => {
-    if (node.type.name === 'variable') {
-      result += `{{${node.attrs.name}}}`;
-    } else if (node.isText && node.text) {
-      let text = node.text;
-      // Apply LaTeX formatting based on marks
-      const marks = node.marks;
-      const hasBold = marks.some(m => m.type.name === 'bold');
-      const hasItalic = marks.some(m => m.type.name === 'italic');
-      const hasUnderline = marks.some(m => m.type.name === 'underline');
+  editor.state.doc.forEach((node) => {
+    if (node.type.name === 'paragraph') {
+      let paraText = '';
+      node.forEach((child) => {
+        if (child.type.name === 'variable') {
+          paraText += `{{${child.attrs.name}}}`;
+        } else if (child.isText && child.text) {
+          let text = child.text;
+          // Apply LaTeX formatting based on marks
+          const marks = child.marks;
+          const hasBold = marks.some(m => m.type.name === 'bold');
+          const hasItalic = marks.some(m => m.type.name === 'italic');
+          const hasUnderline = marks.some(m => m.type.name === 'underline');
 
-      if (hasBold) text = `\\textbf{${text}}`;
-      if (hasItalic) text = `\\textit{${text}}`;
-      if (hasUnderline) text = `\\underline{${text}}`;
+          if (hasBold) text = `\\textbf{${text}}`;
+          if (hasItalic) text = `\\textit{${text}}`;
+          if (hasUnderline) text = `\\underline{${text}}`;
 
-      result += text;
+          paraText += text;
+        }
+      });
+      paragraphs.push(paraText);
     }
-    return true;
   });
-  return result.trim();
+
+  return paragraphs.join('\n').trim();
 }
 
 // Convert {{VARIABLE}} text with LaTeX formatting to editor HTML content
+// Each line becomes a separate <p> element so Tiptap preserves paragraph breaks
 function textToEditorHtml(text: string): string {
-  let html = text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+  const lines = text.split('\n');
 
-  // Convert LaTeX formatting to HTML
-  // Handle nested formatting by doing multiple passes
-  html = html.replace(/\\textbf\{([^{}]*)\}/g, '<strong>$1</strong>');
-  html = html.replace(/\\textit\{([^{}]*)\}/g, '<em>$1</em>');
-  html = html.replace(/\\underline\{([^{}]*)\}/g, '<u>$1</u>');
+  return lines.map(line => {
+    let html = line
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
 
-  // Convert variables to spans - check both default and custom variables
-  html = html.replace(/\{\{([A-Z0-9_]+)\}\}/g, (_, name) => {
-    const placeholder = BATCH_PLACEHOLDERS.find(p => p.name === name);
-    const customVars = getCustomVariables();
-    const customVar = customVars.find(p => p.name === name);
-    const label = placeholder?.label || customVar?.label || name;
-    // Register the variable in case it's new
-    addCustomVariable(name);
-    return `<span data-type="variable" data-name="${name}" data-label="${label}">@${label}</span>`;
-  });
+    // Convert LaTeX formatting to HTML
+    // Handle nested formatting by doing multiple passes
+    html = html.replace(/\\textbf\{([^{}]*)\}/g, '<strong>$1</strong>');
+    html = html.replace(/\\textit\{([^{}]*)\}/g, '<em>$1</em>');
+    html = html.replace(/\\underline\{([^{}]*)\}/g, '<u>$1</u>');
 
-  return `<p>${html || '<br>'}</p>`;
+    // Convert variables to spans - check both default and custom variables
+    html = html.replace(/\{\{([A-Z0-9_]+)\}\}/g, (_, name) => {
+      const placeholder = BATCH_PLACEHOLDERS.find(p => p.name === name);
+      const customVars = getCustomVariables();
+      const customVar = customVars.find(p => p.name === name);
+      const label = placeholder?.label || customVar?.label || name;
+      // Register the variable in case it's new
+      addCustomVariable(name);
+      return `<span data-type="variable" data-name="${name}" data-label="${label}">@${label}</span>`;
+    });
+
+    return `<p>${html || '<br>'}</p>`;
+  }).join('');
 }
 
 // Formatting toolbar for the editor

--- a/src/lib/latex-templates.js
+++ b/src/lib/latex-templates.js
@@ -251,6 +251,9 @@ const LATEX_TEMPLATES = {
     }{%
         \\renewcommand{\\familydefault}{\\ttdefault}%
     }%
+    % Activate the font family — \\familydefault only stores the value,
+    % \\fontfamily actually switches the active font for subsequent text
+    \\fontfamily{\\familydefault}%
     % Apply font size by redefining \\normalsize
     % This ensures the size persists in tabular environments and after groups
     \\ifthenelse{\\equal{\\FontSize}{10pt}}{%
@@ -263,6 +266,7 @@ const LATEX_TEMPLATES = {
 
 % Direct font size application - use when \\normalsize might be overridden
 \\newcommand{\\applyDocumentFontSize}{%
+    \\fontfamily{\\familydefault}%
     \\ifthenelse{\\equal{\\FontSize}{10pt}}{%
         \\fontsize{10pt}{12pt}\\selectfont%
     }{%


### PR DESCRIPTION
## Summary
- **Fix PDF preview showing Courier for body text when Times New Roman is selected.** The LaTeX template's `\applyFontSettings` updated `\familydefault` (a stored value) but never called `\fontfamily` to activate the switch. The letterhead appeared correct because it explicitly calls `\usefont{\encodingdefault}{\familydefault}...`, but all other text (body, address blocks, signature, references) stayed in Courier.
- **Correct font selector label** from "Courier" to "Courier New" to match SECNAV M-5216.5 terminology and the actual rendered font.
- **Fix forms preview not updating after user edits.** The `VariableChipEditor` (Tiptap rich text editor) had a broken newline round-trip: `textToEditorHtml` put all text in a single `<p>` (collapsing newlines), and `editorToText` concatenated paragraphs without inserting `\n`. After any edit to supplementalInfo, proposedAction, or remarksText, the PDF showed all text as one giant line.

## Changes
| File | Change |
|------|--------|
| `src/lib/latex-templates.js` | Add `\fontfamily{\familydefault}` to `\applyFontSettings` and `\applyDocumentFontSize` |
| `src/components/editor/DocumentTypeSelector.tsx` | Label: "Courier" → "Courier New" |
| `src/components/ui/variable-chip-editor.tsx` | Fix `textToEditorHtml` to split lines into separate `<p>` elements; fix `editorToText` to join paragraphs with `\n` |

## Root Cause — Font
In LaTeX, `\renewcommand{\familydefault}{\rmdefault}` only stores the new default — it does not switch the active font. You need `\fontfamily{\familydefault}\selectfont` to actually activate it.

## Root Cause — Forms
The Tiptap editor's `textToEditorHtml` wrapped all text in one `<p>` tag (HTML collapses `\n` to spaces). The `editorToText` used flat `descendants()` traversal without inserting `\n` between paragraph nodes. First compile with default data looked correct because the store still had original `\n`-separated text; any user edit triggered `onUpdate` → `editorToText` → store overwritten with collapsed text.

## Test plan
- [ ] Select Times New Roman → verify entire PDF preview renders in Times (letterhead, body, signature, refs)
- [ ] Select Courier New → verify entire PDF preview renders in Courier
- [ ] Switch between document types in compliant mode → verify font resets correctly
- [ ] Generate DOCX with both fonts → verify output matches
- [ ] Open NAVMC 10274 form → verify example data renders correctly
- [ ] Edit the Supplemental Information field → verify preview updates with proper paragraph breaks
- [ ] Edit the Proposed Action field → verify preview updates
- [ ] Open NAVMC 118(11) form → verify example data renders correctly
- [ ] Edit the Remarks field → verify preview updates with proper line breaks