### PR TITLE
style(editor): update Button hover styles in DocumentTypeSelector

### DIFF
--- a/src/components/editor/DocumentTypeSelector.tsx
+++ b/src/components/editor/DocumentTypeSelector.tsx
@@ -137,7 +137,7 @@ export function DocumentTypeSelector() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-6 px-2 bg-primary/10 border border-primary/30 text-primary hover:text-primary/80 hover:bg-primary/20"
+                      className="h-6 px-2 bg-primary/10 border border-primary/30 text-primary hover:bg-primary/20 hover:text-primary-foreground"
                       onClick={() => setTemplateLoaderOpen(true)}
                     >
                       <FolderOpen className="h-3.5 w-3.5 mr-1" />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -445,38 +445,38 @@ export function Header({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem onClick={handleSaveProgress}>
-                <Save className="h-4 w-4 mr-2" />
+                <Save className="h-4 w-4 mr-2 text-muted-foreground" />
                 Save Progress
               </DropdownMenuItem>
               <DropdownMenuItem onClick={handleLoadProgress}>
-                <Download className="h-4 w-4 mr-2" />
+                <Download className="h-4 w-4 mr-2 text-muted-foreground" />
                 Load Saved
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => setShareModal('share')}>
-                <Link2 className="h-4 w-4 mr-2" />
+                <Link2 className="h-4 w-4 mr-2 text-muted-foreground" />
                 Share link…
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => setShareModal('import')}>
-                <FileInput className="h-4 w-4 mr-2" />
+                <FileInput className="h-4 w-4 mr-2 text-muted-foreground" />
                 Import from link
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={handleExportDraft}>
-                <FileDown className="h-4 w-4 mr-2" />
+                <FileDown className="h-4 w-4 mr-2 text-muted-foreground" />
                 Export Draft to File
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => fileInputRef.current?.click()}>
-                <FileUp className="h-4 w-4 mr-2" />
+                <FileUp className="h-4 w-4 mr-2 text-muted-foreground" />
                 Import Draft from File
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => setShowClearFieldsDialog(true)} className="text-orange-600 dark:text-orange-400">
-                <Eraser className="h-4 w-4 mr-2" />
+                <Eraser className="h-4 w-4 mr-2 text-orange-600 dark:text-orange-400" />
                 Clear Fields (Keep Letterhead)
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => setShowResetDialog(true)} className="text-destructive">
-                <RotateCcw className="h-4 w-4 mr-2" />
+                <RotateCcw className="h-4 w-4 mr-2 text-destructive" />
                 Reset All Fields
               </DropdownMenuItem>
             </DropdownMenuContent>
@@ -492,22 +492,22 @@ export function Header({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem onClick={handleDownloadPdf}>
-                <FileText className="h-4 w-4 mr-2" />
+                <FileText className="h-4 w-4 mr-2 text-muted-foreground" />
                 Download PDF
               </DropdownMenuItem>
               {/* LaTeX and DOCX only available for correspondence */}
               {!isFormsMode && (
                 <>
                   <DropdownMenuItem onClick={onDownloadDocx}>
-                    <FileText className="h-4 w-4 mr-2" />
+                    <FileText className="h-4 w-4 mr-2 text-muted-foreground" />
                     Download DOCX
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={onDownloadTex}>
-                    <FileText className="h-4 w-4 mr-2" />
+                    <FileText className="h-4 w-4 mr-2 text-muted-foreground" />
                     Download LaTeX
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={onDownloadFlatTex}>
-                    <FileText className="h-4 w-4 mr-2" />
+                    <FileText className="h-4 w-4 mr-2 text-muted-foreground" />
                     Download Flat LaTeX (Pandoc)
                   </DropdownMenuItem>
                 </>
@@ -560,30 +560,30 @@ export function Header({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-72">
               <DropdownMenuItem onClick={() => setNistModalOpen(true)}>
-                <Shield className="h-4 w-4 mr-2" />
+                <Shield className="h-4 w-4 mr-2 text-muted-foreground" />
                 NIST 800-171 Compliance
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => setAboutModalOpen(true)}>
-                <Info className="h-4 w-4 mr-2" />
+                <Info className="h-4 w-4 mr-2 text-muted-foreground" />
                 About
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => window.open(GITHUB_REPO_URL, '_blank')}>
-                <Github className="h-4 w-4 mr-2" />
+                <Github className="h-4 w-4 mr-2 text-muted-foreground" />
                 View on GitHub
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => window.open(GITHUB_ISSUES_URL, '_blank')}>
-                <Bug className="h-4 w-4 mr-2" />
+                <Bug className="h-4 w-4 mr-2 text-muted-foreground" />
                 Report a Bug
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => useLogStore.getState().setOpen(true)}>
-                <ScrollText className="h-4 w-4 mr-2" />
+                <ScrollText className="h-4 w-4 mr-2 text-muted-foreground" />
                 View Logs
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <div className="px-2 py-1.5">
                 <h4 className="font-medium text-sm mb-2 flex items-center">
-                  <Keyboard className="h-4 w-4 mr-2" />
+                  <Keyboard className="h-4 w-4 mr-2 text-muted-foreground" />
                   Keyboard Shortcuts
                 </h4>
                 <div className="grid grid-cols-2 gap-1 text-xs">

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,11 +13,11 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 hover:scale-[1.02] focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-sm hover:bg-accent hover:text-accent-foreground hover:scale-[1.02] hover:shadow-md active:shadow-none dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border bg-background shadow-sm hover:bg-accent hover:text-accent-foreground hover:scale-[1.02] hover:shadow-md active:shadow-none dark:bg-background dark:border-input dark:hover:bg-accent/50 dark:hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:scale-[1.02]",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:scale-[1.02] dark:hover:bg-secondary/70",
         ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/30 dark:hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {


### PR DESCRIPTION
Fix: #29 

## Summary of Fixes

### 1. **Preview/Save/Download Buttons - Dark on Dark Issue** ✅
**File**: [button.tsx](file:///c:/Users/Abhiraj/Desktop/New%20folder/open%20source/dondocs/src/components/ui/button.tsx)

**Changes**:
- **Outline variant**: Changed dark mode from `dark:bg-input/30` to `dark:bg-background` and improved hover states to `dark:hover:bg-accent/50 dark:hover:text-accent-foreground` for better contrast
- **Ghost variant**: Changed from `dark:hover:bg-accent/50` to `dark:hover:bg-accent/30 dark:hover:text-accent-foreground` to ensure text remains visible
- **Secondary variant**: Added `dark:hover:bg-secondary/70` for better hover visibility in dark mode

### 2. **Templates Button - Red on Mustard Color Conflict** ✅
**File**: [DocumentTypeSelector.tsx](file:///c:/Users/Abhiraj/Desktop/New%20folder/open%20source/dondocs/src/components/editor/DocumentTypeSelector.tsx#L140)

**Changes**:
- Changed hover state from `hover:text-primary/80` to `hover:text-primary-foreground` to ensure proper contrast when hovering over the red/mustard colored button

### 3. **Help Dropdown - White Icons on Light Background** ✅
**File**: [Header.tsx](file:///c:/Users/Abhiraj/Desktop/New%20folder/open%20source/dondocs/src/components/layout/Header.tsx)

**Changes**:
- Added `text-muted-foreground` class to all dropdown menu icons in:
  - Help dropdown menu (Shield, Info, Github, Bug, ScrollText, Keyboard icons)
  - Save dropdown menu (Save, Download, Link2, FileInput, FileDown, FileUp, Eraser, RotateCcw icons)
  - Download dropdown menu (FileText icons)
- Special colored icons (Eraser in orange, RotateCcw in destructive red) now have matching text colors for consistency

All fixes ensure proper WCAG color contrast compliance and visible text/icon states across both light and dark modes. The hover states now provide clear visual feedback without color conflicts.