### PR TITLE
fix(docx): switch pandoc.wasm CDN from jsDelivr to unpkg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/lib/pandoc/pandoc.js
+++ b/public/lib/pandoc/pandoc.js
@@ -47,10 +47,21 @@ const fds = [
 ];
 const options = { debug: false };
 const wasi = new WASI(args, env, fds, options);
-// Fetch pandoc WASM binary from jsDelivr CDN (pandoc-wasm npm package, pandoc 3.9).
+// Fetch pandoc WASM binary from unpkg CDN (pandoc-wasm npm package, pandoc 3.9).
+// NOTE: we previously used jsDelivr, but jsDelivr enforces a 50 MB/file limit and
+// this WASM is ~58 MB. jsDelivr responds with HTTP 403 and a plain-text body
+// ("File size exceeded the configured limit of 50 MB."), which then fails
+// WebAssembly.instantiate() with a cryptic "expected magic word 00 61 73 6d,
+// found 46 69 6c 65" error (the ASCII bytes of "File"). unpkg has no such limit.
 // Uses ArrayBuffer instantiation instead of instantiateStreaming to bypass MIME type checks.
-const wasmUrl = "https://cdn.jsdelivr.net/npm/pandoc-wasm@1.0.1/src/pandoc.wasm";
+const wasmUrl = "https://unpkg.com/pandoc-wasm@1.0.1/src/pandoc.wasm";
 const wasmResponse = await fetch(wasmUrl);
+if (!wasmResponse.ok) {
+  throw new Error(
+    `Failed to fetch pandoc.wasm from ${wasmUrl}: ` +
+    `HTTP ${wasmResponse.status} ${wasmResponse.statusText}`
+  );
+}
 const wasmBytes = await wasmResponse.arrayBuffer();
 const { instance } = await WebAssembly.instantiate(wasmBytes, {
   wasi_snapshot_preview1: wasi.wasiImport,


### PR DESCRIPTION
## Problem

Users cannot download DOCX output from the live site. Reported in #31 — "Unable to download any filetype completed correspondence. After clicking download, nothing happens."

Browser console shows:

```
[ERROR] DOCX generation error: CompileError: WebAssembly.instantiate():
expected magic word 00 61 73 6d, found 46 69 6c 65 @+0
```

## Root cause

jsDelivr enforces a **50 MB per-file size limit**. Our `pandoc.wasm` (from the `pandoc-wasm@1.0.1` npm package) is **~58 MB**, so jsDelivr refuses to serve it:

```
HTTP/2 403
content-type: text/plain; charset=utf-8
content-length: 49

File size exceeded the configured limit of 50 MB.
```

`pandoc.js` was blindly feeding that 49-byte error body into `WebAssembly.instantiate()`. The bytes `46 69 6c 65` in the error are ASCII `"File"` — the start of jsDelivr's plain-text error message.

## Why did this just break?

This bug was latent for ~2 months, hidden by service-worker caching: early fetches succeeded (before jsDelivr started caching the 403), and the WASM stayed pinned in `CacheStorage` for anyone who had it.

PR #32 (PWA stale-cache fix, shipped earlier today) invalidated those caches on deploy, which exposed the broken CDN URL for all users simultaneously.

## Changes

- **`public/lib/pandoc/pandoc.js`** — switch `wasmUrl` from `cdn.jsdelivr.net` to `unpkg.com`. unpkg has no file-size limit, returns `content-type: application/wasm`, and includes proper CORS headers. Verified HTTP 200 with correct `\0asm` magic bytes.
- Add a `response.ok` guard so any future CDN failure throws a clear HTTP-status error instead of the cryptic WebAssembly decode error.
- **`package.json` / `package-lock.json`** — bump to `1.1.2`. Required so the service worker activates a new build and clients fetch the updated `pandoc.js` instead of serving the broken cached one.

## Alternative CDNs considered

| Option | Size limit | Verdict |
|---|---|---|
| **unpkg** | None | ✅ Chosen — simplest swap |
| GitHub Releases | None | Better long-term stability; more setup |
| Self-host on CF Pages | None | Best for control; adds a build-time step |

unpkg is the fastest path to restoration. We can revisit self-hosting later if unpkg availability becomes an issue.

## Test plan

- [x] Pull this branch, `npm run dev`, verify DOCX export produces a valid `.docx` file
- [x] Check browser devtools Network tab — `pandoc.wasm` returns HTTP 200 with `content-type: application/wasm`
- [x] Confirm CF Pages preview deploy builds with version `1.1.2`
- [x] On live site after merge: hard-refresh, trigger DOCX export, confirm file downloads cleanly
- [x] (Defensive) Temporarily point `wasmUrl` at a 404 to confirm the new `response.ok` guard surfaces a readable error

Refs #31