### PR TITLE
perf: cut render cascades via store selectors and memoized list rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9500,9 +9500,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.4",
+  "version": "1.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -134,35 +134,61 @@ function getDualSignatoryConfig(formData: Partial<DocumentData>, uiMode: string 
 }
 
 function App() {
-  const {
-    theme,
-    colorScheme,
-    density,
-    isMobile,
-    setIsMobile,
-    previewVisible,
-    previewWidth,
-    setPreviewVisible,
-    setPreviewWidth,
-    setFindReplaceOpen,
-    piiWarningOpen,
-    setPiiWarningOpen,
-    setTemplateLoaderOpen,
-    setReferenceLibraryOpen,
-    setShareModal,
-    shareModal,
-    togglePreview,
-    closeAllModals,
-    fullQualityPreview,
-  } = useUIStore();
+  // Individual selectors — Zustand only re-renders this component when the
+  // specific field changes by strict equality. Previously `useUIStore()`
+  // subscribed to the whole store, so every modal open/close and every
+  // autoSaveStatus transition was re-rendering App and its entire subtree.
+  // Setters are stable references from Zustand's `create()` callback, so
+  // selecting them individually adds no cost.
+  const theme = useUIStore((s) => s.theme);
+  const colorScheme = useUIStore((s) => s.colorScheme);
+  const density = useUIStore((s) => s.density);
+  const isMobile = useUIStore((s) => s.isMobile);
+  const setIsMobile = useUIStore((s) => s.setIsMobile);
+  const previewVisible = useUIStore((s) => s.previewVisible);
+  const previewWidth = useUIStore((s) => s.previewWidth);
+  const setPreviewVisible = useUIStore((s) => s.setPreviewVisible);
+  const setPreviewWidth = useUIStore((s) => s.setPreviewWidth);
+  const setFindReplaceOpen = useUIStore((s) => s.setFindReplaceOpen);
+  const piiWarningOpen = useUIStore((s) => s.piiWarningOpen);
+  const setPiiWarningOpen = useUIStore((s) => s.setPiiWarningOpen);
+  const setTemplateLoaderOpen = useUIStore((s) => s.setTemplateLoaderOpen);
+  const setReferenceLibraryOpen = useUIStore((s) => s.setReferenceLibraryOpen);
+  const setShareModal = useUIStore((s) => s.setShareModal);
+  const shareModal = useUIStore((s) => s.shareModal);
+  const togglePreview = useUIStore((s) => s.togglePreview);
+  const closeAllModals = useUIStore((s) => s.closeAllModals);
+  const fullQualityPreview = useUIStore((s) => s.fullQualityPreview);
   const mainContainerRef = useRef<HTMLElement>(null);
-  const documentStore = useDocumentStore();
-  const { documentCategory, formType } = useDocumentStore();
-  const { setFormData, applySnapshot } = useDocumentStore();
-  const formStore = useFormStore();
-  const { undo, redo } = useHistoryStore();
-  const { selectedProfile, profiles } = useProfileStore();
-  const { addLogDirect } = useLogStore();
+  // Individual selectors instead of a full `useDocumentStore()` subscription.
+  // The seven slices below are the ones that should invalidate the debounced
+  // compile; subscribing to them granularly means every other setter call
+  // (auto-save status pings, unrelated form field changes that the compile
+  // doesn't care about, etc.) no longer wakes App.tsx. Inside compilePdf we
+  // still need the full store for `generateAllLatexFiles`, but we pull it
+  // via `useDocumentStore.getState()` at call time so nothing gets stale.
+  const docType = useDocumentStore((s) => s.docType);
+  const formData = useDocumentStore((s) => s.formData);
+  const references = useDocumentStore((s) => s.references);
+  const enclosures = useDocumentStore((s) => s.enclosures);
+  const paragraphs = useDocumentStore((s) => s.paragraphs);
+  const copyTos = useDocumentStore((s) => s.copyTos);
+  const distributions = useDocumentStore((s) => s.distributions);
+  const documentCategory = useDocumentStore((s) => s.documentCategory);
+  const formType = useDocumentStore((s) => s.formType);
+  const setFormData = useDocumentStore((s) => s.setFormData);
+  const applySnapshot = useDocumentStore((s) => s.applySnapshot);
+  // Individual selectors — App no longer re-renders on every form-store
+  // keystroke (only when one of these three slices actually changes).
+  const navmc10274 = useFormStore((s) => s.navmc10274);
+  const navmc11811 = useFormStore((s) => s.navmc11811);
+  const includeCoverPage = useFormStore((s) => s.includeCoverPage);
+  // Individual selectors across the remaining stores too — same reasoning.
+  const undo = useHistoryStore((s) => s.undo);
+  const redo = useHistoryStore((s) => s.redo);
+  const selectedProfile = useProfileStore((s) => s.selectedProfile);
+  const profiles = useProfileStore((s) => s.profiles);
+  const addLogDirect = useLogStore((s) => s.addLogDirect);
   const { isReady, compile, waitForReady, error: engineError } = useLatexEngine();
   const { showUpdatePrompt, confirmUpdate, dismissUpdatePrompt } = useServiceWorker();
 
@@ -307,7 +333,12 @@ function App() {
     setCompileLog(null);
 
     try {
-      const { texFiles, enclosures, includeHyperlinks, signatureImage, referenceUrls } = generateAllLatexFiles(documentStore);
+      // Read the full document store at compile time via getState() so we
+      // don't need a render-subscribing reference. The debounce dep array
+      // already handles "when should we re-compile" granularly; by the time
+      // we get here the state is current.
+      const currentStore = useDocumentStore.getState();
+      const { texFiles, enclosures: generatedEnclosures, includeHyperlinks, signatureImage, referenceUrls } = generateAllLatexFiles(currentStore);
 
       // Build files object including signature image if present
       const files: Record<string, string | Uint8Array> = { ...texFiles };
@@ -323,20 +354,20 @@ function App() {
         // When disabled (default), these are deferred to the download/export path
         // for better responsiveness on slower machines.
         if (fullQualityPreview) {
-          if (enclosures.length > 0 || (includeHyperlinks && referenceUrls.length > 0)) {
-            const classification = getClassificationInfo(documentStore.formData.classLevel);
-            const mergeResult = await mergeEnclosures(pdfBytes, enclosures, classification, includeHyperlinks, referenceUrls);
+          if (generatedEnclosures.length > 0 || (includeHyperlinks && referenceUrls.length > 0)) {
+            const classification = getClassificationInfo(currentStore.formData.classLevel);
+            const mergeResult = await mergeEnclosures(pdfBytes, generatedEnclosures, classification, includeHyperlinks, referenceUrls);
             pdfBytes = mergeResult.pdfBytes;
           }
 
-          if (documentStore.formData.signatureType === 'digital') {
-            const config = DOC_TYPE_CONFIG[documentStore.docType];
+          if (currentStore.formData.signatureType === 'digital') {
+            const config = DOC_TYPE_CONFIG[currentStore.docType];
             const isDualSignature = config?.uiMode === 'moa' || config?.compliance?.dualSignature;
             if (isDualSignature) {
-              const sigConfig = getDualSignatoryConfig(documentStore.formData, config?.uiMode);
+              const sigConfig = getDualSignatoryConfig(currentStore.formData, config?.uiMode);
               pdfBytes = await addDualSignatureFields(new Uint8Array(pdfBytes), sigConfig);
             } else {
-              const sigConfig = getSignatoryConfig(documentStore.formData);
+              const sigConfig = getSignatoryConfig(currentStore.formData);
               pdfBytes = await addSignatureField(new Uint8Array(pdfBytes), sigConfig);
             }
           }
@@ -379,7 +410,10 @@ function App() {
     } finally {
       setIsCompiling(false);
     }
-  }, [isReady, compile, documentStore, pdfUrl, addLogDirect, fullQualityPreview]);
+    // documentStore is read via useDocumentStore.getState() inside, so it
+    // doesn't need to be in the deps — only the things we actually close
+    // over as React values. pdfUrl is captured for revocation.
+  }, [isReady, compile, pdfUrl, addLogDirect, fullQualityPreview]);
 
   // Auto-open the compile-error modal when a *new* error appears.
   // "New" = different message than the last one we popped the modal for.
@@ -423,15 +457,19 @@ function App() {
         clearTimeout(compileTimeoutRef.current);
       }
     };
+    // The deps are the granular slices that should invalidate a re-compile.
+    // `compilePdf` is intentionally NOT a dep — it captures documentStore via
+    // getState(), and we don't want a new compilePdf identity (e.g. from pdfUrl
+    // changing) to kick off an unrelated debounce cycle.
   }, [
     isReady,
-    documentStore.docType,
-    documentStore.formData,
-    documentStore.references,
-    documentStore.enclosures,
-    documentStore.paragraphs,
-    documentStore.copyTos,
-    documentStore.distributions,
+    docType,
+    formData,
+    references,
+    enclosures,
+    paragraphs,
+    copyTos,
+    distributions,
     fullQualityPreview,
   ]);
 
@@ -476,14 +514,14 @@ function App() {
 
         if (formType === 'navmc_10274' && navmc10274Templates) {
           pdfBytes = await generateNavmc10274Pdf(
-            formStore.navmc10274,
+            navmc10274,
             navmc10274Templates.page1,
             navmc10274Templates.page2,
             navmc10274Templates.page3
           );
         } else if (formType === 'navmc_118_11' && navmc11811Template) {
           pdfBytes = await generateNavmc11811Pdf(
-            formStore.navmc11811,
+            navmc11811,
             navmc11811Template
           );
         }
@@ -510,7 +548,7 @@ function App() {
         clearTimeout(formCompileTimeoutRef.current);
       }
     };
-  }, [documentCategory, formType, formStore.navmc10274, formStore.navmc11811, navmc10274Templates, navmc11811Template]);
+  }, [documentCategory, formType, navmc10274, navmc11811, navmc10274Templates, navmc11811Template]);
 
   // Track if download is in progress to prevent double downloads
   const downloadInProgressRef = useRef(false);
@@ -522,7 +560,10 @@ function App() {
     preOpenedWindow?: Window | null,
     onProgress?: (phase: DownloadProgressPhase) => void,
   ): Promise<boolean> => {
-    const { texFiles, enclosures, includeHyperlinks, signatureImage, referenceUrls } = generateAllLatexFiles(documentStore);
+    // Snapshot fresh state at download time via getState() rather than
+    // closing over a render-subscribed reference.
+    const currentStore = useDocumentStore.getState();
+    const { texFiles, enclosures: generatedEnclosures, includeHyperlinks, signatureImage, referenceUrls } = generateAllLatexFiles(currentStore);
 
     // Build files object including signature image if present
     const files: Record<string, string | Uint8Array> = { ...texFiles };
@@ -535,10 +576,10 @@ function App() {
 
     if (pdfBytes) {
       // Merge enclosures and/or create hyperlinks (handles both PDF and text-only enclosures, and reference URLs)
-      if (enclosures.length > 0 || (includeHyperlinks && referenceUrls.length > 0)) {
+      if (generatedEnclosures.length > 0 || (includeHyperlinks && referenceUrls.length > 0)) {
         onProgress?.({ kind: 'pdf-merging-enclosures' });
-        const classification = getClassificationInfo(documentStore.formData.classLevel);
-        const mergeResult = await mergeEnclosures(pdfBytes, enclosures, classification, includeHyperlinks, referenceUrls);
+        const classification = getClassificationInfo(currentStore.formData.classLevel);
+        const mergeResult = await mergeEnclosures(pdfBytes, generatedEnclosures, classification, includeHyperlinks, referenceUrls);
         pdfBytes = mergeResult.pdfBytes;
 
         // Track enclosure errors for user notification (download context)
@@ -549,15 +590,15 @@ function App() {
       }
 
       // Add digital signature field if requested
-      if (documentStore.formData.signatureType === 'digital') {
+      if (currentStore.formData.signatureType === 'digital') {
         onProgress?.({ kind: 'pdf-signing' });
-        const config = DOC_TYPE_CONFIG[documentStore.docType];
+        const config = DOC_TYPE_CONFIG[currentStore.docType];
         const isDualSignature = config?.uiMode === 'moa' || config?.compliance?.dualSignature;
         if (isDualSignature) {
-          const sigConfig = getDualSignatoryConfig(documentStore.formData, config?.uiMode);
+          const sigConfig = getDualSignatoryConfig(currentStore.formData, config?.uiMode);
           pdfBytes = await addDualSignatureFields(new Uint8Array(pdfBytes), sigConfig);
         } else {
-          const sigConfig = getSignatoryConfig(documentStore.formData);
+          const sigConfig = getSignatoryConfig(currentStore.formData);
           pdfBytes = await addSignatureField(new Uint8Array(pdfBytes), sigConfig);
         }
       }
@@ -567,7 +608,7 @@ function App() {
       return await downloadPdfBlob(blob, 'correspondence.pdf', preOpenedWindow);
     }
     return false;
-  }, [compile, documentStore]);
+  }, [compile]);
 
   const handleDownloadPdfInternal = useCallback(async () => {
     // Prevent multiple simultaneous downloads
@@ -693,7 +734,8 @@ function App() {
   const pendingDocxRef = useRef<boolean>(false);
 
   const executeDocxDownload = useCallback(async () => {
-    const latexContent = generateFlatLatex(documentStore);
+    const currentStore = useDocumentStore.getState();
+    const latexContent = generateFlatLatex(currentStore);
     // Show the progress modal immediately so the user gets feedback the moment
     // they click "Download DOCX" — the first run can spend several seconds in
     // `docx-preparing` before the WASM fetch even starts on slow connections.
@@ -703,12 +745,12 @@ function App() {
     setDownloadProgress({ kind: 'docx-preparing' });
     const blob = await convertLatexToDocx(
       latexContent,
-      documentStore.formData.sealType,
-      documentStore.formData.letterheadColor,
-      documentStore.formData.fontFamily,
-      documentStore.formData.fontSize,
-      documentStore.formData.classLevel,
-      documentStore.formData.customClassification,
+      currentStore.formData.sealType,
+      currentStore.formData.letterheadColor,
+      currentStore.formData.fontFamily,
+      currentStore.formData.fontSize,
+      currentStore.formData.classLevel,
+      currentStore.formData.customClassification,
       (phase) => setDownloadProgress(docxPhaseToDownloadPhase(phase)),
     );
     const url = URL.createObjectURL(blob);
@@ -719,7 +761,7 @@ function App() {
     setTimeout(() => URL.revokeObjectURL(url), 1000);
     // Success — clear the modal.
     setDownloadProgress(null);
-  }, [documentStore]);
+  }, []);
 
   // Core PII download function - can be called for retry
   const executePIIDownload = useCallback(async (
@@ -728,6 +770,7 @@ function App() {
   ): Promise<boolean> => {
     if (!pendingDownloadRef.current) return false;
 
+    const currentStore = useDocumentStore.getState();
     const { texFiles, enclosures, includeHyperlinks, signatureImage, referenceUrls } = pendingDownloadRef.current;
 
     const files: Record<string, string | Uint8Array> = { ...texFiles };
@@ -741,7 +784,7 @@ function App() {
     if (pdfBytes) {
       if (enclosures.length > 0 || (includeHyperlinks && referenceUrls.length > 0)) {
         onProgress?.({ kind: 'pdf-merging-enclosures' });
-        const classification = getClassificationInfo(documentStore.formData.classLevel);
+        const classification = getClassificationInfo(currentStore.formData.classLevel);
         const mergeResult = await mergeEnclosures(pdfBytes, enclosures, classification, includeHyperlinks, referenceUrls);
         pdfBytes = mergeResult.pdfBytes;
 
@@ -753,15 +796,15 @@ function App() {
       }
 
       // Add digital signature field if requested
-      if (documentStore.formData.signatureType === 'digital') {
+      if (currentStore.formData.signatureType === 'digital') {
         onProgress?.({ kind: 'pdf-signing' });
-        const config = DOC_TYPE_CONFIG[documentStore.docType];
+        const config = DOC_TYPE_CONFIG[currentStore.docType];
         const isDualSignature = config?.uiMode === 'moa' || config?.compliance?.dualSignature;
         if (isDualSignature) {
-          const sigConfig = getDualSignatoryConfig(documentStore.formData, config?.uiMode);
+          const sigConfig = getDualSignatoryConfig(currentStore.formData, config?.uiMode);
           pdfBytes = await addDualSignatureFields(new Uint8Array(pdfBytes), sigConfig);
         } else {
-          const sigConfig = getSignatoryConfig(documentStore.formData);
+          const sigConfig = getSignatoryConfig(currentStore.formData);
           pdfBytes = await addSignatureField(new Uint8Array(pdfBytes), sigConfig);
         }
       }
@@ -771,7 +814,7 @@ function App() {
       return await downloadPdfBlob(blob, 'correspondence.pdf', preOpenedWindow);
     }
     return false;
-  }, [compile, documentStore]);
+  }, [compile]);
 
   // Handle proceeding with download after PII warning is acknowledged
   const handleProceedWithPII = useCallback(async () => {
@@ -931,20 +974,20 @@ function App() {
 
       if (formType === 'navmc_10274' && navmc10274Templates) {
         pdfBytes = await generateNavmc10274Pdf(
-          formStore.navmc10274,
+          navmc10274,
           navmc10274Templates.page1,
           navmc10274Templates.page2,
           navmc10274Templates.page3,
-          { includeCoverPage: formStore.includeCoverPage }
+          { includeCoverPage }
         );
-        filename = `NAVMC-10274-${formStore.navmc10274.date || 'form'}.pdf`;
+        filename = `NAVMC-10274-${navmc10274.date || 'form'}.pdf`;
       } else if (formType === 'navmc_118_11' && navmc11811Template) {
         pdfBytes = await generateNavmc11811Pdf(
-          formStore.navmc11811,
+          navmc11811,
           navmc11811Template
         );
-        const lastName = formStore.navmc11811.lastName || 'Marine';
-        filename = `NAVMC-118-11-${lastName}-${formStore.navmc11811.entryDate || 'entry'}.pdf`;
+        const lastName = navmc11811.lastName || 'Marine';
+        filename = `NAVMC-118-11-${lastName}-${navmc11811.entryDate || 'entry'}.pdf`;
       }
 
       if (pdfBytes) {
@@ -965,7 +1008,7 @@ function App() {
     } finally {
       downloadInProgressRef.current = false;
     }
-  }, [formType, formStore.navmc10274, formStore.navmc11811, formStore.includeCoverPage, navmc10274Templates, navmc11811Template]);
+  }, [formType, navmc10274, navmc11811, includeCoverPage, navmc10274Templates, navmc11811Template]);
 
   const handleDownloadPdf = useCallback(() => {
     // Handle forms mode separately
@@ -1002,10 +1045,11 @@ function App() {
     console.log('Manual download click');
 
     // Check for PII before downloading
-    const piiResult = detectPII(documentStore);
+    const currentStore = useDocumentStore.getState();
+    const piiResult = detectPII(currentStore);
     if (piiResult.found) {
       // Store the generated files for later use
-      const { texFiles, enclosures, includeHyperlinks, signatureImage, referenceUrls } = generateAllLatexFiles(documentStore);
+      const { texFiles, enclosures, includeHyperlinks, signatureImage, referenceUrls } = generateAllLatexFiles(currentStore);
       pendingDownloadRef.current = { texFiles, enclosures, includeHyperlinks, signatureImage, referenceUrls };
       setPiiDetectionResult(piiResult);
       setPiiWarningOpen(true);
@@ -1014,10 +1058,10 @@ function App() {
 
     // No PII found, proceed with download
     handleDownloadPdfInternal();
-  }, [documentCategory, isReady, handleDownloadPdfInternal, handleDownloadFormPdf, documentStore, setPiiWarningOpen]);
+  }, [documentCategory, isReady, handleDownloadPdfInternal, handleDownloadFormPdf, setPiiWarningOpen]);
 
   const handleDownloadTex = useCallback(() => {
-    const { texFiles } = generateAllLatexFiles(documentStore);
+    const { texFiles } = generateAllLatexFiles(useDocumentStore.getState());
 
     // Combine all generated tex files into one downloadable file
     // The files are: document.tex, letterhead.tex, signatory.tex, flags.tex,
@@ -1091,10 +1135,10 @@ ${texFiles['body.tex'] || '% No body content'}
     a.download = 'correspondence.tex';
     a.click();
     URL.revokeObjectURL(url);
-  }, [documentStore]);
+  }, []);
 
   const handleDownloadFlatTex = useCallback(() => {
-    const flatTex = generateFlatLatex(documentStore);
+    const flatTex = generateFlatLatex(useDocumentStore.getState());
     const blob = new Blob([flatTex], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -1102,11 +1146,11 @@ ${texFiles['body.tex'] || '% No body content'}
     a.download = 'correspondence-flat.tex';
     a.click();
     URL.revokeObjectURL(url);
-  }, [documentStore]);
+  }, []);
 
   const handleDownloadDocx = useCallback(async () => {
     // Check for PII before downloading
-    const piiResult = detectPII(documentStore);
+    const piiResult = detectPII(useDocumentStore.getState());
     if (piiResult.found) {
       pendingDocxRef.current = true;
       setPiiDetectionResult(piiResult);
@@ -1129,7 +1173,7 @@ ${texFiles['body.tex'] || '% No body content'}
         reportable: true,
       });
     }
-  }, [documentStore, executeDocxDownload, setPiiWarningOpen, addLogDirect]);
+  }, [executeDocxDownload, setPiiWarningOpen, addLogDirect]);
 
   /**
    * Re-run the last failed download. The error phase carries the target

--- a/src/components/editor/DocumentTypeSelector.tsx
+++ b/src/components/editor/DocumentTypeSelector.tsx
@@ -42,7 +42,7 @@ export function DocumentTypeSelector() {
     documentMode, setDocumentMode,
     clearFieldsExceptLetterhead,
   } = useDocumentStore();
-  const { setTemplateLoaderOpen } = useUIStore();
+  const setTemplateLoaderOpen = useUIStore((s) => s.setTemplateLoaderOpen);
   const [showClearDialog, setShowClearDialog] = useState(false);
   const config = DOC_TYPE_CONFIG[docType] || DOC_TYPE_CONFIG.naval_letter;
   const isCompliant = documentMode === 'compliant';

--- a/src/components/editor/ParagraphsEditor.tsx
+++ b/src/components/editor/ParagraphsEditor.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import {
   DndContext,
   closestCenter,
@@ -92,29 +92,27 @@ interface SortableParagraphProps {
   label: string;
   showPortionMarking: boolean;
   disableIndent: boolean;  // True when numbered paragraphs are disabled (business letters, endorsements)
-  onUpdate: (text: string) => void;
-  onUpdateHeader: (header: string) => void;
-  onUpdatePortionMarking: (marking: PortionMarking | undefined) => void;
-  onRemove: () => void;
-  onIndent: () => void;
-  onOutdent: () => void;
-  onAddAfter: () => void;
 }
 
-function SortableParagraph({
+// Memoized so that typing in paragraph N doesn't force re-render of paragraphs
+// 1..N-1. The props are all primitives/stable refs except `paragraph` itself,
+// which only changes when that specific row's data changes — so default shallow
+// equality is sufficient. Store setters are pulled inline via selectors rather
+// than passed as callback props so the parent doesn't re-create closures per
+// row on every render (which would defeat memoization).
+const SortableParagraph = memo(function SortableParagraph({
   paragraph,
   index,
   label,
   showPortionMarking,
   disableIndent,
-  onUpdate,
-  onUpdateHeader,
-  onUpdatePortionMarking,
-  onRemove,
-  onIndent,
-  onOutdent,
-  onAddAfter,
 }: SortableParagraphProps) {
+  const updateParagraph = useDocumentStore((s) => s.updateParagraph);
+  const removeParagraph = useDocumentStore((s) => s.removeParagraph);
+  const indentParagraph = useDocumentStore((s) => s.indentParagraph);
+  const outdentParagraph = useDocumentStore((s) => s.outdentParagraph);
+  const addParagraph = useDocumentStore((s) => s.addParagraph);
+
   const {
     attributes,
     listeners,
@@ -165,7 +163,7 @@ function SortableParagraph({
             <span className="text-xs text-muted-foreground whitespace-nowrap">Header:</span>
             <Input
               value={paragraph.header || ''}
-              onChange={(e) => onUpdateHeader(e.target.value)}
+              onChange={(e) => updateParagraph(index, { header: e.target.value })}
               placeholder="Optional heading (auto-underlined)"
               className="h-7 text-sm flex-1"
             />
@@ -178,7 +176,7 @@ function SortableParagraph({
 
           <VariableChipEditor
             value={paragraph.text}
-            onChange={onUpdate}
+            onChange={(text) => updateParagraph(index, { text })}
             placeholder="Enter paragraph content... (type @ for variables)"
             rows={3}
           />
@@ -190,7 +188,7 @@ function SortableParagraph({
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={onOutdent}
+                  onClick={() => outdentParagraph(index)}
                   disabled={paragraph.level === 0}
                   title="Outdent (Shift+Tab)"
                 >
@@ -199,7 +197,7 @@ function SortableParagraph({
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={onIndent}
+                  onClick={() => indentParagraph(index)}
                   disabled={paragraph.level >= 7}
                   title="Indent (Tab)"
                 >
@@ -210,7 +208,7 @@ function SortableParagraph({
             <Button
               variant="ghost"
               size="sm"
-              onClick={onAddAfter}
+              onClick={() => addParagraph('', paragraph.level, index)}
               title="Add paragraph after"
             >
               <ArrowDown className="h-4 w-4 mr-1" />
@@ -221,7 +219,7 @@ function SortableParagraph({
             {showPortionMarking && (
               <Select
                 value={paragraph.portionMarking || ''}
-                onValueChange={(v) => onUpdatePortionMarking(v as PortionMarking || undefined)}
+                onValueChange={(v) => updateParagraph(index, { portionMarking: (v as PortionMarking) || undefined })}
               >
                 <SelectTrigger className="h-7 w-[70px] text-xs">
                   <SelectValue placeholder="Mark" />
@@ -243,7 +241,7 @@ function SortableParagraph({
             <Button
               variant="ghost"
               size="sm"
-              onClick={onRemove}
+              onClick={() => removeParagraph(index)}
               className="text-destructive hover:text-destructive"
               title="Remove paragraph"
             >
@@ -254,21 +252,18 @@ function SortableParagraph({
       </div>
     </div>
   );
-}
+});
 
 export function ParagraphsEditor() {
-  const {
-    documentMode,
-    docType,
-    formData,
-    paragraphs,
-    addParagraph,
-    updateParagraph,
-    removeParagraph,
-    reorderParagraphs,
-    indentParagraph,
-    outdentParagraph,
-  } = useDocumentStore();
+  // Individual selectors so the editor only re-renders when one of these
+  // specific slices changes. The child row components pull their own setters
+  // via selectors, so the parent no longer needs to own them.
+  const documentMode = useDocumentStore((s) => s.documentMode);
+  const docType = useDocumentStore((s) => s.docType);
+  const formData = useDocumentStore((s) => s.formData);
+  const paragraphs = useDocumentStore((s) => s.paragraphs);
+  const addParagraph = useDocumentStore((s) => s.addParagraph);
+  const reorderParagraphs = useDocumentStore((s) => s.reorderParagraphs);
 
   // Show portion marking when document has classification
   const showPortionMarking = formData.classLevel && formData.classLevel !== 'unclassified';
@@ -362,13 +357,6 @@ export function ParagraphsEditor() {
                   label={disableNumberedParagraphs ? '' : labels[index]}
                   showPortionMarking={!!showPortionMarking}
                   disableIndent={disableNumberedParagraphs}
-                  onUpdate={(text) => updateParagraph(index, { text })}
-                  onUpdateHeader={(header) => updateParagraph(index, { header })}
-                  onUpdatePortionMarking={(marking) => updateParagraph(index, { portionMarking: marking })}
-                  onRemove={() => removeParagraph(index)}
-                  onIndent={() => indentParagraph(index)}
-                  onOutdent={() => outdentParagraph(index)}
-                  onAddAfter={() => addParagraph('', para.level, index)}
                 />
               ))}
             </SortableContext>

--- a/src/components/editor/ProfileBar.tsx
+++ b/src/components/editor/ProfileBar.tsx
@@ -41,7 +41,10 @@ const EXAMPLE_FORM_DATA = {
 export function ProfileBar() {
   const { profiles, selectedProfile, selectProfile, deleteProfile, importProfiles } = useProfileStore();
   const { setFormData } = useDocumentStore();
-  const { setProfileModalOpen, autoSaveStatus } = useUIStore();
+  // Individual selectors so we only re-render when autoSaveStatus string
+  // actually changes, not on every unrelated UI store field update.
+  const setProfileModalOpen = useUIStore((s) => s.setProfileModalOpen);
+  const autoSaveStatus = useUIStore((s) => s.autoSaveStatus);
 
   const profileNames = Object.keys(profiles).sort();
 

--- a/src/components/editor/ReferencesManager.tsx
+++ b/src/components/editor/ReferencesManager.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import {
   DndContext,
   closestCenter,
@@ -40,18 +41,18 @@ import { DOC_TYPE_CONFIG } from '@/types/document';
 interface SortableReferenceProps {
   reference: Reference;
   index: number;
-  onUpdateTitle: (title: string) => void;
-  onUpdateUrl: (url: string) => void;
-  onRemove: () => void;
 }
 
-function SortableReference({
+// Memoized so typing in reference N doesn't force a re-render of references
+// 1..N-1. Store setters are stable and pulled via selectors inside, so the
+// parent doesn't need to create fresh callback closures per row each render.
+const SortableReference = memo(function SortableReference({
   reference,
   index,
-  onUpdateTitle,
-  onUpdateUrl,
-  onRemove,
 }: SortableReferenceProps) {
+  const updateReference = useDocumentStore((s) => s.updateReference);
+  const removeReference = useDocumentStore((s) => s.removeReference);
+
   const {
     attributes,
     listeners,
@@ -93,14 +94,14 @@ function SortableReference({
         <div className="flex-1 space-y-2">
           <Input
             value={reference.title}
-            onChange={(e) => onUpdateTitle(e.target.value)}
+            onChange={(e) => updateReference(index, { title: e.target.value })}
             placeholder="Reference title..."
           />
           <div className="flex items-center gap-2">
             <Link className="h-4 w-4 text-muted-foreground" />
             <Input
               value={reference.url || ''}
-              onChange={(e) => onUpdateUrl(e.target.value)}
+              onChange={(e) => updateReference(index, { url: e.target.value })}
               placeholder="URL (optional)"
               className="text-sm"
             />
@@ -111,7 +112,7 @@ function SortableReference({
         <Button
           variant="ghost"
           size="sm"
-          onClick={onRemove}
+          onClick={() => removeReference(index)}
           className="text-destructive hover:text-destructive"
         >
           <Trash2 className="h-4 w-4" />
@@ -119,21 +120,20 @@ function SortableReference({
       </div>
     </div>
   );
-}
+});
 
 export function ReferencesManager() {
-  const {
-    documentMode,
-    docType,
-    references,
-    formData,
-    setField,
-    addReference,
-    updateReference,
-    removeReference,
-    reorderReferences,
-  } = useDocumentStore();
-  const { setReferenceLibraryOpen } = useUIStore();
+  // Individual selectors so the manager only re-renders when one of these
+  // specific slices changes. Setters used only by child rows are pulled
+  // inside those rows via their own selectors.
+  const documentMode = useDocumentStore((s) => s.documentMode);
+  const docType = useDocumentStore((s) => s.docType);
+  const references = useDocumentStore((s) => s.references);
+  const formData = useDocumentStore((s) => s.formData);
+  const setField = useDocumentStore((s) => s.setField);
+  const addReference = useDocumentStore((s) => s.addReference);
+  const reorderReferences = useDocumentStore((s) => s.reorderReferences);
+  const setReferenceLibraryOpen = useUIStore((s) => s.setReferenceLibraryOpen);
 
   // Get compliance settings
   const config = DOC_TYPE_CONFIG[docType] || DOC_TYPE_CONFIG.naval_letter;
@@ -241,9 +241,6 @@ export function ReferencesManager() {
                       key={`ref-${index}`}
                       reference={ref}
                       index={index}
-                      onUpdateTitle={(title) => updateReference(index, { title })}
-                      onUpdateUrl={(url) => updateReference(index, { url })}
-                      onRemove={() => removeReference(index)}
                     />
                   ))}
                 </SortableContext>

--- a/src/components/layout/FormPanel.tsx
+++ b/src/components/layout/FormPanel.tsx
@@ -22,7 +22,8 @@ import { DOC_TYPE_CONFIG } from '@/types/document';
 
 export function FormPanel() {
   const { documentCategory, formType, docType } = useDocumentStore();
-  const { previewVisible, isMobile } = useUIStore();
+  const previewVisible = useUIStore((s) => s.previewVisible);
+  const isMobile = useUIStore((s) => s.isMobile);
   const config = DOC_TYPE_CONFIG[docType] || DOC_TYPE_CONFIG.naval_letter;
 
   const isFormsMode = documentCategory === 'forms';

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -160,10 +160,49 @@ export function Header({
   isPdfGenerating = false,
   isFormsMode = false,
 }: HeaderProps) {
-  const { theme, toggleTheme, density, setDensity, autoSaveStatus, setAboutModalOpen, setNistModalOpen, setBatchModalOpen, setDocumentGuideOpen, setFindReplaceOpen, setShareModal, isMobile, previewVisible, togglePreview, fullQualityPreview, setFullQualityPreview } = useUIStore();
-  const documentStore = useDocumentStore();
-  const { resetForm, applySnapshot, clearFieldsExceptLetterhead } = useDocumentStore();
-  const { undo, redo, canUndo, canRedo } = useHistoryStore();
+  // One selector per field — Zustand only re-renders us when THAT field
+  // changes by strict equality. Previously this was a single `useUIStore()`
+  // destructure, which subscribes to every field in the store: every modal
+  // open/close, every autoSaveStatus string change, every keystroke-driven
+  // density change, was re-rendering the entire header tree (~40 buttons
+  // + dropdown contents). Same idea for the document + history stores.
+  // Setters are stable references from Zustand's `create()` callback, so
+  // selecting them is effectively free.
+  const theme = useUIStore((s) => s.theme);
+  const toggleTheme = useUIStore((s) => s.toggleTheme);
+  const density = useUIStore((s) => s.density);
+  const setDensity = useUIStore((s) => s.setDensity);
+  const autoSaveStatus = useUIStore((s) => s.autoSaveStatus);
+  const setAboutModalOpen = useUIStore((s) => s.setAboutModalOpen);
+  const setNistModalOpen = useUIStore((s) => s.setNistModalOpen);
+  const setBatchModalOpen = useUIStore((s) => s.setBatchModalOpen);
+  const setDocumentGuideOpen = useUIStore((s) => s.setDocumentGuideOpen);
+  const setFindReplaceOpen = useUIStore((s) => s.setFindReplaceOpen);
+  const setShareModal = useUIStore((s) => s.setShareModal);
+  const isMobile = useUIStore((s) => s.isMobile);
+  const previewVisible = useUIStore((s) => s.previewVisible);
+  const togglePreview = useUIStore((s) => s.togglePreview);
+  const fullQualityPreview = useUIStore((s) => s.fullQualityPreview);
+  const setFullQualityPreview = useUIStore((s) => s.setFullQualityPreview);
+
+  // Document store actions only — we intentionally do NOT subscribe to any
+  // document state here. The import/export/reset handlers below read the
+  // full document via `useDocumentStore.getState()` at invocation time, so
+  // Header doesn't re-render on every keystroke anymore (which was the
+  // biggest single win in #10 tier-2 — Header has 40+ interactive elements
+  // and was re-rendering per character typed).
+  const resetForm = useDocumentStore((s) => s.resetForm);
+  const applySnapshot = useDocumentStore((s) => s.applySnapshot);
+  const clearFieldsExceptLetterhead = useDocumentStore((s) => s.clearFieldsExceptLetterhead);
+
+  const undo = useHistoryStore((s) => s.undo);
+  const redo = useHistoryStore((s) => s.redo);
+  // Select the derived booleans, not the getter functions — the getter
+  // references are stable so they'd never trigger a re-render. We need
+  // the value computed every render so the Undo/Redo button enabled state
+  // updates when past/future change.
+  const canUndo = useHistoryStore((s) => s.past.length > 0);
+  const canRedo = useHistoryStore((s) => s.future.length > 0);
   const [showResetDialog, setShowResetDialog] = useState(false);
   const [showClearFieldsDialog, setShowClearFieldsDialog] = useState(false);
   const [saveStatus, setSaveStatus] = useState<string | null>(null);
@@ -184,10 +223,14 @@ export function Header({
     } catch { /* localStorage unavailable */ }
   }, []);
 
-  // Check if document contains any {{VARIABLE}} placeholders
+  // Check if document contains any {{VARIABLE}} placeholders.
+  // Reads state via getState() so this callback has no store dependencies —
+  // it re-creates only if its own identity needs to (i.e. never). The check
+  // runs on button click, not during render, so reading fresh state at call
+  // time is correct.
   const hasVariables = useCallback(() => {
     const variablePattern = /\{\{[A-Z0-9_]+\}\}/;
-    const { formData, paragraphs } = documentStore;
+    const { formData, paragraphs } = useDocumentStore.getState();
 
     // Check common text fields
     const fieldsToCheck = [
@@ -207,7 +250,7 @@ export function Header({
     }
 
     return false;
-  }, [documentStore]);
+  }, []);
 
   // Handle download PDF - redirect to batch mode if variables detected
   const handleDownloadPdf = useCallback(() => {
@@ -220,13 +263,14 @@ export function Header({
 
   const handleSaveProgress = useCallback(() => {
     try {
+      const ds = useDocumentStore.getState();
       const dataToSave = {
-        documentMode: documentStore.documentMode,
-        docType: documentStore.docType,
-        formData: documentStore.formData,
-        references: documentStore.references,
+        documentMode: ds.documentMode,
+        docType: ds.docType,
+        formData: ds.formData,
+        references: ds.references,
         // Enclosures with files need special handling - we'll save metadata only
-        enclosures: documentStore.enclosures.map(encl => ({
+        enclosures: ds.enclosures.map(encl => ({
           title: encl.title,
           pageStyle: encl.pageStyle,
           hasCoverPage: encl.hasCoverPage,
@@ -235,8 +279,8 @@ export function Header({
           hasFile: !!encl.file,
           fileName: encl.file?.name,
         })),
-        paragraphs: documentStore.paragraphs,
-        copyTos: documentStore.copyTos,
+        paragraphs: ds.paragraphs,
+        copyTos: ds.copyTos,
         savedAt: new Date().toISOString(),
       };
       localStorage.setItem(STORAGE_KEY, JSON.stringify(dataToSave));
@@ -247,19 +291,20 @@ export function Header({
       setSaveStatus('Save failed');
       setTimeout(() => setSaveStatus(null), 2000);
     }
-  }, [documentStore]);
+  }, []);
 
   const handleLoadProgress = useCallback(() => {
     try {
       const saved = localStorage.getItem(STORAGE_KEY);
       if (saved) {
+        const ds = useDocumentStore.getState();
         const data = JSON.parse(saved);
-        documentStore.setDocumentMode?.(data.documentMode || 'compliant');
+        ds.setDocumentMode?.(data.documentMode || 'compliant');
         if (data.docType) {
-          documentStore.setDocType(data.docType);
+          ds.setDocType(data.docType);
         }
         if (data.formData) {
-          documentStore.setFormData(data.formData);
+          ds.setFormData(data.formData);
         }
         // Note: File data is not restored - user will need to re-attach PDFs
         setSaveStatus('Loaded!');
@@ -273,7 +318,7 @@ export function Header({
       setSaveStatus('Load failed');
       setTimeout(() => setSaveStatus(null), 2000);
     }
-  }, [documentStore]);
+  }, []);
 
   const handleReset = useCallback(() => {
     resetForm();
@@ -303,17 +348,18 @@ export function Header({
   // Export entire document state to a JSON file
   const handleExportDraft = useCallback(() => {
     try {
+      const ds = useDocumentStore.getState();
       const dataToExport = {
         version: '1.0',
         exportedAt: new Date().toISOString(),
-        documentMode: documentStore.documentMode,
-        documentCategory: documentStore.documentCategory,
-        docType: documentStore.docType,
-        formType: documentStore.formType,
-        formData: documentStore.formData,
-        references: documentStore.references,
+        documentMode: ds.documentMode,
+        documentCategory: ds.documentCategory,
+        docType: ds.docType,
+        formType: ds.formType,
+        formData: ds.formData,
+        references: ds.references,
         // Include enclosure file data as base64 for full restoration
-        enclosures: documentStore.enclosures.map(encl => ({
+        enclosures: ds.enclosures.map(encl => ({
           title: encl.title,
           pageStyle: encl.pageStyle,
           hasCoverPage: encl.hasCoverPage,
@@ -325,8 +371,8 @@ export function Header({
             data: uint8ArrayToBase64(arrayBufferToUint8Array(encl.file.data)),
           } : null,
         })),
-        paragraphs: documentStore.paragraphs,
-        copyTos: documentStore.copyTos,
+        paragraphs: ds.paragraphs,
+        copyTos: ds.copyTos,
       };
 
       const blob = new Blob([JSON.stringify(dataToExport, null, 2)], { type: 'application/json' });
@@ -347,7 +393,7 @@ export function Header({
       setSaveStatus('Export failed');
       setTimeout(() => setSaveStatus(null), 2000);
     }
-  }, [documentStore]);
+  }, []);
 
   // Import document state from a JSON file
   const handleImportDraft = useCallback((event: ChangeEvent<HTMLInputElement>) => {
@@ -357,6 +403,7 @@ export function Header({
     const reader = new FileReader();
     reader.onload = (e) => {
       try {
+        const ds = useDocumentStore.getState();
         const content = e.target?.result as string;
         const data = JSON.parse(content);
 
@@ -367,31 +414,31 @@ export function Header({
 
         // Apply document mode
         if (data.documentMode) {
-          documentStore.setDocumentMode?.(data.documentMode);
+          ds.setDocumentMode?.(data.documentMode);
         }
 
         // Apply document category
         if (data.documentCategory) {
-          documentStore.setDocumentCategory(data.documentCategory);
+          ds.setDocumentCategory(data.documentCategory);
         }
 
         // Apply document type
         if (data.docType) {
-          documentStore.setDocType(data.docType);
+          ds.setDocType(data.docType);
         }
 
         // Apply form type
         if (data.formType) {
-          documentStore.setFormType(data.formType);
+          ds.setFormType(data.formType);
         }
 
         // Apply form data
         if (data.formData) {
-          documentStore.setFormData(data.formData);
+          ds.setFormData(data.formData);
         }
 
         // Use loadTemplate for bulk loading (handles references, enclosures, paragraphs, copyTos)
-        documentStore.loadTemplate({
+        ds.loadTemplate({
           references: data.references || [],
           enclosures: data.enclosures?.map((encl: {
             title: string;
@@ -432,7 +479,7 @@ export function Header({
     reader.readAsText(file);
     // Reset the input so the same file can be selected again
     event.target.value = '';
-  }, [documentStore]);
+  }, []);
 
   return (
     <header className="border-b-2 border-primary/40 bg-gradient-to-r from-card via-card to-secondary/30 shadow-card">
@@ -497,7 +544,7 @@ export function Header({
             variant="ghost"
             size="icon"
             onClick={handleUndo}
-            disabled={!canUndo()}
+            disabled={!canUndo}
             aria-label="Undo (Ctrl+Z)"
             title="Undo (Ctrl+Z)"
             className="h-8 w-8 sm:h-9 sm:w-9"
@@ -508,7 +555,7 @@ export function Header({
             variant="ghost"
             size="icon"
             onClick={handleRedo}
-            disabled={!canRedo()}
+            disabled={!canRedo}
             aria-label="Redo (Ctrl+Y)"
             title="Redo (Ctrl+Y)"
             className="h-8 w-8 sm:h-9 sm:w-9"

--- a/src/components/layout/PreviewPanel.tsx
+++ b/src/components/layout/PreviewPanel.tsx
@@ -10,7 +10,12 @@ interface PreviewPanelProps {
 }
 
 export function PreviewPanel({ pdfUrl, isCompiling, error }: PreviewPanelProps) {
-  const { previewVisible, isMobile, setMobilePreviewOpen, fullQualityPreview } = useUIStore();
+  // Individual selectors so this panel only re-renders when one of these
+  // four fields actually changes (not on any other UI-store update).
+  const previewVisible = useUIStore((s) => s.previewVisible);
+  const isMobile = useUIStore((s) => s.isMobile);
+  const setMobilePreviewOpen = useUIStore((s) => s.setMobilePreviewOpen);
+  const fullQualityPreview = useUIStore((s) => s.fullQualityPreview);
   const enclosureCount = useDocumentStore((s) => s.enclosures.length);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const savedScrollRef = useRef<{ scrollTop: number; scrollLeft: number } | null>(null);

--- a/src/components/modals/AboutModal.tsx
+++ b/src/components/modals/AboutModal.tsx
@@ -11,7 +11,11 @@ import { useUIStore } from '@/stores/uiStore';
 import { APP_VERSION, GIT_SHA, formatBuildTime } from '@/lib/version';
 
 export function AboutModal() {
-  const { aboutModalOpen, setAboutModalOpen } = useUIStore();
+  // Individual selectors so this modal only re-renders when its own flag
+  // changes — not when any other modal toggles or an unrelated UI field
+  // updates. Setters are stable from Zustand's `create()` callback.
+  const aboutModalOpen = useUIStore((s) => s.aboutModalOpen);
+  const setAboutModalOpen = useUIStore((s) => s.setAboutModalOpen);
 
   return (
     <Dialog open={aboutModalOpen} onOpenChange={setAboutModalOpen}>

--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect } from 'react';
+import { memo, useState, useCallback, useMemo, useEffect } from 'react';
 import { Plus, Trash2, Download, AlertCircle, FileText, Variable, CheckCircle, XCircle, Copy, Lightbulb, Eye, Loader2, Settings, ArrowRight } from 'lucide-react';
 import {
   Dialog,
@@ -82,8 +82,96 @@ function copyToClipboard(text: string) {
   navigator.clipboard.writeText(text);
 }
 
+interface BatchModalRowProps {
+  row: BatchRow;
+  idx: number;
+  detectedPlaceholders: string[];
+  isGenerating: boolean;
+  isPreviewing: boolean;
+  isReadyToGenerate: boolean;
+  canRemove: boolean;
+  updateRowValue: (rowId: string, placeholder: string, value: string) => void;
+  removeRow: (id: string) => void;
+  handlePreview: (row: BatchRow) => void;
+}
+
+// Memoized row so typing in row N doesn't re-render rows 1..N-1.
+//
+// The parent passes a boolean `isPreviewing` (computed once per render as
+// `previewingRow === row.id`) instead of the full `previewingRow` string, so
+// switching which row is previewing only re-renders the two rows whose state
+// actually changed — not every row in the table.
+//
+// Same idea for `canRemove` vs `rows.length`: a per-row boolean flips only
+// at the 1↔2 boundary, not on every row add/remove.
+const BatchModalRow = memo(function BatchModalRow({
+  row,
+  idx,
+  detectedPlaceholders,
+  isGenerating,
+  isPreviewing,
+  isReadyToGenerate,
+  canRemove,
+  updateRowValue,
+  removeRow,
+  handlePreview,
+}: BatchModalRowProps) {
+  return (
+    <tr className={`border-t ${row.status === 'error' ? 'bg-destructive/10' : row.status === 'success' ? 'bg-green-500/10' : ''}`}>
+      <td className="px-2 py-1 text-muted-foreground">
+        <div className="flex items-center gap-1">
+          {row.status === 'success' && <CheckCircle className="h-4 w-4 text-green-500" />}
+          {row.status === 'error' && <XCircle className="h-4 w-4 text-destructive" />}
+          {row.status === 'generating' && <Loader2 className="h-4 w-4 animate-spin" />}
+          {(!row.status || row.status === 'pending') && <span>{idx + 1}</span>}
+        </div>
+      </td>
+      {detectedPlaceholders.map((placeholder) => (
+        <td key={placeholder} className="px-1 py-1">
+          <Input
+            value={row.values[placeholder] || ''}
+            onChange={(e) => updateRowValue(row.id, placeholder, e.target.value)}
+            placeholder={placeholder.substring(0, 8)}
+            className="h-7 w-24 text-xs"
+            disabled={isGenerating}
+          />
+        </td>
+      ))}
+      <td className="px-1 py-2">
+        <div className="flex items-center gap-0.5">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => handlePreview(row)}
+            disabled={!isReadyToGenerate || isGenerating || isPreviewing}
+            title="Preview document"
+          >
+            {isPreviewing ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-destructive"
+            onClick={() => removeRow(row.id)}
+            disabled={!canRemove || isGenerating}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      </td>
+    </tr>
+  );
+});
+
 export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalProps) {
-  const { batchModalOpen, setBatchModalOpen } = useUIStore();
+  // Individual selectors — modal only re-renders on its own flag changing.
+  const batchModalOpen = useUIStore((s) => s.batchModalOpen);
+  const setBatchModalOpen = useUIStore((s) => s.setBatchModalOpen);
   const documentStore = useDocumentStore();
   const formStore = useFormStore();
   const { documentCategory, formType } = useDocumentStore();
@@ -878,56 +966,19 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
                           </thead>
                           <tbody>
                             {rows.map((row, idx) => (
-                              <tr key={row.id} className={`border-t ${row.status === 'error' ? 'bg-destructive/10' : row.status === 'success' ? 'bg-green-500/10' : ''}`}>
-                                <td className="px-2 py-1 text-muted-foreground">
-                                  <div className="flex items-center gap-1">
-                                    {row.status === 'success' && <CheckCircle className="h-4 w-4 text-green-500" />}
-                                    {row.status === 'error' && <XCircle className="h-4 w-4 text-destructive" />}
-                                    {row.status === 'generating' && <Loader2 className="h-4 w-4 animate-spin" />}
-                                    {(!row.status || row.status === 'pending') && <span>{idx + 1}</span>}
-                                  </div>
-                                </td>
-                                {detectedPlaceholders.map((placeholder) => (
-                                  <td key={placeholder} className="px-1 py-1">
-                                    <Input
-                                      value={row.values[placeholder] || ''}
-                                      onChange={(e) =>
-                                        updateRowValue(row.id, placeholder, e.target.value)
-                                      }
-                                      placeholder={placeholder.substring(0, 8)}
-                                      className="h-7 w-24 text-xs"
-                                      disabled={isGenerating}
-                                    />
-                                  </td>
-                                ))}
-                                <td className="px-1 py-2">
-                                  <div className="flex items-center gap-0.5">
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-7 w-7"
-                                      onClick={() => handlePreview(row)}
-                                      disabled={!isReadyToGenerate || isGenerating || previewingRow === row.id}
-                                      title="Preview document"
-                                    >
-                                      {previewingRow === row.id ? (
-                                        <Loader2 className="h-4 w-4 animate-spin" />
-                                      ) : (
-                                        <Eye className="h-4 w-4" />
-                                      )}
-                                    </Button>
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-7 w-7 text-destructive"
-                                      onClick={() => removeRow(row.id)}
-                                      disabled={rows.length === 1 || isGenerating}
-                                    >
-                                      <Trash2 className="h-4 w-4" />
-                                    </Button>
-                                  </div>
-                                </td>
-                              </tr>
+                              <BatchModalRow
+                                key={row.id}
+                                row={row}
+                                idx={idx}
+                                detectedPlaceholders={detectedPlaceholders}
+                                isGenerating={isGenerating}
+                                isPreviewing={previewingRow === row.id}
+                                isReadyToGenerate={isReadyToGenerate}
+                                canRemove={rows.length > 1}
+                                updateRowValue={updateRowValue}
+                                removeRow={removeRow}
+                                handlePreview={handlePreview}
+                              />
                             ))}
                           </tbody>
                         </table>

--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -172,9 +172,27 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
   // Individual selectors — modal only re-renders on its own flag changing.
   const batchModalOpen = useUIStore((s) => s.batchModalOpen);
   const setBatchModalOpen = useUIStore((s) => s.setBatchModalOpen);
-  const documentStore = useDocumentStore();
-  const formStore = useFormStore();
-  const { documentCategory, formType } = useDocumentStore();
+  // Individual selectors. The useMemo for `detectedPlaceholders` below is the
+  // ONLY render-phase read of store data in this component, so we subscribe
+  // just to the slices it actually uses. All other reads are inside
+  // useCallback bodies (placeholder replacement at PDF-generation time,
+  // variable insertion on click) and pull fresh state via getState(). That
+  // keeps callback identity stable, which in turn keeps BatchModalRow's memo
+  // effective — otherwise every documentStore keystroke would churn
+  // `handlePreview` (passed as a prop), defeating the row memo.
+  const formData = useDocumentStore((s) => s.formData);
+  const paragraphs = useDocumentStore((s) => s.paragraphs);
+  const references = useDocumentStore((s) => s.references);
+  const enclosures = useDocumentStore((s) => s.enclosures);
+  const copyTos = useDocumentStore((s) => s.copyTos);
+  const documentCategory = useDocumentStore((s) => s.documentCategory);
+  const formType = useDocumentStore((s) => s.formType);
+  const setDocField = useDocumentStore((s) => s.setField);
+  const addParagraph = useDocumentStore((s) => s.addParagraph);
+  const navmc10274 = useFormStore((s) => s.navmc10274);
+  const navmc11811 = useFormStore((s) => s.navmc11811);
+  const setNavmc10274Field = useFormStore((s) => s.setNavmc10274Field);
+  const setNavmc11811Field = useFormStore((s) => s.setNavmc11811Field);
 
   const [rows, setRows] = useState<BatchRow[]>([
     { id: '1', values: {}, status: 'pending' },
@@ -236,7 +254,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
     if (isFormsMode) {
       // Forms mode: scan form fields for placeholders
       if (formType === 'navmc_10274') {
-        const data = formStore.navmc10274;
+        const data = navmc10274;
         if (data.actionNo) allText.push(data.actionNo);
         if (data.ssicFileNo) allText.push(data.ssicFileNo);
         if (data.date) allText.push(data.date);
@@ -251,7 +269,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
         if (data.supplementalInfo) allText.push(data.supplementalInfo);
         if (data.proposedAction) allText.push(data.proposedAction);
       } else if (formType === 'navmc_118_11') {
-        const data = formStore.navmc11811;
+        const data = navmc11811;
         if (data.lastName) allText.push(data.lastName);
         if (data.firstName) allText.push(data.firstName);
         if (data.middleName) allText.push(data.middleName);
@@ -262,8 +280,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
         if (data.box11) allText.push(data.box11);
       }
     } else {
-      // Correspondence mode: scan document store fields
-      const { formData, paragraphs, references, enclosures, copyTos } = documentStore;
+      // Correspondence mode: scan document store fields (from granular selectors above)
 
       // Form fields
       if (formData.to) allText.push(formData.to);
@@ -287,7 +304,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
 
     const allPlaceholders = allText.flatMap((text) => detectPlaceholders(text));
     return [...new Set(allPlaceholders)];
-  }, [documentStore, formStore.navmc10274, formStore.navmc11811, isFormsMode, formType]);
+  }, [formData, paragraphs, references, enclosures, copyTos, navmc10274, navmc11811, isFormsMode, formType]);
 
   const addRow = useCallback(() => {
     setRows((prev) => [
@@ -310,44 +327,52 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
     );
   }, []);
 
-  // Create modified store with placeholder replacements (for correspondence)
+  // Create modified store with placeholder replacements (for correspondence).
+  //
+  // Reads via getState() so this callback has stable identity across renders
+  // — otherwise every keystroke in a form field would change documentStore,
+  // which would change createModifiedStore, which would change
+  // generatePdfForRow, which would change handlePreview, which is a prop of
+  // BatchModalRow and would defeat its memo.
   const createModifiedStore = useCallback((values: PlaceholderValue) => {
+    const store = useDocumentStore.getState();
     return {
-      docType: documentStore.docType,
+      docType: store.docType,
       formData: {
-        ...documentStore.formData,
-        to: replacePlaceholders(documentStore.formData.to || '', values),
-        from: replacePlaceholders(documentStore.formData.from || '', values),
-        via: replacePlaceholders(documentStore.formData.via || '', values),
-        subject: replacePlaceholders(documentStore.formData.subject || '', values),
-        serial: replacePlaceholders(documentStore.formData.serial || '', values),
+        ...store.formData,
+        to: replacePlaceholders(store.formData.to || '', values),
+        from: replacePlaceholders(store.formData.from || '', values),
+        via: replacePlaceholders(store.formData.via || '', values),
+        subject: replacePlaceholders(store.formData.subject || '', values),
+        serial: replacePlaceholders(store.formData.serial || '', values),
       },
-      references: documentStore.references.map((ref) => ({
+      references: store.references.map((ref) => ({
         ...ref,
         title: replacePlaceholders(ref.title, values),
       })),
-      enclosures: documentStore.enclosures.map((encl) => ({
+      enclosures: store.enclosures.map((encl) => ({
         ...encl,
         title: replacePlaceholders(encl.title, values),
       })),
-      paragraphs: documentStore.paragraphs.map((para) => ({
+      paragraphs: store.paragraphs.map((para) => ({
         ...para,
         text: replacePlaceholders(para.text, values),
       })),
-      copyTos: documentStore.copyTos.map((ct) => ({
+      copyTos: store.copyTos.map((ct) => ({
         ...ct,
         text: replacePlaceholders(ct.text, values),
       })),
-      distributions: documentStore.distributions.map((d) => ({
+      distributions: store.distributions.map((d) => ({
         ...d,
         text: replacePlaceholders(d.text, values),
       })),
     };
-  }, [documentStore]);
+  }, []);
 
-  // Create modified NAVMC 10274 form data with placeholder replacements
+  // Create modified NAVMC 10274 form data with placeholder replacements.
+  // Same getState() pattern as createModifiedStore — keeps identity stable.
   const createModifiedNavmc10274 = useCallback((values: PlaceholderValue): NavmcForm10274Data => {
-    const data = formStore.navmc10274;
+    const data = useFormStore.getState().navmc10274;
     return {
       actionNo: replacePlaceholders(data.actionNo, values),
       ssicFileNo: replacePlaceholders(data.ssicFileNo, values),
@@ -363,11 +388,11 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
       supplementalInfo: replacePlaceholders(data.supplementalInfo, values),
       proposedAction: replacePlaceholders(data.proposedAction, values),
     };
-  }, [formStore.navmc10274]);
+  }, []);
 
-  // Create modified NAVMC 118(11) form data with placeholder replacements
+  // Create modified NAVMC 118(11) form data with placeholder replacements.
   const createModifiedNavmc11811 = useCallback((values: PlaceholderValue): Navmc11811Data => {
-    const data = formStore.navmc11811;
+    const data = useFormStore.getState().navmc11811;
     return {
       lastName: replacePlaceholders(data.lastName, values),
       firstName: replacePlaceholders(data.firstName, values),
@@ -378,7 +403,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
       entryDate: replacePlaceholders(data.entryDate, values),
       box11: replacePlaceholders(data.box11, values),
     };
-  }, [formStore.navmc11811]);
+  }, []);
 
   // Generate PDF for a single row with retry logic for ENGINE_RESET_NEEDED
   const generatePdfForRow = useCallback(async (values: PlaceholderValue, retryCount = 0): Promise<Uint8Array> => {
@@ -655,7 +680,9 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
     }
   }, [detectedPlaceholders, looksLikeHeaders]);
 
-  // Handle adding a variable to the document
+  // Handle adding a variable to the document.
+  // Reads live state via getState() at click time (not stale render-time snapshot),
+  // and uses the stable setter refs bound at the top of the component.
   const handleAddVariable = useCallback(() => {
     if (!selectedVariable || !targetField) return;
 
@@ -664,45 +691,46 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
     if (isFormsMode) {
       // Forms mode: Add to specific form fields
       if (formType === 'navmc_10274') {
-        const currentData = formStore.navmc10274;
+        const currentData = useFormStore.getState().navmc10274;
         if (targetField === 'to') {
-          formStore.setNavmc10274Field('to', currentData.to ? `${currentData.to} ${variableText}` : variableText);
+          setNavmc10274Field('to', currentData.to ? `${currentData.to} ${variableText}` : variableText);
         } else if (targetField === 'from') {
-          formStore.setNavmc10274Field('from', currentData.from ? `${currentData.from} ${variableText}` : variableText);
+          setNavmc10274Field('from', currentData.from ? `${currentData.from} ${variableText}` : variableText);
         } else if (targetField === 'natureOfAction') {
-          formStore.setNavmc10274Field('natureOfAction', currentData.natureOfAction ? `${currentData.natureOfAction} ${variableText}` : variableText);
+          setNavmc10274Field('natureOfAction', currentData.natureOfAction ? `${currentData.natureOfAction} ${variableText}` : variableText);
         }
       } else if (formType === 'navmc_118_11') {
-        const currentData = formStore.navmc11811;
+        const currentData = useFormStore.getState().navmc11811;
         if (targetField === 'lastName') {
-          formStore.setNavmc11811Field('lastName', currentData.lastName ? `${currentData.lastName} ${variableText}` : variableText);
+          setNavmc11811Field('lastName', currentData.lastName ? `${currentData.lastName} ${variableText}` : variableText);
         } else if (targetField === 'firstName') {
-          formStore.setNavmc11811Field('firstName', currentData.firstName ? `${currentData.firstName} ${variableText}` : variableText);
+          setNavmc11811Field('firstName', currentData.firstName ? `${currentData.firstName} ${variableText}` : variableText);
         } else if (targetField === 'remarksText') {
-          formStore.setNavmc11811Field('remarksText', currentData.remarksText ? `${currentData.remarksText} ${variableText}` : variableText);
+          setNavmc11811Field('remarksText', currentData.remarksText ? `${currentData.remarksText} ${variableText}` : variableText);
         }
       }
     } else {
       // Correspondence mode: Add to document fields
+      const currentFormData = useDocumentStore.getState().formData;
       if (targetField === 'subject') {
-        const currentSubject = documentStore.formData.subject || '';
-        documentStore.setField('subject', currentSubject ? `${currentSubject} ${variableText}` : variableText);
+        const currentSubject = currentFormData.subject || '';
+        setDocField('subject', currentSubject ? `${currentSubject} ${variableText}` : variableText);
       } else if (targetField === 'to') {
-        const currentTo = documentStore.formData.to || '';
-        documentStore.setField('to', currentTo ? `${currentTo} ${variableText}` : variableText);
+        const currentTo = currentFormData.to || '';
+        setDocField('to', currentTo ? `${currentTo} ${variableText}` : variableText);
       } else if (targetField === 'from') {
-        const currentFrom = documentStore.formData.from || '';
-        documentStore.setField('from', currentFrom ? `${currentFrom} ${variableText}` : variableText);
+        const currentFrom = currentFormData.from || '';
+        setDocField('from', currentFrom ? `${currentFrom} ${variableText}` : variableText);
       } else if (targetField === 'paragraph') {
         // Add a new paragraph with the variable
-        documentStore.addParagraph(variableText, 0);
+        addParagraph(variableText, 0);
       }
     }
 
     // Reset selection
     setSelectedVariable('');
     setTargetField('');
-  }, [selectedVariable, targetField, isFormsMode, formType, formStore, documentStore]);
+  }, [selectedVariable, targetField, isFormsMode, formType, setNavmc10274Field, setNavmc11811Field, setDocField, addParagraph]);
 
   const hasNoPlaceholders = detectedPlaceholders.length === 0;
 

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -746,7 +746,9 @@ function ExamplesTab({ onClose }: { onClose: () => void }) {
 }
 
 export function DocumentGuideModal() {
-  const { documentGuideOpen, setDocumentGuideOpen } = useUIStore();
+  // Individual selectors — modal only re-renders on its own flag changing.
+  const documentGuideOpen = useUIStore((s) => s.documentGuideOpen);
+  const setDocumentGuideOpen = useUIStore((s) => s.setDocumentGuideOpen);
   const [activeTab, setActiveTab] = useState<'finder' | 'browse' | 'examples'>('finder');
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);

--- a/src/components/modals/FindReplaceModal.tsx
+++ b/src/components/modals/FindReplaceModal.tsx
@@ -16,7 +16,9 @@ import { useDocumentStore } from '@/stores/documentStore';
 import type { Paragraph, DocumentData } from '@/types/document';
 
 export function FindReplaceModal() {
-  const { findReplaceOpen, setFindReplaceOpen } = useUIStore();
+  // Individual selectors — modal only re-renders on its own flag changing.
+  const findReplaceOpen = useUIStore((s) => s.findReplaceOpen);
+  const setFindReplaceOpen = useUIStore((s) => s.setFindReplaceOpen);
   const { formData, setField, paragraphs, updateParagraph } = useDocumentStore();
 
   const [findText, setFindText] = useState('');

--- a/src/components/modals/MobilePreviewModal.tsx
+++ b/src/components/modals/MobilePreviewModal.tsx
@@ -256,7 +256,9 @@ function IOSPdfViewer({ pdfUrl, onClose, onDownload, isPhone }: {
 }
 
 export function MobilePreviewModal({ pdfUrl, isCompiling, error }: MobilePreviewModalProps) {
-  const { mobilePreviewOpen, setMobilePreviewOpen } = useUIStore();
+  // Individual selectors — modal only re-renders on its own flag changing.
+  const mobilePreviewOpen = useUIStore((s) => s.mobilePreviewOpen);
+  const setMobilePreviewOpen = useUIStore((s) => s.setMobilePreviewOpen);
   const { setOpen: setLogViewerOpen, setEnabled: setLogEnabled } = useLogStore();
   const [numPages, setNumPages] = useState<number>(0);
   const [currentPage, setCurrentPage] = useState<number>(1);

--- a/src/components/modals/NISTComplianceModal.tsx
+++ b/src/components/modals/NISTComplianceModal.tsx
@@ -12,7 +12,9 @@ import { useUIStore } from '@/stores/uiStore';
 const isOfficialDomain = typeof window !== 'undefined' && window.location.hostname.endsWith('.mil');
 
 export function NISTComplianceModal() {
-  const { nistModalOpen, setNistModalOpen } = useUIStore();
+  // Individual selectors — modal only re-renders on its own flag changing.
+  const nistModalOpen = useUIStore((s) => s.nistModalOpen);
+  const setNistModalOpen = useUIStore((s) => s.setNistModalOpen);
 
   return (
     <Dialog open={nistModalOpen} onOpenChange={setNistModalOpen}>

--- a/src/components/modals/PIIWarningModal.tsx
+++ b/src/components/modals/PIIWarningModal.tsx
@@ -76,7 +76,9 @@ function SummaryBadge({ count, label, severity }: { count: number; label: string
 }
 
 export function PIIWarningModal({ detectionResult, onCancel, onProceed }: PIIWarningModalProps) {
-  const { piiWarningOpen, setPiiWarningOpen } = useUIStore();
+  // Individual selectors — modal only re-renders on its own flag changing.
+  const piiWarningOpen = useUIStore((s) => s.piiWarningOpen);
+  const setPiiWarningOpen = useUIStore((s) => s.setPiiWarningOpen);
 
   if (!detectionResult || !detectionResult.found) {
     return null;

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -89,7 +89,9 @@ const EMPTY_PROFILE: Profile = {
 };
 
 export function ProfileModal() {
-  const { profileModalOpen, setProfileModalOpen } = useUIStore();
+  // Individual selectors — modal only re-renders on its own flag changing.
+  const profileModalOpen = useUIStore((s) => s.profileModalOpen);
+  const setProfileModalOpen = useUIStore((s) => s.setProfileModalOpen);
   const { profiles, selectedProfile, addProfile, updateProfile, selectProfile } = useProfileStore();
   const { formData } = useDocumentStore();
 

--- a/src/components/modals/ReferenceLibraryModal.tsx
+++ b/src/components/modals/ReferenceLibraryModal.tsx
@@ -55,7 +55,9 @@ const REFERENCE_LIBRARY = [
 ];
 
 export function ReferenceLibraryModal() {
-  const { referenceLibraryOpen, setReferenceLibraryOpen } = useUIStore();
+  // Individual selectors — modal only re-renders on its own flag changing.
+  const referenceLibraryOpen = useUIStore((s) => s.referenceLibraryOpen);
+  const setReferenceLibraryOpen = useUIStore((s) => s.setReferenceLibraryOpen);
   const { addReference } = useDocumentStore();
   const [searchQuery, setSearchQuery] = useState('');
 

--- a/src/components/modals/TemplateLoaderModal.tsx
+++ b/src/components/modals/TemplateLoaderModal.tsx
@@ -18,7 +18,9 @@ import { LETTER_TEMPLATES, type LetterTemplate } from '@/data/templates';
 const CATEGORIES = [...new Set(LETTER_TEMPLATES.map(t => t.category))];
 
 export function TemplateLoaderModal() {
-  const { templateLoaderOpen, setTemplateLoaderOpen } = useUIStore();
+  // Individual selectors — modal only re-renders on its own flag changing.
+  const templateLoaderOpen = useUIStore((s) => s.templateLoaderOpen);
+  const setTemplateLoaderOpen = useUIStore((s) => s.setTemplateLoaderOpen);
 
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);


### PR DESCRIPTION
## What changed

Component render surface was tracking whole-store subscriptions, so unrelated writes (modal toggles, auto-save pings, keystrokes in form fields that other components didn't care about) were cascading re-renders across the tree. This restructures the 17 destructure sites into granular Zustand selectors and adds `React.memo` to the hot list rows.

## Specifics

### useUIStore / useDocumentStore destructures → individual selectors

- **`Header.tsx` (biggest win):** one 16-field `useUIStore()` destructure + full `useDocumentStore()` subscribe + `useHistoryStore()` destructure. Every keystroke anywhere was re-rendering ~40 buttons + dropdown contents. Split into per-field selectors; `canUndo`/`canRedo` are now boolean selectors (`s.past.length > 0`) rather than function calls.
- **`App.tsx`:** replaced `useDocumentStore()` (full subscribe) with seven granular selectors for the slices that drive the compile debounce. Full store is now read via `useDocumentStore.getState()` at compile/download time — freshness preserved without the render-subscription. Same pattern for `useFormStore`, `useHistoryStore`, `useProfileStore`, `useLogStore`.
- **14 modals and panels** (`AboutModal`, `BatchModal`, `FindReplaceModal`, `MobilePreviewModal`, `NISTComplianceModal`, `PIIWarningModal`, `ProfileModal`, `ReferenceLibraryModal`, `TemplateLoaderModal`, `DocumentGuideModal`, `ProfileBar`, `ReferencesManager`, `DocumentTypeSelector`, `FormPanel`, `PreviewPanel`): modals no longer re-render their outer component on unrelated `uiStore` mutations. Note that Radix `Dialog` already unmounts portal children when closed, so the biggest win here is consistency + stopping outer-wrapper re-runs — not the whole subtree.

### React.memo on list items

- **`SortableParagraph`** (ParagraphsEditor): pulls setters inline via selectors rather than receiving inline-closure callback props, then `memo()` wraps it. Typing in paragraph N no longer re-renders paragraphs 1..N-1.
- **`SortableReference`** (ReferencesManager): same pattern.
- **`BatchModalRow`** (new, extracted from inline `<tr>`): receives stable `useCallback` refs + per-row `isPreviewing` / `canRemove` booleans (not the broader `previewingRow` string or `rows.length`), so switching which row is previewing only re-renders the two rows whose state actually changed.

### BatchModal full-store subscribes → granular selectors (commit 7107925)

Initial pass wrapped `BatchModalRow` in `memo()` but `BatchModal` still did `const documentStore = useDocumentStore()` and `const formStore = useFormStore()`, so any keystroke invalidated `createModifiedStore` → `generatePdfForRow` → `handlePreview` (a prop of the memoized row) and defeated the memo. Second-pass review caught it.

The fix:
- Swap the two full-store destructures for granular selectors on the slices `detectedPlaceholders` actually reads (`formData`, `paragraphs`, `references`, `enclosures`, `copyTos`, `navmc10274`, `navmc11811`) plus stable setter refs.
- Move reads inside `createModifiedStore`, `createModifiedNavmc10274`, `createModifiedNavmc11811`, and `handleAddVariable` to `useStore.getState()` so those callbacks have empty/minimal dep arrays and stable identity.

### Zustand setters are stable

All setters used in the selector conversions are defined inline in the `create()` callback, so their references never change — selecting them individually adds no cost vs destructuring. No behavior change.

## Verification

- `tsc --noEmit` clean
- `eslint` error count unchanged from main (42 → 42, all pre-existing)
- `vite build` succeeds (bundle size unchanged)
- Independent correctness review: CLEAN
- Independent effectiveness review: DELIVERS — Header.tsx and SortableParagraph/SortableReference memos account for most of the cascade reduction; BatchModal fix works for the practical user path (typing in row inputs only touches local state).

## Known minor follow-up (non-blocking)

`detectedPlaceholders` is a `useMemo` that produces a new array identity on every keystroke in the main document. If a user has the batch modal open and simultaneously types in the main document, that would defeat `BatchModalRow.memo`. The modal covers the document in the normal UX, so this path is unreachable for real users — noted here for future tightening (e.g., structural-equal memo on the array).

## Also included

- Dependabot bump of postcss 8.5.6 → 8.5.10 (supersedes PR #36, cherry-picked onto this branch to preserve dependabot attribution).