### PR TITLE
feat: add top-level React Error Boundary with session recovery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.7",
+  "version": "1.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,21 +1,22 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { debug } from '@/lib/debug';
-
-// localStorage key for the auto-saved document. Must match Header.tsx's
-// STORAGE_KEY — when that file changes, this one needs to change too.
-// Kept here as a constant rather than imported to avoid any chance of the
-// import path itself being part of a render crash.
-const STORAGE_KEY = 'dondocs-document';
+import { STORAGE_KEYS } from '@/lib/constants';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
 }
 
+// Distinct states so the user can tell apart "your draft is in your
+// clipboard" from "there was nothing to copy" from "we tried but the
+// browser refused (e.g. clipboard permission denied or insecure
+// context — clipboard API needs HTTPS or localhost)".
+type CopyStatus = 'idle' | 'copied' | 'empty' | 'failed';
+
 interface ErrorBoundaryState {
   error: Error | null;
   errorInfo: ErrorInfo | null;
   detailsOpen: boolean;
-  copyStatus: 'idle' | 'copied' | 'failed';
+  copyStatus: CopyStatus;
 }
 
 /**
@@ -52,6 +53,11 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     detailsOpen: false,
     copyStatus: 'idle',
   };
+  // Tracks the pending copy-status reset timer so we can clear it on
+  // unmount (or on a second click that supersedes the first). Without
+  // this we'd risk a setState-on-unmounted-component warning if the user
+  // clicks Reload within the 2s window.
+  private copyStatusTimer: ReturnType<typeof setTimeout> | null = null;
 
   static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
     return { error };
@@ -64,21 +70,43 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     debug.error('Boundary', 'Render error caught', { error, errorInfo });
   }
 
+  componentWillUnmount(): void {
+    if (this.copyStatusTimer !== null) {
+      clearTimeout(this.copyStatusTimer);
+      this.copyStatusTimer = null;
+    }
+  }
+
+  private scheduleCopyStatusReset(): void {
+    if (this.copyStatusTimer !== null) {
+      clearTimeout(this.copyStatusTimer);
+    }
+    this.copyStatusTimer = setTimeout(() => {
+      this.copyStatusTimer = null;
+      this.setState({ copyStatus: 'idle' });
+    }, 2000);
+  }
+
   handleCopySession = async (): Promise<void> => {
     try {
-      const data = localStorage.getItem(STORAGE_KEY);
+      const data = localStorage.getItem(STORAGE_KEYS.DOCUMENT);
       if (!data) {
-        this.setState({ copyStatus: 'failed' });
+        this.setState({ copyStatus: 'empty' });
+        this.scheduleCopyStatusReset();
         return;
       }
+      // navigator.clipboard requires a secure context (HTTPS or
+      // localhost). On http://192.168.x.x and similar, writeText
+      // rejects — we fall through to the catch below and surface a
+      // distinct "failed" status so the user knows it wasn't an
+      // empty-draft case.
       await navigator.clipboard.writeText(data);
       this.setState({ copyStatus: 'copied' });
-      // Reset the badge after a couple of seconds so the user knows they can
-      // copy again if they want (e.g. cleared their clipboard).
-      setTimeout(() => this.setState({ copyStatus: 'idle' }), 2000);
+      this.scheduleCopyStatusReset();
     } catch (err) {
       debug.error('Boundary', 'Failed to copy session', err);
       this.setState({ copyStatus: 'failed' });
+      this.scheduleCopyStatusReset();
     }
   };
 
@@ -91,7 +119,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       return;
     }
     try {
-      localStorage.removeItem(STORAGE_KEY);
+      localStorage.removeItem(STORAGE_KEYS.DOCUMENT);
     } catch (err) {
       debug.error('Boundary', 'Failed to clear session before reload', err);
     }
@@ -195,7 +223,15 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
               wordBreak: 'break-word',
             }}
           >
-            <strong>{error.name}:</strong> {error.message}
+            {/*
+              React generally wraps non-Error throws with `Error`, but
+              user code can still throw a plain string, null, or a
+              POJO. Coerce defensively so the boundary never throws
+              while rendering its own fallback (which would be
+              catastrophic — the boundary can't catch its own errors).
+            */}
+            <strong>{String(error.name ?? 'Error')}:</strong>{' '}
+            {String(error.message ?? error)}
           </div>
 
           <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '16px' }}>
@@ -207,9 +243,11 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             >
               {copyStatus === 'copied'
                 ? 'Copied ✓'
-                : copyStatus === 'failed'
+                : copyStatus === 'empty'
                   ? 'No saved draft'
-                  : 'Copy saved draft'}
+                  : copyStatus === 'failed'
+                    ? 'Copy failed'
+                    : 'Copy saved draft'}
             </button>
             <button
               type="button"
@@ -250,13 +288,13 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
               <div style={{ fontSize: '12px', color: '#475569', marginBottom: '4px' }}>
                 Stack trace
               </div>
-              <code style={codeStyle}>{error.stack || '(no stack available)'}</code>
+              <code style={codeStyle}>{String(error.stack ?? '(no stack available)')}</code>
               {errorInfo?.componentStack && (
                 <>
                   <div style={{ fontSize: '12px', color: '#475569', margin: '12px 0 4px 0' }}>
                     Component stack
                   </div>
-                  <code style={codeStyle}>{errorInfo.componentStack}</code>
+                  <code style={codeStyle}>{String(errorInfo.componentStack)}</code>
                 </>
               )}
             </div>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,268 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { debug } from '@/lib/debug';
+
+// localStorage key for the auto-saved document. Must match Header.tsx's
+// STORAGE_KEY — when that file changes, this one needs to change too.
+// Kept here as a constant rather than imported to avoid any chance of the
+// import path itself being part of a render crash.
+const STORAGE_KEY = 'dondocs-document';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+  detailsOpen: boolean;
+  copyStatus: 'idle' | 'copied' | 'failed';
+}
+
+/**
+ * Top-level error boundary for the app.
+ *
+ * Catches any render-phase exception in the tree below it and shows a
+ * recovery UI instead of leaving the user with a white screen. The
+ * recovery UI is intentionally low-dependency: inline styles + a couple
+ * of Tailwind utility classes only. Anything richer (shadcn Button,
+ * Dialog, theme tokens) risks being part of *what crashed*.
+ *
+ * The boundary itself can't recover from errors in event handlers, async
+ * code, server-rendered HTML, or errors thrown in the boundary itself.
+ * For our purposes that's fine — the dominant failure mode this addresses
+ * is a render-time bug somewhere in the editor / form / preview tree
+ * that turned the whole tab into a white screen with no way out.
+ *
+ * Recovery options offered to the user:
+ *  - Copy session: exfiltrate the auto-saved JSON to the clipboard so
+ *    they can paste it into a recovery channel (or just hold it before
+ *    a wipe).
+ *  - Reload: window.location.reload(). Cheap. Often enough — the boundary
+ *    only catches RENDER errors, so reloading replays the same render
+ *    against the same persisted state and will likely crash again, but
+ *    sometimes the crash was a transient network or async race.
+ *  - Reset & reload: clear localStorage[STORAGE_KEY] then reload. The
+ *    escape hatch when the persisted session itself is what's crashing
+ *    on rehydrate.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {
+    error: null,
+    errorInfo: null,
+    detailsOpen: false,
+    copyStatus: 'idle',
+  };
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    this.setState({ errorInfo });
+    // Funnel into the existing debug stream so the in-app log viewer (and
+    // anything wired up to it later, e.g. a remote sink) captures the crash.
+    debug.error('Boundary', 'Render error caught', { error, errorInfo });
+  }
+
+  handleCopySession = async (): Promise<void> => {
+    try {
+      const data = localStorage.getItem(STORAGE_KEY);
+      if (!data) {
+        this.setState({ copyStatus: 'failed' });
+        return;
+      }
+      await navigator.clipboard.writeText(data);
+      this.setState({ copyStatus: 'copied' });
+      // Reset the badge after a couple of seconds so the user knows they can
+      // copy again if they want (e.g. cleared their clipboard).
+      setTimeout(() => this.setState({ copyStatus: 'idle' }), 2000);
+    } catch (err) {
+      debug.error('Boundary', 'Failed to copy session', err);
+      this.setState({ copyStatus: 'failed' });
+    }
+  };
+
+  handleReload = (): void => {
+    window.location.reload();
+  };
+
+  handleResetAndReload = (): void => {
+    if (!window.confirm('This will erase your auto-saved draft and reload. Continue?')) {
+      return;
+    }
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (err) {
+      debug.error('Boundary', 'Failed to clear session before reload', err);
+    }
+    window.location.reload();
+  };
+
+  toggleDetails = (): void => {
+    this.setState((s) => ({ detailsOpen: !s.detailsOpen }));
+  };
+
+  render(): ReactNode {
+    const { error, errorInfo, detailsOpen, copyStatus } = this.state;
+
+    if (!error) {
+      return this.props.children;
+    }
+
+    // Inline styles only — Tailwind classes might fail to load if a CSS
+    // regression is what crashed the app. The container styling here is
+    // deliberately boring so it works even on a blank document.
+    const containerStyle: React.CSSProperties = {
+      minHeight: '100vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: '24px',
+      backgroundColor: '#f8fafc',
+      color: '#0f172a',
+      fontFamily: 'system-ui, -apple-system, sans-serif',
+    };
+
+    const cardStyle: React.CSSProperties = {
+      maxWidth: '640px',
+      width: '100%',
+      backgroundColor: '#ffffff',
+      border: '1px solid #e2e8f0',
+      borderRadius: '8px',
+      padding: '24px',
+      boxShadow: '0 1px 3px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.06)',
+    };
+
+    const buttonStyle: React.CSSProperties = {
+      padding: '8px 14px',
+      borderRadius: '6px',
+      border: '1px solid #cbd5e1',
+      backgroundColor: '#ffffff',
+      color: '#0f172a',
+      fontSize: '14px',
+      fontWeight: 500,
+      cursor: 'pointer',
+    };
+
+    const primaryButtonStyle: React.CSSProperties = {
+      ...buttonStyle,
+      backgroundColor: '#0f172a',
+      color: '#ffffff',
+      borderColor: '#0f172a',
+    };
+
+    const dangerButtonStyle: React.CSSProperties = {
+      ...buttonStyle,
+      borderColor: '#dc2626',
+      color: '#dc2626',
+    };
+
+    const codeStyle: React.CSSProperties = {
+      display: 'block',
+      backgroundColor: '#f1f5f9',
+      border: '1px solid #e2e8f0',
+      borderRadius: '4px',
+      padding: '12px',
+      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+      fontSize: '12px',
+      lineHeight: '1.5',
+      overflowX: 'auto',
+      whiteSpace: 'pre-wrap',
+      wordBreak: 'break-word',
+      maxHeight: '240px',
+    };
+
+    return (
+      <div style={containerStyle} role="alert" aria-live="assertive">
+        <div style={cardStyle}>
+          <h1 style={{ fontSize: '20px', fontWeight: 600, margin: '0 0 8px 0' }}>
+            Something went wrong
+          </h1>
+          <p style={{ margin: '0 0 16px 0', color: '#475569', fontSize: '14px', lineHeight: 1.5 }}>
+            DonDocs hit an error it couldn't recover from. Your auto-saved draft is
+            still in this browser — you can copy it to your clipboard before reloading.
+          </p>
+
+          <div
+            style={{
+              backgroundColor: '#fef2f2',
+              border: '1px solid #fecaca',
+              borderRadius: '6px',
+              padding: '12px',
+              marginBottom: '16px',
+              fontSize: '13px',
+              color: '#991b1b',
+              wordBreak: 'break-word',
+            }}
+          >
+            <strong>{error.name}:</strong> {error.message}
+          </div>
+
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '16px' }}>
+            <button
+              type="button"
+              onClick={this.handleCopySession}
+              style={buttonStyle}
+              aria-label="Copy auto-saved session data to clipboard"
+            >
+              {copyStatus === 'copied'
+                ? 'Copied ✓'
+                : copyStatus === 'failed'
+                  ? 'No saved draft'
+                  : 'Copy saved draft'}
+            </button>
+            <button
+              type="button"
+              onClick={this.handleReload}
+              style={primaryButtonStyle}
+              aria-label="Reload the page"
+            >
+              Reload
+            </button>
+            <button
+              type="button"
+              onClick={this.handleResetAndReload}
+              style={dangerButtonStyle}
+              aria-label="Erase saved draft and reload"
+            >
+              Reset and reload
+            </button>
+          </div>
+
+          <button
+            type="button"
+            onClick={this.toggleDetails}
+            style={{
+              ...buttonStyle,
+              border: 'none',
+              padding: '4px 0',
+              backgroundColor: 'transparent',
+              color: '#475569',
+              fontSize: '13px',
+            }}
+            aria-expanded={detailsOpen}
+          >
+            {detailsOpen ? '▾ Hide details' : '▸ Show details'}
+          </button>
+
+          {detailsOpen && (
+            <div style={{ marginTop: '12px' }}>
+              <div style={{ fontSize: '12px', color: '#475569', marginBottom: '4px' }}>
+                Stack trace
+              </div>
+              <code style={codeStyle}>{error.stack || '(no stack available)'}</code>
+              {errorInfo?.componentStack && (
+                <>
+                  <div style={{ fontSize: '12px', color: '#475569', margin: '12px 0 4px 0' }}>
+                    Component stack
+                  </div>
+                  <code style={codeStyle}>{errorInfo.componentStack}</code>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -22,6 +22,7 @@ import { useUIStore } from '@/stores/uiStore';
 import { useDocumentStore } from '@/stores/documentStore';
 import { useHistoryStore } from '@/stores/historyStore';
 import { uint8ArrayToBase64, base64ToUint8Array, arrayBufferToUint8Array } from '@/lib/encoding';
+import { STORAGE_KEYS } from '@/lib/constants';
 import { useLogStore } from '@/stores/logStore';
 
 interface HeaderProps {
@@ -48,7 +49,7 @@ interface HeaderProps {
 
 const GITHUB_REPO_URL = 'https://github.com/marinecoders/dondocs';
 const GITHUB_NEW_ISSUE_URL = 'https://github.com/marinecoders/dondocs/issues/new';
-const STORAGE_KEY = 'dondocs-document';
+const STORAGE_KEY = STORAGE_KEYS.DOCUMENT;
 
 // GitHub URLs over ~8 KB start to fail in some browsers; cap the prefilled
 // log payload so the link always works. Users can still copy full logs from

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -199,6 +199,10 @@ export const STORAGE_KEYS = {
   SELECTED_PROFILE: 'dondocs-selected-profile',
   THEME: 'dondocs-theme',
   LAST_DOC_TYPE: 'dondocs-last-doc-type',
+  // Auto-saved current document. Read/written by Header.tsx (Save / Load
+  // buttons) and read by ErrorBoundary.tsx (Copy saved draft / Reset and
+  // reload buttons). Keep these in sync via this single source of truth.
+  DOCUMENT: 'dondocs-document',
 } as const;
 
 /**

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -40,7 +40,16 @@ function migrateLocalStorage() {
   }
 }
 
-migrateLocalStorage();
+// migrateLocalStorage runs BEFORE the ErrorBoundary mounts, so any throw
+// here would bypass the boundary and produce the white screen we just
+// added the boundary to prevent. Guard with try/catch — migration is
+// best-effort cleanup of legacy keys; failing to migrate one key
+// shouldn't prevent the app from booting.
+try {
+  migrateLocalStorage();
+} catch (err) {
+  console.error('[main] migrateLocalStorage failed (non-fatal):', err);
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { ErrorBoundary } from '@/components/ErrorBoundary'
 
 // Initialize debug utility (registers global DONDOCS object and keyboard shortcut)
 import '@/lib/debug'
@@ -43,6 +44,8 @@ migrateLocalStorage();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
Closes #18.

Wraps `<App>` in `main.tsx` with a top-level `<ErrorBoundary>`. A render-time crash anywhere in the tree now lands on a recovery UI instead of a white screen.

## What the boundary catches

Render-phase exceptions in any component below it. Per React's documented behavior, error boundaries do NOT catch:

- errors thrown inside event handlers
- errors thrown in async code (`Promise.then`, `setTimeout`, etc.)
- errors thrown during server-side rendering
- errors thrown in the boundary itself

For our purposes that's fine — the failure mode this addresses is the "editor / form / preview tree throws on render and the whole tab goes blank" case, which is what users have actually hit.

## Recovery UI

Three actions exposed to the user:

- **Copy saved draft** — exfiltrates `localStorage['dondocs-document']` (the auto-saved session) to the clipboard so the user can preserve work before any reload. Falls back gracefully if there's nothing saved.
- **Reload** — `window.location.reload()`. Cheap retry; useful when the crash was caused by a transient async race rather than the persisted state.
- **Reset and reload** — clears `localStorage['dondocs-document']` then reloads. Confirmation prompt first. Escape hatch for the case where the persisted session itself is the thing that crashes on rehydrate.

Plus a collapsible details section showing `error.stack` and `errorInfo.componentStack` for when a developer / power user wants to report the bug.

The error is also funneled into the existing `debug.error` stream so the in-app log viewer captures it, alongside whatever else is feeding that stream.

## Why inline styles in the fallback

The boundary itself is the last line of defense — if Tailwind class generation or a shadcn primitive is *what crashed*, importing those inside the fallback would crash the boundary too. So the recovery UI uses inline styles + plain HTML buttons. Looks plain, but it survives classes of failure that a styled fallback wouldn't.

## Verification

- `tsc --noEmit` clean
- `eslint`: 41 problems (unchanged from main; the new file is clean)
- `vite build` succeeds; bundle grew 4 KB raw / 1.4 KB gzipped (the new component itself)
- Version bumped 1.1.7 → 1.1.8