### PR TITLE
fix(navmc-11811): resolve {{NAME}}/{{DATE}} placeholders on normal download (closes #13)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.10",
+  "version": "1.1.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import { generateFlatLatex } from '@/services/latex/flat-generator';
 import { convertLatexToDocx } from '@/services/docx/pandoc-converter';
 import { generateNavmc10274Pdf, loadNavmc10274Templates } from '@/services/pdf/navmc10274Generator';
 import { generateNavmc11811Pdf, loadNavmc11811Template } from '@/services/pdf/navmc11811Generator';
+import { applyPlaceholdersToNavmc11811, buildNavmc11811DefaultValues } from '@/lib/placeholders';
 import { mergeEnclosures } from '@/services/pdf/mergeEnclosures';
 import type { ClassificationInfo, EnclosureError } from '@/services/pdf/mergeEnclosures';
 import { addSignatureField, addDualSignatureFields, type DualSignatureFieldConfig, type SignatureFieldConfig } from '@/services/pdf/addSignatureField';
@@ -520,8 +521,14 @@ function App() {
             navmc10274Templates.page3
           );
         } else if (formType === 'navmc_118_11' && navmc11811Template) {
+          // Resolve cross-field placeholders ({{NAME}}, {{DATE}}, etc.)
+          // from the form's own field values before generating, so users
+          // typing `{{NAME}}` in the remarks field see the joined name
+          // in the output PDF instead of literal `{{NAME}}` (issue #13).
+          const values = buildNavmc11811DefaultValues(navmc11811);
+          const resolved = applyPlaceholdersToNavmc11811(navmc11811, values);
           pdfBytes = await generateNavmc11811Pdf(
-            navmc11811,
+            resolved,
             navmc11811Template
           );
         }
@@ -982,8 +989,13 @@ function App() {
         );
         filename = `NAVMC-10274-${navmc10274.date || 'form'}.pdf`;
       } else if (formType === 'navmc_118_11' && navmc11811Template) {
+        // Same self-referential placeholder resolution as the live-preview
+        // path above (compile useEffect). Without this, normal download
+        // renders `{{NAME}}` etc. as literal yellow-highlighted text.
+        const values = buildNavmc11811DefaultValues(navmc11811);
+        const resolved = applyPlaceholdersToNavmc11811(navmc11811, values);
         pdfBytes = await generateNavmc11811Pdf(
-          navmc11811,
+          resolved,
           navmc11811Template
         );
         const lastName = navmc11811.lastName || 'Marine';

--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -29,10 +29,16 @@ import { generateNavmc10274Pdf, loadNavmc10274Templates } from '@/services/pdf/n
 import { generateNavmc11811Pdf, loadNavmc11811Template } from '@/services/pdf/navmc11811Generator';
 import { debug } from '@/lib/debug';
 import { TIMING, BATCH_PLACEHOLDERS, NAVMC_10274_PLACEHOLDERS, NAVMC_118_11_PLACEHOLDERS } from '@/lib/constants';
+import {
+  detectPlaceholders,
+  replacePlaceholders,
+  applyPlaceholdersToNavmc10274,
+  applyPlaceholdersToNavmc11811,
+  type PlaceholderValues,
+} from '@/lib/placeholders';
 
-interface PlaceholderValue {
-  [key: string]: string;
-}
+// Local alias retained for naming compatibility with the rest of this file.
+type PlaceholderValue = PlaceholderValues;
 
 interface BatchRow {
   id: string;
@@ -56,26 +62,6 @@ interface BatchModalProps {
 
 // Max retries for ENGINE_RESET_NEEDED
 const MAX_RETRIES = 2;
-
-// Detect placeholders in text (format: {{PLACEHOLDER_NAME}} - case insensitive)
-function detectPlaceholders(text: string): string[] {
-  const regex = /\{\{([A-Za-z0-9_]+)\}\}/g;
-  const placeholders = new Set<string>();
-  let match;
-  while ((match = regex.exec(text)) !== null) {
-    // Normalize to uppercase for consistency
-    placeholders.add(match[1].toUpperCase());
-  }
-  return Array.from(placeholders);
-}
-
-// Replace placeholders in text (case insensitive)
-function replacePlaceholders(text: string, values: PlaceholderValue): string {
-  return text.replace(/\{\{([A-Za-z0-9_]+)\}\}/gi, (match, key) => {
-    const upperKey = key.toUpperCase();
-    return values[upperKey] !== undefined ? values[upperKey] : match;
-  });
-}
 
 // Copy text to clipboard
 function copyToClipboard(text: string) {
@@ -369,40 +355,17 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
     };
   }, []);
 
-  // Create modified NAVMC 10274 form data with placeholder replacements.
+  // Create modified NAVMC form data with placeholder replacements.
   // Same getState() pattern as createModifiedStore — keeps identity stable.
+  // Substitution itself is delegated to the shared `applyPlaceholdersTo*`
+  // helpers in @/lib/placeholders so the batch and normal-download paths
+  // can't drift apart (issue #13 was caused by exactly that drift).
   const createModifiedNavmc10274 = useCallback((values: PlaceholderValue): NavmcForm10274Data => {
-    const data = useFormStore.getState().navmc10274;
-    return {
-      actionNo: replacePlaceholders(data.actionNo, values),
-      ssicFileNo: replacePlaceholders(data.ssicFileNo, values),
-      date: replacePlaceholders(data.date, values),
-      from: replacePlaceholders(data.from, values),
-      via: replacePlaceholders(data.via, values),
-      orgStation: replacePlaceholders(data.orgStation, values),
-      to: replacePlaceholders(data.to, values),
-      natureOfAction: replacePlaceholders(data.natureOfAction, values),
-      copyTo: replacePlaceholders(data.copyTo, values),
-      references: replacePlaceholders(data.references, values),
-      enclosures: replacePlaceholders(data.enclosures, values),
-      supplementalInfo: replacePlaceholders(data.supplementalInfo, values),
-      proposedAction: replacePlaceholders(data.proposedAction, values),
-    };
+    return applyPlaceholdersToNavmc10274(useFormStore.getState().navmc10274, values);
   }, []);
 
-  // Create modified NAVMC 118(11) form data with placeholder replacements.
   const createModifiedNavmc11811 = useCallback((values: PlaceholderValue): Navmc11811Data => {
-    const data = useFormStore.getState().navmc11811;
-    return {
-      lastName: replacePlaceholders(data.lastName, values),
-      firstName: replacePlaceholders(data.firstName, values),
-      middleName: replacePlaceholders(data.middleName, values),
-      edipi: replacePlaceholders(data.edipi, values),
-      remarksText: replacePlaceholders(data.remarksText, values),
-      remarksTextRight: replacePlaceholders(data.remarksTextRight || '', values),
-      entryDate: replacePlaceholders(data.entryDate, values),
-      box11: replacePlaceholders(data.box11, values),
-    };
+    return applyPlaceholdersToNavmc11811(useFormStore.getState().navmc11811, values);
   }, []);
 
   // Generate PDF for a single row with retry logic for ENGINE_RESET_NEEDED

--- a/src/lib/placeholders.ts
+++ b/src/lib/placeholders.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared placeholder detection / replacement utilities.
+ *
+ * Documents in this app can contain placeholders like `{{NAME}}` or
+ * `{{ENTRY_DATE}}`. These are filled in at PDF-generation time. There are
+ * two flows that need to substitute them:
+ *
+ *  - **Batch mode** (BatchModal.tsx) — substitutes from per-row values
+ *    pasted from a CSV / table.
+ *  - **Normal mode** (App.tsx download paths) — substitutes from the
+ *    form's own field values (e.g. `{{NAME}}` resolves to the joined
+ *    `lastName, firstName, middleName`). Without this, normal download
+ *    would render `{{NAME}}` as literal yellow-highlighted text in the
+ *    output PDF (issue #13).
+ *
+ * Both flows now use the same primitives here. Placeholders that have no
+ * value in the supplied map fall through unchanged — `replacePlaceholders`
+ * never invents values, and the generators yellow-highlight any remaining
+ * `{{...}}` so users can see what's still unfilled.
+ */
+
+import type { Navmc11811Data, NavmcForm10274Data } from '@/stores/formStore';
+
+/**
+ * Map from placeholder name (uppercased, no braces) to its value.
+ *
+ * Lookups are case-insensitive — keys are uppercased on insert and
+ * uppercased on lookup, so `{{name}}` and `{{NAME}}` resolve to the
+ * same value.
+ */
+export type PlaceholderValues = Record<string, string>;
+
+const PLACEHOLDER_RE = /\{\{([A-Za-z0-9_]+)\}\}/g;
+
+/**
+ * Detect all unique placeholder names used in `text`.
+ *
+ * Returns uppercased names with braces stripped — e.g. given
+ * `"On {{date}}, {{NAME}} did X"` returns `["DATE", "NAME"]`.
+ */
+export function detectPlaceholders(text: string): string[] {
+  const seen = new Set<string>();
+  let match: RegExpExecArray | null;
+  // Use a fresh regex copy so concurrent callers don't share lastIndex.
+  const re = new RegExp(PLACEHOLDER_RE.source, PLACEHOLDER_RE.flags);
+  while ((match = re.exec(text)) !== null) {
+    seen.add(match[1].toUpperCase());
+  }
+  return Array.from(seen);
+}
+
+/**
+ * Replace every `{{NAME}}` occurrence in `text` with `values[NAME]`.
+ *
+ * Case-insensitive — `{{name}}` looks up `NAME`. If the key isn't in
+ * `values`, the original `{{name}}` is left in place so the generator's
+ * placeholder-highlight can still flag it.
+ */
+export function replacePlaceholders(text: string, values: PlaceholderValues): string {
+  return text.replace(PLACEHOLDER_RE, (match, key: string) => {
+    const upper = key.toUpperCase();
+    return Object.prototype.hasOwnProperty.call(values, upper) ? values[upper] : match;
+  });
+}
+
+/**
+ * Build a default placeholder map from an NAVMC 118(11) form's own field
+ * values. Used for normal (non-batch) downloads so cross-field
+ * placeholders like `{{NAME}}` and `{{DATE}}` resolve to what the user
+ * already entered.
+ *
+ * The keys here MUST match the documented placeholder names in
+ * `NAVMC_118_11_PLACEHOLDERS` (constants.ts) plus a handful of common
+ * aliases. Custom user-defined placeholders that aren't in this map will
+ * fall through to `replacePlaceholders` unchanged and end up
+ * yellow-highlighted in the output — which is the right signal that
+ * "this variable has no value yet".
+ */
+export function buildNavmc11811DefaultValues(data: Navmc11811Data): PlaceholderValues {
+  const fullName = [data.lastName, data.firstName, data.middleName]
+    .filter(Boolean)
+    .join(', ')
+    .toUpperCase();
+
+  return {
+    // Composite — matches NAVMC_118_11_PLACEHOLDERS example "DOE, JOHN MICHAEL"
+    NAME: fullName,
+    // Per-component aliases. Allow both underscored and joined spellings
+    // so a user typing `{{LASTNAME}}` or `{{LAST_NAME}}` both work.
+    LASTNAME: data.lastName,
+    LAST_NAME: data.lastName,
+    FIRSTNAME: data.firstName,
+    FIRST_NAME: data.firstName,
+    MIDDLENAME: data.middleName,
+    MIDDLE_NAME: data.middleName,
+    // Middle initial
+    MI: data.middleName ? data.middleName[0].toUpperCase() : '',
+    EDIPI: data.edipi,
+    BOX11: data.box11,
+    BOX_11: data.box11,
+    // Date — both DATE (per placeholder list) and ENTRY_DATE (the field name)
+    DATE: data.entryDate,
+    ENTRY_DATE: data.entryDate,
+  };
+}
+
+/**
+ * Apply placeholder substitution to every text field of a Navmc11811Data.
+ * Returns a NEW object — does not mutate `data`.
+ *
+ * Pass `values = buildNavmc11811DefaultValues(data)` for the normal
+ * download path, or per-row values from BatchModal for batch mode.
+ */
+export function applyPlaceholdersToNavmc11811(
+  data: Navmc11811Data,
+  values: PlaceholderValues
+): Navmc11811Data {
+  return {
+    lastName: replacePlaceholders(data.lastName, values),
+    firstName: replacePlaceholders(data.firstName, values),
+    middleName: replacePlaceholders(data.middleName, values),
+    edipi: replacePlaceholders(data.edipi, values),
+    remarksText: replacePlaceholders(data.remarksText, values),
+    remarksTextRight: replacePlaceholders(data.remarksTextRight ?? '', values),
+    entryDate: replacePlaceholders(data.entryDate, values),
+    box11: replacePlaceholders(data.box11, values),
+  };
+}
+
+/**
+ * Apply placeholder substitution to every text field of an NavmcForm10274Data.
+ * Mirrors the BatchModal-internal helper so both the batch and normal
+ * paths share the same primitive.
+ */
+export function applyPlaceholdersToNavmc10274(
+  data: NavmcForm10274Data,
+  values: PlaceholderValues
+): NavmcForm10274Data {
+  return {
+    actionNo: replacePlaceholders(data.actionNo, values),
+    ssicFileNo: replacePlaceholders(data.ssicFileNo, values),
+    date: replacePlaceholders(data.date, values),
+    from: replacePlaceholders(data.from, values),
+    via: replacePlaceholders(data.via, values),
+    orgStation: replacePlaceholders(data.orgStation, values),
+    to: replacePlaceholders(data.to, values),
+    natureOfAction: replacePlaceholders(data.natureOfAction, values),
+    copyTo: replacePlaceholders(data.copyTo, values),
+    references: replacePlaceholders(data.references, values),
+    enclosures: replacePlaceholders(data.enclosures, values),
+    supplementalInfo: replacePlaceholders(data.supplementalInfo, values),
+    proposedAction: replacePlaceholders(data.proposedAction, values),
+  };
+}


### PR DESCRIPTION
Closes #13. NAVMC 118(11) PDFs downloaded outside batch mode rendered custom variables like `{{NAME}}` and `{{DATE}}` as literal yellow-highlighted text instead of substituting values.

## Why batch worked but normal didn't

`BatchModal.tsx` had its own `replacePlaceholders` + a per-form `createModifiedNavmc11811` helper that called it. The normal-download path (`App.tsx:524` for live preview, `App.tsx:991` for the actual download) skipped substitution entirely and passed raw `formStore.navmc11811` to `generateNavmc11811Pdf`. The generator's `drawTextWithHighlights` then yellow-highlighted every unsubstituted `{{...}}` it saw.

## Approach

Extract placeholder primitives into a shared module so the batch path and the normal-download path can't drift apart again.

New file `src/lib/placeholders.ts` exports:

- `detectPlaceholders(text)` — find `{{NAMES}}` in text
- `replacePlaceholders(text, values)` — substitute, leaving unmatched placeholders in place so the generator's yellow-highlight still flags them
- `applyPlaceholdersToNavmc11811(data, values)` — substitute every text field of an `Navmc11811Data`
- `applyPlaceholdersToNavmc10274(data, values)` — same for the 10274 form (used by the batch path)
- `buildNavmc11811DefaultValues(data)` — build a values map from the form's own field values, so `{{NAME}}` resolves to the joined `lastName, firstName, middleName`, `{{DATE}}` to `entryDate`, and the natural per-field aliases (`{{LAST_NAME}}`, `{{EDIPI}}`, `{{MI}}`, `{{BOX11}}`, etc.) work too

## Wiring

- **`App.tsx`** — both NAVMC 118(11) paths (live-preview effect ~L522 and download handler ~L990) now build a default values map from the current form data and apply it before calling `generateNavmc11811Pdf`. Custom user-defined variables that aren't in the default map fall through to literal `{{X}}` and remain yellow-highlighted — same visual signal as before, but actual cross-field references now work.
- **`BatchModal.tsx`** — drops its inline `replacePlaceholders` / `detectPlaceholders` definitions and the field-by-field `createModifiedNavmc10274` / `createModifiedNavmc11811`. Both now go through the shared helpers. Net **-25 lines** in this file.

## Out of scope

- A normal-download placeholder values UI for NAVMC 10274. The 10274 is feature-flavored differently (counseling sheet) and the issue doesn't call for it; if the same gap exists there, file a separate bug.
- Correspondence (non-form) documents in normal mode. They go through `generator.ts` which doesn't yellow-highlight unfilled placeholders, so the visible bug doesn't apply.

## Verification

- `tsc --noEmit` clean
- `eslint`: 41 problems — matches main baseline (the 2 errors flagged in `BatchModal.tsx` and `App.tsx` are pre-existing)
- `vite build` succeeds
- Version bumped 1.1.10 → 1.1.11