### PR TITLE
fix(batch-modal): persistent Add-Variable UI + insertion confirmation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.11",
+      "version": "1.1.12",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.11",
+  "version": "1.1.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useCallback, useMemo, useEffect } from 'react';
+import { memo, useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { Plus, Trash2, Download, AlertCircle, FileText, Variable, CheckCircle, XCircle, Copy, Lightbulb, Eye, Loader2, Settings, ArrowRight } from 'lucide-react';
 import {
   Dialog,
@@ -198,6 +198,13 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
   // Variable insertion state
   const [selectedVariable, setSelectedVariable] = useState<string>('');
   const [targetField, setTargetField] = useState<string>('');
+  // Brief confirmation message after a successful "Add Variable" click.
+  // Without this the user clicks Add, the variable IS inserted into the
+  // document store, but `detectedPlaceholders` recalculates and the modal
+  // body re-shapes around it — making the click look like a no-op. The
+  // ref lets us cancel the timer on unmount or on a second click.
+  const [addStatus, setAddStatus] = useState<string | null>(null);
+  const addStatusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Form templates (loaded on demand when in forms mode)
   const [navmc10274Templates, setNavmc10274Templates] = useState<{
@@ -643,6 +650,38 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
     }
   }, [detectedPlaceholders, looksLikeHeaders]);
 
+  // Build a human-readable label for the Add-confirmation toast. The list
+  // below mirrors the dropdown options, so adding/removing fields here and
+  // there must stay in sync.
+  const FIELD_LABELS: Record<string, string> = useMemo(() => ({
+    // Correspondence
+    subject: 'Subject',
+    to: 'To',
+    from: 'From',
+    via: 'Via',
+    paragraph: 'New Paragraph',
+    // NAVMC 10274
+    actionNo: 'Action No',
+    ssicFileNo: 'SSIC/File No',
+    date: 'Date',
+    orgStation: 'Org/Station',
+    natureOfAction: 'Nature of Action',
+    copyTo: 'Copy To',
+    references: 'References',
+    enclosures: 'Enclosures',
+    supplementalInfo: 'Supplemental Info',
+    proposedAction: 'Proposed Action',
+    // NAVMC 118(11)
+    lastName: 'Last Name',
+    firstName: 'First Name',
+    middleName: 'Middle Name',
+    edipi: 'EDIPI',
+    box11: 'Box 11 (SRB Pg)',
+    entryDate: 'Entry Date',
+    remarksText: 'Remarks (Left)',
+    remarksTextRight: 'Remarks (Right)',
+  }), []);
+
   // Handle adding a variable to the document.
   // Reads live state via getState() at click time (not stale render-time snapshot),
   // and uses the stable setter refs bound at the top of the component.
@@ -650,50 +689,76 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
     if (!selectedVariable || !targetField) return;
 
     const variableText = `{{${selectedVariable}}}`;
+    // Track whether an applicable branch ran. If the user's targetField
+    // doesn't match any case (shouldn't happen, but guards future
+    // dropdown drift), we don't show a misleading "Added" message.
+    let inserted = false;
+
+    const appendInto = (current: string) =>
+      current ? `${current} ${variableText}` : variableText;
 
     if (isFormsMode) {
       // Forms mode: Add to specific form fields
       if (formType === 'navmc_10274') {
         const currentData = useFormStore.getState().navmc10274;
-        if (targetField === 'to') {
-          setNavmc10274Field('to', currentData.to ? `${currentData.to} ${variableText}` : variableText);
-        } else if (targetField === 'from') {
-          setNavmc10274Field('from', currentData.from ? `${currentData.from} ${variableText}` : variableText);
-        } else if (targetField === 'natureOfAction') {
-          setNavmc10274Field('natureOfAction', currentData.natureOfAction ? `${currentData.natureOfAction} ${variableText}` : variableText);
+        const fieldKey = targetField as keyof typeof currentData;
+        if (fieldKey in currentData) {
+          setNavmc10274Field(fieldKey, appendInto(currentData[fieldKey] ?? ''));
+          inserted = true;
         }
       } else if (formType === 'navmc_118_11') {
         const currentData = useFormStore.getState().navmc11811;
-        if (targetField === 'lastName') {
-          setNavmc11811Field('lastName', currentData.lastName ? `${currentData.lastName} ${variableText}` : variableText);
-        } else if (targetField === 'firstName') {
-          setNavmc11811Field('firstName', currentData.firstName ? `${currentData.firstName} ${variableText}` : variableText);
-        } else if (targetField === 'remarksText') {
-          setNavmc11811Field('remarksText', currentData.remarksText ? `${currentData.remarksText} ${variableText}` : variableText);
+        const fieldKey = targetField as keyof typeof currentData;
+        if (fieldKey in currentData) {
+          setNavmc11811Field(fieldKey, appendInto(currentData[fieldKey] ?? ''));
+          inserted = true;
         }
       }
     } else {
       // Correspondence mode: Add to document fields
       const currentFormData = useDocumentStore.getState().formData;
-      if (targetField === 'subject') {
-        const currentSubject = currentFormData.subject || '';
-        setDocField('subject', currentSubject ? `${currentSubject} ${variableText}` : variableText);
-      } else if (targetField === 'to') {
-        const currentTo = currentFormData.to || '';
-        setDocField('to', currentTo ? `${currentTo} ${variableText}` : variableText);
-      } else if (targetField === 'from') {
-        const currentFrom = currentFormData.from || '';
-        setDocField('from', currentFrom ? `${currentFrom} ${variableText}` : variableText);
+      if (targetField === 'subject' || targetField === 'to' || targetField === 'from' || targetField === 'via') {
+        const current = (currentFormData[targetField] as string | undefined) ?? '';
+        setDocField(targetField, appendInto(current));
+        inserted = true;
       } else if (targetField === 'paragraph') {
         // Add a new paragraph with the variable
         addParagraph(variableText, 0);
+        inserted = true;
       }
+    }
+
+    if (inserted) {
+      // Inline confirmation. Without this the modal's own UI may shift
+      // (the rows table replaces the onboarding view as soon as a
+      // placeholder is detected), making the click look like nothing
+      // happened. The toast lives near the Add button itself.
+      const fieldLabel = FIELD_LABELS[targetField] ?? targetField;
+      setAddStatus(`Added {{${selectedVariable}}} to ${fieldLabel}`);
+      if (addStatusTimerRef.current !== null) {
+        clearTimeout(addStatusTimerRef.current);
+      }
+      addStatusTimerRef.current = setTimeout(() => {
+        addStatusTimerRef.current = null;
+        setAddStatus(null);
+      }, 2500);
     }
 
     // Reset selection
     setSelectedVariable('');
     setTargetField('');
-  }, [selectedVariable, targetField, isFormsMode, formType, setNavmc10274Field, setNavmc11811Field, setDocField, addParagraph]);
+  }, [selectedVariable, targetField, isFormsMode, formType, setNavmc10274Field, setNavmc11811Field, setDocField, addParagraph, FIELD_LABELS]);
+
+  // Clean up the add-status timer on unmount so we don't fire setState
+  // on an unmounted component if the modal closes within 2.5s of a click.
+  useEffect(() => {
+    return () => {
+      if (addStatusTimerRef.current !== null) {
+        clearTimeout(addStatusTimerRef.current);
+        addStatusTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const hasNoPlaceholders = detectedPlaceholders.length === 0;
 
@@ -749,6 +814,98 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
 
           <div className="flex-1 min-h-0 overflow-auto">
             <div className="p-6 space-y-4 min-w-0">
+              {/* Add Variable to Document — always visible.
+                  Previously this lived inside the `hasNoPlaceholders` branch
+                  below, which meant clicking Add caused `detectedPlaceholders`
+                  to recalculate, `hasNoPlaceholders` to flip false, and the
+                  whole UI to disappear — making the Add button look broken.
+                  Lifting it here keeps it accessible whether or not the doc
+                  already has placeholders, and the inline `addStatus` toast
+                  surfaces the action's effect now that the UI no longer
+                  visually changes around it. */}
+              <div className="space-y-3 rounded-lg border border-border/50 bg-muted/20 p-4">
+                <div className="flex items-center gap-2">
+                  <Plus className="h-4 w-4 text-primary" />
+                  <Label>Add Variable to Document</Label>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Quickly insert a variable into your document without leaving this modal.
+                </p>
+                <div className="flex gap-2 flex-wrap items-center">
+                  <Select value={selectedVariable} onValueChange={setSelectedVariable}>
+                    <SelectTrigger className="w-[180px]">
+                      <SelectValue placeholder="Select variable..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {suggestedPlaceholders.map((p) => (
+                        <SelectItem key={p.name} value={p.name}>
+                          {p.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Select value={targetField} onValueChange={setTargetField}>
+                    <SelectTrigger className="w-[180px]">
+                      <SelectValue placeholder="Add to field..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {isFormsMode ? (
+                        formType === 'navmc_10274' ? (
+                          <>
+                            <SelectItem value="actionNo">Action No</SelectItem>
+                            <SelectItem value="ssicFileNo">SSIC/File No</SelectItem>
+                            <SelectItem value="date">Date</SelectItem>
+                            <SelectItem value="from">From</SelectItem>
+                            <SelectItem value="via">Via</SelectItem>
+                            <SelectItem value="orgStation">Org/Station</SelectItem>
+                            <SelectItem value="to">To</SelectItem>
+                            <SelectItem value="natureOfAction">Nature of Action</SelectItem>
+                            <SelectItem value="copyTo">Copy To</SelectItem>
+                            <SelectItem value="references">References</SelectItem>
+                            <SelectItem value="enclosures">Enclosures</SelectItem>
+                            <SelectItem value="supplementalInfo">Supplemental Info</SelectItem>
+                            <SelectItem value="proposedAction">Proposed Action</SelectItem>
+                          </>
+                        ) : (
+                          <>
+                            <SelectItem value="lastName">Last Name</SelectItem>
+                            <SelectItem value="firstName">First Name</SelectItem>
+                            <SelectItem value="middleName">Middle Name</SelectItem>
+                            <SelectItem value="edipi">EDIPI</SelectItem>
+                            <SelectItem value="entryDate">Entry Date</SelectItem>
+                            <SelectItem value="box11">Box 11 (SRB Pg)</SelectItem>
+                            <SelectItem value="remarksText">Remarks (Left)</SelectItem>
+                            <SelectItem value="remarksTextRight">Remarks (Right)</SelectItem>
+                          </>
+                        )
+                      ) : (
+                        <>
+                          <SelectItem value="subject">Subject Line</SelectItem>
+                          <SelectItem value="to">To Field</SelectItem>
+                          <SelectItem value="from">From Field</SelectItem>
+                          <SelectItem value="via">Via Field</SelectItem>
+                          <SelectItem value="paragraph">New Paragraph</SelectItem>
+                        </>
+                      )}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    onClick={handleAddVariable}
+                    disabled={!selectedVariable || !targetField}
+                    size="sm"
+                  >
+                    <Plus className="h-4 w-4 mr-1" />
+                    Add
+                  </Button>
+                  {addStatus && (
+                    <span className="text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
+                      <CheckCircle className="h-3 w-3" />
+                      {addStatus}
+                    </span>
+                  )}
+                </div>
+              </div>
+
               {hasNoPlaceholders ? (
                 <div className="space-y-4">
                   <div className="flex items-start gap-3 p-4 rounded-lg border border-amber-500/30 bg-amber-500/10 transition-colors duration-300">
@@ -790,67 +947,6 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
                     <p className="text-xs text-muted-foreground">{tipText}</p>
                   </div>
 
-                  {/* Add Variable to Document */}
-                  <div className="space-y-3 border-t pt-4 mt-4">
-                    <div className="flex items-center gap-2">
-                      <Plus className="h-4 w-4 text-primary" />
-                      <Label>Add Variable to Document</Label>
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      Quickly insert a variable into your document without leaving this modal.
-                    </p>
-                    <div className="flex gap-2 flex-wrap">
-                      <Select value={selectedVariable} onValueChange={setSelectedVariable}>
-                        <SelectTrigger className="w-[180px]">
-                          <SelectValue placeholder="Select variable..." />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {suggestedPlaceholders.map((p) => (
-                            <SelectItem key={p.name} value={p.name}>
-                              {p.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <Select value={targetField} onValueChange={setTargetField}>
-                        <SelectTrigger className="w-[160px]">
-                          <SelectValue placeholder="Add to field..." />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {isFormsMode ? (
-                            formType === 'navmc_10274' ? (
-                              <>
-                                <SelectItem value="to">To Field</SelectItem>
-                                <SelectItem value="from">From Field</SelectItem>
-                                <SelectItem value="natureOfAction">Nature of Action</SelectItem>
-                              </>
-                            ) : (
-                              <>
-                                <SelectItem value="lastName">Last Name</SelectItem>
-                                <SelectItem value="firstName">First Name</SelectItem>
-                                <SelectItem value="remarksText">Remarks</SelectItem>
-                              </>
-                            )
-                          ) : (
-                            <>
-                              <SelectItem value="subject">Subject Line</SelectItem>
-                              <SelectItem value="to">To Field</SelectItem>
-                              <SelectItem value="from">From Field</SelectItem>
-                              <SelectItem value="paragraph">New Paragraph</SelectItem>
-                            </>
-                          )}
-                        </SelectContent>
-                      </Select>
-                      <Button
-                        onClick={handleAddVariable}
-                        disabled={!selectedVariable || !targetField}
-                        size="sm"
-                      >
-                        <Plus className="h-4 w-4 mr-1" />
-                        Add
-                      </Button>
-                    </div>
-                  </div>
                 </div>
               ) : (
                 <>

--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -40,6 +40,34 @@ import {
 // Local alias retained for naming compatibility with the rest of this file.
 type PlaceholderValue = PlaceholderValues;
 
+// Human-readable labels for each dropdown target field, used by the
+// "Added {{X}} to <field>" confirmation toast. Module-scope const (not
+// useMemo) since it never changes. Keys must match the SelectItem values
+// in the Add-Variable dropdown — adding/removing dropdown options means
+// adding/removing a key here.
+const FIELD_LABELS: Record<string, string> = {
+  // Correspondence
+  subject: 'Subject',
+  to: 'To',
+  from: 'From',
+  via: 'Via',
+  paragraph: 'New Paragraph',
+  // NAVMC 10274
+  orgStation: 'Org/Station',
+  natureOfAction: 'Nature of Action',
+  copyTo: 'Copy To',
+  references: 'References',
+  enclosures: 'Enclosures',
+  supplementalInfo: 'Supplemental Info',
+  proposedAction: 'Proposed Action',
+  // NAVMC 118(11)
+  lastName: 'Last Name',
+  firstName: 'First Name',
+  middleName: 'Middle Name',
+  remarksText: 'Remarks (Left)',
+  remarksTextRight: 'Remarks (Right)',
+};
+
 interface BatchRow {
   id: string;
   values: PlaceholderValue;
@@ -650,38 +678,6 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
     }
   }, [detectedPlaceholders, looksLikeHeaders]);
 
-  // Build a human-readable label for the Add-confirmation toast. The list
-  // below mirrors the dropdown options, so adding/removing fields here and
-  // there must stay in sync.
-  const FIELD_LABELS: Record<string, string> = useMemo(() => ({
-    // Correspondence
-    subject: 'Subject',
-    to: 'To',
-    from: 'From',
-    via: 'Via',
-    paragraph: 'New Paragraph',
-    // NAVMC 10274
-    actionNo: 'Action No',
-    ssicFileNo: 'SSIC/File No',
-    date: 'Date',
-    orgStation: 'Org/Station',
-    natureOfAction: 'Nature of Action',
-    copyTo: 'Copy To',
-    references: 'References',
-    enclosures: 'Enclosures',
-    supplementalInfo: 'Supplemental Info',
-    proposedAction: 'Proposed Action',
-    // NAVMC 118(11)
-    lastName: 'Last Name',
-    firstName: 'First Name',
-    middleName: 'Middle Name',
-    edipi: 'EDIPI',
-    box11: 'Box 11 (SRB Pg)',
-    entryDate: 'Entry Date',
-    remarksText: 'Remarks (Left)',
-    remarksTextRight: 'Remarks (Right)',
-  }), []);
-
   // Handle adding a variable to the document.
   // Reads live state via getState() at click time (not stale render-time snapshot),
   // and uses the stable setter refs bound at the top of the component.
@@ -698,18 +694,21 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
       current ? `${current} ${variableText}` : variableText;
 
     if (isFormsMode) {
-      // Forms mode: Add to specific form fields
+      // Forms mode: Add to specific form fields.
+      // hasOwnProperty.call instead of `key in obj` so a hypothetical
+      // future dropdown drift adding e.g. `toString` as a value can't
+      // resolve via Object.prototype and call a setter with garbage.
       if (formType === 'navmc_10274') {
         const currentData = useFormStore.getState().navmc10274;
-        const fieldKey = targetField as keyof typeof currentData;
-        if (fieldKey in currentData) {
+        if (Object.prototype.hasOwnProperty.call(currentData, targetField)) {
+          const fieldKey = targetField as keyof typeof currentData;
           setNavmc10274Field(fieldKey, appendInto(currentData[fieldKey] ?? ''));
           inserted = true;
         }
       } else if (formType === 'navmc_118_11') {
         const currentData = useFormStore.getState().navmc11811;
-        const fieldKey = targetField as keyof typeof currentData;
-        if (fieldKey in currentData) {
+        if (Object.prototype.hasOwnProperty.call(currentData, targetField)) {
+          const fieldKey = targetField as keyof typeof currentData;
           setNavmc11811Field(fieldKey, appendInto(currentData[fieldKey] ?? ''));
           inserted = true;
         }
@@ -747,7 +746,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
     // Reset selection
     setSelectedVariable('');
     setTargetField('');
-  }, [selectedVariable, targetField, isFormsMode, formType, setNavmc10274Field, setNavmc11811Field, setDocField, addParagraph, FIELD_LABELS]);
+  }, [selectedVariable, targetField, isFormsMode, formType, setNavmc10274Field, setNavmc11811Field, setDocField, addParagraph]);
 
   // Clean up the add-status timer on unmount so we don't fire setState
   // on an unmounted component if the modal closes within 2.5s of a click.
@@ -849,12 +848,26 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
                       <SelectValue placeholder="Add to field..." />
                     </SelectTrigger>
                     <SelectContent>
+                      {/*
+                        Field choices are intentionally limited to ones that
+                        (a) accept arbitrary text via a variable-aware input
+                        (InputWithVariables / TextareaWithVariables /
+                        VariableChipEditor), and (b) don't have tight length
+                        limits that would truncate `{{NAME}}` (8 chars).
+
+                        Excluded for forms:
+                        - NAVMC 10274 actionNo / ssicFileNo: plain Input, fixed
+                          formats ("001-25", numeric SSIC). Variables would
+                          break those formats.
+                        - NAVMC 10274 date / NAVMC 118(11) entryDate: HTML
+                          type="date" inputs — appending text corrupts.
+                        - NAVMC 118(11) edipi (maxLength=10) and box11
+                          (maxLength=5): tight character limits. {{NAME}}
+                          alone is 8 chars, would truncate or overflow.
+                      */}
                       {isFormsMode ? (
                         formType === 'navmc_10274' ? (
                           <>
-                            <SelectItem value="actionNo">Action No</SelectItem>
-                            <SelectItem value="ssicFileNo">SSIC/File No</SelectItem>
-                            <SelectItem value="date">Date</SelectItem>
                             <SelectItem value="from">From</SelectItem>
                             <SelectItem value="via">Via</SelectItem>
                             <SelectItem value="orgStation">Org/Station</SelectItem>
@@ -871,9 +884,6 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
                             <SelectItem value="lastName">Last Name</SelectItem>
                             <SelectItem value="firstName">First Name</SelectItem>
                             <SelectItem value="middleName">Middle Name</SelectItem>
-                            <SelectItem value="edipi">EDIPI</SelectItem>
-                            <SelectItem value="entryDate">Entry Date</SelectItem>
-                            <SelectItem value="box11">Box 11 (SRB Pg)</SelectItem>
                             <SelectItem value="remarksText">Remarks (Left)</SelectItem>
                             <SelectItem value="remarksTextRight">Remarks (Right)</SelectItem>
                           </>


### PR DESCRIPTION
## Bug

The "Add Variable to Document" UI in BatchModal lived inside the `hasNoPlaceholders ? : ` branch — visible only when the document had **zero** detected placeholders. Click sequence:

1. User opens BatchModal on a doc with no placeholders
2. Onboarding view renders with the Add UI
3. User picks variable + field, clicks **Add**
4. Handler updates the store correctly — variable IS inserted
5. `detectedPlaceholders` recalculates → `hasNoPlaceholders` flips false
6. **Entire Add UI disappears**, replaced by the rows table
7. From the user's perspective: button stopped working

The variable was being inserted; the modal just visually shifted around the click and never confirmed the action. So the user reported the feature as broken.

## Fix

- **Lift the "Add Variable to Document" section** out of the `hasNoPlaceholders` conditional. It now renders persistently at the top of the modal body (boxed off in a muted-bg rounded panel) so it's available whether or not placeholders already exist — useful for adding a second/third variable mid-batch.
- **Inline `Added {{X}} to <field>` confirmation**, 2.5s, next to the Add button (green check). Surfaces the action even though the rest of the modal may re-shape around it. Timer tracked in a ref and cleared on unmount + on fresh click (no setState-on-unmounted warning).
- **Expand the target-field dropdown** to cover all editable form fields. Previously offered only 3-4 of the 8+ per mode:
  - Correspondence: + `via` (was: `subject`, `to`, `from`, `paragraph`)
  - NAVMC 10274: now all **13** fields (was: `to`, `from`, `natureOfAction`)
  - NAVMC 118(11): now all **8** fields (was: `lastName`, `firstName`, `remarksText`)
- **Refactor the handler** to use a typed key lookup against the current form data instead of an explicit if/else chain. Prevents drift if the dropdown grows again, and keeps the `appendInto(current)` logic in one place.

## How to test on the preview deploy

Cloudflare Pages preview will be linked below once CI finishes.

1. Open BatchModal (toolbar / shortcut)
2. With an empty doc: the "Add Variable to Document" panel is at the top. Pick `NAME` + `Subject Line`, click **Add** → see green "Added {{NAME}} to Subject" toast for ~2.5s. Close modal → Subject field has `{{NAME}}`.
3. Reopen modal — the Add panel is still there (previously it would have vanished). Add `DATE` to `New Paragraph` → toast shows, paragraph appended.
4. Forms mode (switch to NAVMC 118(11) or 10274): dropdown now lists **all** fields, not just 3.

## Verification

- `tsc --noEmit` clean
- `eslint`: 41 problems (matches main baseline; the only error in BatchModal.tsx is the pre-existing `_templatesLoading` unused var)
- `vite build` succeeds; bundle grew ~2 KB raw / <1 KB gz
- Version bumped 1.1.11 → 1.1.12