### PR TITLE
fix(navmc-forms): use DatePicker for military date format (closes #15)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 rchiofalo
+Copyright (c) 2026 Roberto Chiofalo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # DonDocs — Naval Correspondence & Form Generator
 
-> "The docs are done when the docs are done."
-
 [![MIT License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![SECNAV M-5216.5](https://img.shields.io/badge/SECNAV-M--5216.5-blue)](https://www.secnav.navy.mil/doni/SECNAV%20Manuals1/5216.5%20DON%20Correspondence%20Manual.pdf)
 [![MCO 5216.20B](https://img.shields.io/badge/MCO-5216.20B-red)](https://www.marines.mil/News/Publications/MCPEL/Electronic-Library-Display/Article/899678/mco-521620/)
@@ -13,7 +11,6 @@
 
 ## Table of Contents
 
-- [Key Features](#key-features)
 - [Getting Started](#getting-started)
 - [Features](#features)
 - [Document Types](#document-types)
@@ -25,44 +22,6 @@
 - [Form Templates](#form-templates)
 - [Development](#development)
 - [License](#license)
-
----
-
-## Key Features
-
-### Publication-Quality Output
-- **LaTeX-based PDF generation** via WebAssembly - pixel-perfect formatting impossible with typical web tools
-- Professional typesetting that matches official military publications
-- Consistent spacing, margins, and font handling per SECNAV specifications
-
-### Comprehensive Data Libraries
-- **3,139 military units** with full addresses, MCC codes, and organizational data
-- **2,240 SSIC codes** from SECNAV M-5210.2 (August 2018)
-- **107 regulatory references** across 12 categories (MCO, SECNAVINST, NAVADMIN)
-- **74 office codes** (S-1, G-3, CO, XO, etc.) for signature blocks
-- **50+ military ranks** (USMC and Navy, all grades E1-O10 plus Warrant Officers)
-
-### Security-First Design
-- **100% client-side processing** - nothing leaves your browser
-- **PII/PHI detection** warns before download (SSN, EDIPI, DOB, medical info)
-- **Digital signature fields** compatible with CAC/PIV cards and Adobe Acrobat
-- **Classification markings** from Unclassified through TOP SECRET//SCI
-- **CUI handling** with 10 categories and distribution statements
-- **Portion markings** per-paragraph: (U), (CUI), (FOUO), (C), (S), (TS)
-- **NIST 800-171 compliant** - works on air-gapped networks (SIPR/JWICS)
-
-### Comprehensive Document Support
-- **20 document types** across letters, endorsements, memoranda, agreements, and executive formats
-- **Dynamic form adaptation** — the editor automatically shows/hides and reconfigures sections based on document type (e.g., dual-command fields for MOA/MOU, executive memo layouts, business letter salutations)
-- **11 pre-built templates** for common correspondence (awards, appointments, investigations, personnel)
-- **Distribution lists** and **Copy To** support per SECNAV Ch 8
-- **Continuation subject line** toggle for page 2+ headers
-- **Custom classification markings** for non-standard banners
-
-### Export Formats
-- **PDF** - Full-featured with enclosures, signatures, and classification markings
-- **DOCX** - Editable Microsoft Word format
-- **LaTeX** - Source files for advanced customization
 
 ---
 
@@ -85,6 +44,13 @@
 ---
 
 ## Features
+
+DonDocs uses a WebAssembly LaTeX compiler to produce publication-quality PDFs that match official military typesetting — pixel-perfect spacing, kerning, and margins per SECNAV specifications. Everything runs locally in the browser; nothing is ever sent to a server.
+
+### Export Formats
+- **PDF** — full-featured with enclosures, signatures, and classification markings
+- **DOCX** — editable Microsoft Word output with matching layout
+- **LaTeX** — source files for advanced customization
 
 ### Core Functionality
 - **Real-time PDF Preview** - See your document as you type (1.5s debounce)
@@ -388,167 +354,11 @@ PDF output includes empty signature fields compatible with:
 
 ## Form Templates
 
-This application supports official military forms (NAVMC 10274, NAVMC 118(11), etc.) by overlaying text onto official PDF templates.
+DonDocs supports official military forms (NAVMC 10274, NAVMC 118(11), etc.) by overlaying text onto official PDF templates obtained from [DoD Forms Management](https://forms.documentservices.dla.mil) or [Navy Forms Online](https://www.mynavyhr.navy.mil/References/Forms/).
 
-### Official Form Sources
+For instructions on adding a new form template — flattening XFA, defining box coordinates, generator code patterns — see **[docs/FORM_TEMPLATES.md](docs/FORM_TEMPLATES.md)**.
 
-**All form templates must be obtained from official sources:**
-
-- **DoD Forms Management Program**: https://forms.documentservices.dla.mil
-- **Navy Forms Online**: https://www.mynavyhr.navy.mil/References/Forms/
-
-> ⚠️ **Important**: Do not create new form templates from scratch. Only official, pre-approved forms should be used to ensure compliance with regulations.
-
-### XFA Forms and Flattening
-
-Official military PDF forms are typically encoded using **XFA (XML Forms Architecture)**, an Adobe technology for dynamic forms. XFA forms have special characteristics:
-
-- They contain embedded XML data structures
-- They support dynamic form features (calculations, validations)
-- They are **not compatible** with most PDF libraries (including pdf-lib)
-
-**Before using a form template, it must be "flattened":**
-
-1. **What is flattening?** Converting dynamic XFA form elements into static PDF content (text, lines, rectangles)
-2. **Why flatten?** pdf-lib and most JavaScript PDF libraries cannot read or modify XFA content
-3. **How to flatten?**
-   - Adobe Acrobat Pro: Print to PDF or use "Flatten Form Fields"
-   - Online tools: Various PDF flattening services (ensure no sensitive data)
-   - Command line: `pdftk input.pdf output output.pdf flatten`
-
-### Adding New Form Templates
-
-1. **Obtain the official form** from https://forms.documentservices.dla.mil
-
-2. **Flatten the PDF** to remove XFA encoding:
-   ```bash
-   pdftk official_form.pdf output flattened_form.pdf flatten
-   ```
-
-3. **Extract box boundaries** using the provided script:
-   ```bash
-   pip install pdfplumber
-   python scripts/extract-pdf-boxes.py public/templates/your_form.pdf --save-image
-   ```
-
-4. **Review the annotated image** to verify detected boxes
-
-5. **Create a generator** in `src/services/pdf/` using the smart box positioning system:
-   ```typescript
-   import { calculateTextPosition, type BoxBoundary } from './extractFormFields';
-
-   const BOX_PADDING = { left: 3, top: 3 };
-
-   const PAGE_BOXES: Record<string, BoxBoundary> = {
-     fieldName: { name: 'fieldName', left: 100, top: 500, width: 200, height: 30 },
-     // ... boxes from extract script
-   };
-
-   function getFieldPosition(boxName: keyof typeof PAGE_BOXES) {
-     return calculateTextPosition(PAGE_BOXES[boxName], BOX_PADDING, FONT_SIZE);
-   }
-   ```
-
-### Visual Box Editor (Recommended)
-
-The easiest way to define box coordinates is with the visual editor:
-
-```bash
-# Open in browser
-open tools/box-editor.html
-```
-
-1. Load your PDF template
-2. Click "Draw Mode" and drag to create boxes
-3. Name each box (e.g., `name`, `edipi`, `remarks`)
-4. Copy the TypeScript code or export as JSON
-
-This is a one-time setup per form template.
-
-### Box Detection Script (Alternative)
-
-The `scripts/extract-pdf-boxes.py` script can auto-detect boxes, but works best for forms with clear rectangles:
-
-```bash
-# Basic usage - auto-detect boxes
-python scripts/extract-pdf-boxes.py template.pdf
-
-# Save annotated image showing detected boxes
-python scripts/extract-pdf-boxes.py template.pdf --save-image
-
-# Adjust detection sensitivity
-python scripts/extract-pdf-boxes.py template.pdf --min-size 5 --max-size 300
-
-# Interactive mode for manual box definition
-python scripts/extract-pdf-boxes.py template.pdf --interactive
-
-# Save detected boxes as JSON config for manual editing
-python scripts/extract-pdf-boxes.py template.pdf --save-config
-
-# Load boxes from a JSON config file
-python scripts/extract-pdf-boxes.py --config public/templates/NAVMC118.boxes.json
-```
-
-**Output includes:**
-- Visual ASCII map of detected boxes
-- JSON data with coordinates
-- TypeScript code ready to paste into generators
-
-### JSON Box Configuration
-
-For forms where auto-detection doesn't work well (forms drawn with lines instead of rectangles), use a JSON config file:
-
-```json
-{
-  "template": "NAVMC118_template.pdf",
-  "description": "NAVMC 118(11) Administrative Remarks",
-  "pageSize": { "width": 612, "height": 792 },
-  "boxes": {
-    "name": {
-      "left": 148,
-      "top": 142,
-      "width": 206,
-      "height": 16,
-      "description": "Marine's name (LAST, FIRST MI)"
-    },
-    "edipi": {
-      "left": 465,
-      "top": 142,
-      "width": 106,
-      "height": 16,
-      "description": "DOD ID Number / EDIPI"
-    }
-  }
-}
-```
-
-**Existing configs:**
-- `public/templates/NAVMC118.boxes.json` - NAVMC 118(11) Administrative Remarks
-- `public/templates/NAVMC10274.boxes.json` - NAVMC 10274 Administrative Action
-
-**Workflow for new forms:**
-1. Run auto-detection: `python scripts/extract-pdf-boxes.py template.pdf --save-config`
-2. Edit the generated `template.boxes.json` to fix field names and coordinates
-3. Verify with: `python scripts/extract-pdf-boxes.py --config template.boxes.json`
-4. Copy the TypeScript output into your generator file
-
-### PDF Coordinate System
-
-Understanding PDF coordinates is essential for accurate form filling:
-
-- **Origin**: Bottom-left corner of the page (0, 0)
-- **X-axis**: Increases to the right
-- **Y-axis**: Increases upward
-- **Units**: Points (72 points = 1 inch)
-- **Letter size**: 612 × 792 points
-
-```
-(0, 792) -------- (612, 792)  ← Top of page
-    |                |
-    |                |
-    |                |
-(0, 0) ---------- (612, 0)    ← Bottom of page
-```
+> ⚠️ Only official, pre-approved forms should be used. Don't create form templates from scratch.
 
 ---
 
@@ -574,52 +384,8 @@ npm run build
 ```
 
 ### Project Structure
-```
-dondocs/
-├── tex/                          # LaTeX format templates (advanced)
-│   ├── main.tex                  # Main template
-│   └── templates/                # Document format templates (naval_letter, mfr, etc.)
-├── public/
-│   ├── attachments/              # Seal images
-│   └── lib/
-│       ├── PdfTeXEngine.js       # LaTeX engine
-│       ├── latex-templates.js    # Bundled LaTeX templates for SwiftLaTeX
-│       ├── texlive/              # TeX Live files
-│       └── pandoc/               # Pandoc WASM files for DOCX generation
-│           ├── pandoc.js         # WASM module loader
-│           ├── pandoc.wasm       # Pandoc binary (~58MB, cached by SW)
-│           ├── dondocs.lua       # Four-pass Lua filter for DOCX formatting
-│           └── reference.docx    # DOCX template with base styles
-├── src/
-│   ├── components/
-│   │   ├── editor/               # Form components
-│   │   ├── layout/               # Page layout
-│   │   ├── modals/               # Modal dialogs
-│   │   └── ui/                   # shadcn/ui components
-│   ├── data/
-│   │   ├── templates/            # Content templates (TypeScript) - add new templates here
-│   │   ├── units/                # Unit directory
-│   │   ├── ssic/                 # SSIC codes
-│   │   └── references/           # Reference library
-│   ├── hooks/                    # Custom React hooks
-│   ├── lib/                      # Utility libraries
-│   ├── services/
-│   │   ├── docx/                 # DOCX generation (pandoc WASM pipeline)
-│   │   │   ├── pandoc-converter.ts  # Pandoc WASM conversion + OOXML post-processing
-│   │   │   └── layout-config.ts     # Shared layout proportions (letterhead, columns)
-│   │   ├── latex/                # LaTeX generation
-│   │   │   ├── generator.ts         # PDF LaTeX generator (multi-file, SwiftLaTeX)
-│   │   │   ├── flat-generator.ts    # DOCX flat LaTeX generator (single-file, pandoc)
-│   │   │   └── escaper.ts           # LaTeX character escaping utilities
-│   │   ├── pdf/                  # PDF processing
-│   │   └── pii/                  # PII detection
-│   ├── stores/                   # Zustand stores
-│   └── types/                    # TypeScript types
-├── index.html                    # Entry point
-├── package.json                  # Dependencies
-├── vite.config.ts                # Vite config
-└── Makefile                      # Build commands
-```
+
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md#project-structure) for the full directory layout and key file index.
 
 ### LaTeX Generation Flow
 

--- a/docs/FORM_TEMPLATES.md
+++ b/docs/FORM_TEMPLATES.md
@@ -1,0 +1,177 @@
+# Form Templates
+
+DonDocs supports official military forms (NAVMC 10274, NAVMC 118(11), etc.) by overlaying text onto official PDF templates. This document covers how to add a new form template.
+
+---
+
+## Official Form Sources
+
+**All form templates must be obtained from official sources:**
+
+- **DoD Forms Management Program**: https://forms.documentservices.dla.mil
+- **Navy Forms Online**: https://www.mynavyhr.navy.mil/References/Forms/
+
+> ⚠️ **Important**: Do not create new form templates from scratch. Only official, pre-approved forms should be used to ensure compliance with regulations.
+
+---
+
+## XFA Forms and Flattening
+
+Official military PDF forms are typically encoded using **XFA (XML Forms Architecture)**, an Adobe technology for dynamic forms. XFA forms have special characteristics:
+
+- They contain embedded XML data structures
+- They support dynamic form features (calculations, validations)
+- They are **not compatible** with most PDF libraries (including pdf-lib)
+
+**Before using a form template, it must be "flattened":**
+
+1. **What is flattening?** Converting dynamic XFA form elements into static PDF content (text, lines, rectangles)
+2. **Why flatten?** pdf-lib and most JavaScript PDF libraries cannot read or modify XFA content
+3. **How to flatten?**
+   - Adobe Acrobat Pro: Print to PDF or use "Flatten Form Fields"
+   - Online tools: Various PDF flattening services (ensure no sensitive data)
+   - Command line: `pdftk input.pdf output output.pdf flatten`
+
+---
+
+## Adding New Form Templates
+
+1. **Obtain the official form** from https://forms.documentservices.dla.mil
+
+2. **Flatten the PDF** to remove XFA encoding:
+   ```bash
+   pdftk official_form.pdf output flattened_form.pdf flatten
+   ```
+
+3. **Extract box boundaries** using the provided script:
+   ```bash
+   pip install pdfplumber
+   python scripts/extract-pdf-boxes.py public/templates/your_form.pdf --save-image
+   ```
+
+4. **Review the annotated image** to verify detected boxes
+
+5. **Create a generator** in `src/services/pdf/` using the smart box positioning system:
+   ```typescript
+   import { calculateTextPosition, type BoxBoundary } from './extractFormFields';
+
+   const BOX_PADDING = { left: 3, top: 3 };
+
+   const PAGE_BOXES: Record<string, BoxBoundary> = {
+     fieldName: { name: 'fieldName', left: 100, top: 500, width: 200, height: 30 },
+     // ... boxes from extract script
+   };
+
+   function getFieldPosition(boxName: keyof typeof PAGE_BOXES) {
+     return calculateTextPosition(PAGE_BOXES[boxName], BOX_PADDING, FONT_SIZE);
+   }
+   ```
+
+---
+
+## Visual Box Editor (Recommended)
+
+The easiest way to define box coordinates is with the visual editor:
+
+```bash
+# Open in browser
+open tools/box-editor.html
+```
+
+1. Load your PDF template
+2. Click "Draw Mode" and drag to create boxes
+3. Name each box (e.g., `name`, `edipi`, `remarks`)
+4. Copy the TypeScript code or export as JSON
+
+This is a one-time setup per form template.
+
+---
+
+## Box Detection Script (Alternative)
+
+The `scripts/extract-pdf-boxes.py` script can auto-detect boxes, but works best for forms with clear rectangles:
+
+```bash
+# Basic usage - auto-detect boxes
+python scripts/extract-pdf-boxes.py template.pdf
+
+# Save annotated image showing detected boxes
+python scripts/extract-pdf-boxes.py template.pdf --save-image
+
+# Adjust detection sensitivity
+python scripts/extract-pdf-boxes.py template.pdf --min-size 5 --max-size 300
+
+# Interactive mode for manual box definition
+python scripts/extract-pdf-boxes.py template.pdf --interactive
+
+# Save detected boxes as JSON config for manual editing
+python scripts/extract-pdf-boxes.py template.pdf --save-config
+
+# Load boxes from a JSON config file
+python scripts/extract-pdf-boxes.py --config public/templates/NAVMC118.boxes.json
+```
+
+**Output includes:**
+- Visual ASCII map of detected boxes
+- JSON data with coordinates
+- TypeScript code ready to paste into generators
+
+---
+
+## JSON Box Configuration
+
+For forms where auto-detection doesn't work well (forms drawn with lines instead of rectangles), use a JSON config file:
+
+```json
+{
+  "template": "NAVMC118_template.pdf",
+  "description": "NAVMC 118(11) Administrative Remarks",
+  "pageSize": { "width": 612, "height": 792 },
+  "boxes": {
+    "name": {
+      "left": 148,
+      "top": 142,
+      "width": 206,
+      "height": 16,
+      "description": "Marine's name (LAST, FIRST MI)"
+    },
+    "edipi": {
+      "left": 465,
+      "top": 142,
+      "width": 106,
+      "height": 16,
+      "description": "DOD ID Number / EDIPI"
+    }
+  }
+}
+```
+
+**Existing configs:**
+- `public/templates/NAVMC118.boxes.json` - NAVMC 118(11) Administrative Remarks
+- `public/templates/NAVMC10274.boxes.json` - NAVMC 10274 Administrative Action
+
+**Workflow for new forms:**
+1. Run auto-detection: `python scripts/extract-pdf-boxes.py template.pdf --save-config`
+2. Edit the generated `template.boxes.json` to fix field names and coordinates
+3. Verify with: `python scripts/extract-pdf-boxes.py --config template.boxes.json`
+4. Copy the TypeScript output into your generator file
+
+---
+
+## PDF Coordinate System
+
+Understanding PDF coordinates is essential for accurate form filling:
+
+- **Origin**: Bottom-left corner of the page (0, 0)
+- **X-axis**: Increases to the right
+- **Y-axis**: Increases upward
+- **Units**: Points (72 points = 1 inch)
+- **Letter size**: 612 × 792 points
+
+```
+(0, 792) -------- (612, 792)  ← Top of page
+    |                |
+    |                |
+    |                |
+(0, 0) ---------- (612, 0)    ← Bottom of page
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.12",
+      "version": "1.1.13",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.12",
+  "version": "1.1.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/editor/Form11811Section.tsx
+++ b/src/components/editor/Form11811Section.tsx
@@ -1,6 +1,5 @@
 import { ClipboardList, RotateCcw, ChevronDown, Trash2, FileText } from 'lucide-react';
 import { Label } from '@/components/ui/label';
-import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -16,6 +15,7 @@ import {
 } from '@/components/ui/accordion';
 import { InputWithVariables } from '@/components/ui/variable-autocomplete';
 import { VariableChipEditor } from '@/components/ui/variable-chip-editor';
+import { DatePicker } from '@/components/ui/date-picker';
 import { useFormStore } from '@/stores/formStore';
 import { NAVMC_118_11_PLACEHOLDERS } from '@/lib/constants';
 
@@ -119,11 +119,17 @@ export function Form11811Section() {
               </div>
               <div className="space-y-2">
                 <Label htmlFor="entryDate">Entry Date</Label>
-                <Input
+                {/*
+                  DatePicker (military format "15 Dec 24") instead of a raw
+                  HTML <input type="date"> (which produced ISO 2026-04-25)
+                  per SECNAV M-5216.5 / MCO 1070.12K. The picker accepts
+                  ISO on input, so any existing entryDate values stored in
+                  the old format reformat on first edit. (Issue #15.)
+                */}
+                <DatePicker
                   id="entryDate"
-                  type="date"
                   value={navmc11811.entryDate}
-                  onChange={(e) => setNavmc11811Field('entryDate', e.target.value)}
+                  onChange={(value) => setNavmc11811Field('entryDate', value)}
                 />
               </div>
               <div className="space-y-2">

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/accordion';
 import { InputWithVariables, TextareaWithVariables } from '@/components/ui/variable-autocomplete';
 import { VariableChipEditor } from '@/components/ui/variable-chip-editor';
+import { DatePicker } from '@/components/ui/date-picker';
 import { useFormStore } from '@/stores/formStore';
 import { SSICLookupModal } from '@/components/modals/SSICLookupModal';
 import { UnitLookupModal } from '@/components/modals/UnitLookupModal';
@@ -148,11 +149,17 @@ export function Form6105Section() {
               </div>
               <div className="space-y-2">
                 <Label htmlFor="date">3. Date</Label>
-                <Input
+                {/*
+                  DatePicker (military format "15 Dec 24") instead of a raw
+                  HTML <input type="date"> (which produced ISO 2026-04-25)
+                  per SECNAV M-5216.5 / MCO 1070.12K. The picker accepts
+                  ISO on input, so any existing date values stored in the
+                  old format reformat on first edit. (Issue #15.)
+                */}
+                <DatePicker
                   id="date"
-                  type="date"
                   value={navmc10274.date}
-                  onChange={(e) => setNavmc10274Field('date', e.target.value)}
+                  onChange={(value) => setNavmc10274Field('date', value)}
                 />
               </div>
             </div>


### PR DESCRIPTION
Closes #15. NAVMC 10274 (Page 6/7) and NAVMC 118(11) (Page 11) form date fields used raw HTML `<input type="date">`, which produces ISO format (`2026-04-25`). Per SECNAV M-5216.5 / MCO 1070.12K, naval correspondence dates use abbreviated military format (`15 Dec 24`).

## Why now

The infrastructure already existed — `DatePicker` from `@/components/ui/date-picker` formats to `"d MMM yy"` via date-fns and is **already in use by every other date field** across `MOASection`, `ExecutiveMemoSection`, `JointLetterSection`, `JointMemoSection`, and `AddressingSection`. The two NAVMC form sections were the only holdouts. This PR closes the gap so the app is uniformly on one date primitive.

## Changes

- **`Form6105Section.tsx`** (NAVMC 10274 field 3 "Date"): swap the raw `<Input type="date">` for `<DatePicker>`.
- **`Form11811Section.tsx`** (NAVMC 118(11) "Entry Date"): same swap. Drops the now-unused `Input` import (DatePicker replaced the only usage in this file).

`DatePicker.parseFlexibleDate` accepts ISO (`yyyy-MM-dd`) on input, so any existing date values stored in the old format reformat to military format on first edit. **No data migration needed** — old saved drafts continue to work, just get auto-converted on next edit.

## Sweep

`grep -rnE 'type="date"' src/` returned only these two files before this change. After: zero matches outside of new explanatory comments. NAVMC forms are now using the same date component as the rest of the app.

## Verification

- `tsc --noEmit` clean
- `eslint`: 41 problems (matches main baseline)
- `vite build` succeeds; bundle size unchanged
- Version bumped 1.1.12 → 1.1.13