### PR TITLE
fix(editor): stop underscore runs from being misread as underline (closes #14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.13",
+      "version": "1.1.14",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.13",
+  "version": "1.1.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -458,10 +458,20 @@ function lineToHtml(line: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 
-  // Convert markdown formatting to HTML
+  // Convert markdown formatting to HTML.
+  //
+  // The underline pattern uses `[^_]+?` (not `.+?`) so a run of 3+ raw
+  // underscores doesn't accidentally match as `__<empty>__`-with-tail
+  // and corrupt the user's input. Real fill-in-the-blank lines like
+  // `Signature: __________` show up in the editor as literal text
+  // instead of being silently shortened by the inline `<u>` rewrite.
+  // Side effect: underscored phrases like `__foo_bar__` (an underscore
+  // mid-phrase) won't be detected as underline either — type the
+  // phrase without an internal underscore if you want it underlined.
+  // Issue #14.
   html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
   html = html.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '<em>$1</em>');
-  html = html.replace(/__(.+?)__/g, '<u>$1</u>');
+  html = html.replace(/__([^_]+?)__/g, '<u>$1</u>');
 
   // Also support legacy LaTeX formatting for backward compatibility
   html = html.replace(/\\textbf\{([^{}]*)\}/g, '<strong>$1</strong>');

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -465,10 +465,16 @@ function lineToHtml(line: string): string {
   // and corrupt the user's input. Real fill-in-the-blank lines like
   // `Signature: __________` show up in the editor as literal text
   // instead of being silently shortened by the inline `<u>` rewrite.
-  // Side effect: underscored phrases like `__foo_bar__` (an underscore
-  // mid-phrase) won't be detected as underline either — type the
-  // phrase without an internal underscore if you want it underlined.
-  // Issue #14.
+  //
+  // Round-trip caveat: TipTap's Underline mark imposes no character
+  // restriction, so technically a user could underline text that
+  // contains an underscore — `editorToText` then emits `__foo_bar__`,
+  // and this pattern won't re-detect it. The underline is lost on
+  // save+reload for that one rare case. The fill-in-the-blank case
+  // is far more common in naval correspondence, so we accept the
+  // trade. The matching change is mirrored in
+  // `services/latex/escaper.ts` and `services/latex/flat-generator.ts`
+  // so the PDF and DOCX export paths get the same fix. Issue #14.
   html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
   html = html.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '<em>$1</em>');
   html = html.replace(/__([^_]+?)__/g, '<u>$1</u>');

--- a/src/services/latex/escaper.ts
+++ b/src/services/latex/escaper.ts
@@ -147,7 +147,12 @@ export function convertRichTextToLatex(text: string): string {
   result = result.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '\\textit{$1}');
 
   // Underline: __text__
-  result = result.replace(/__(.+?)__/g, '\\uline{$1}');
+  // The inner group uses [^_]+? (not .+?) so a run of 3+ raw underscores
+  // (fill-in-the-blank lines like `Signature: __________`) doesn't get
+  // partially consumed as `\uline{_}` and produce a corrupted PDF.
+  // See variable-chip-editor.tsx for the matching editor-side fix and
+  // issue #14 for full context.
+  result = result.replace(/__([^_]+?)__/g, '\\uline{$1}');
 
   // Enclosure references: "Enclosure (1)", "enclosure (1)", "Encl (1)", "encl (1)"
   // These get converted to \enclref{1} which creates clickable hyperlinks when enabled

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -79,7 +79,10 @@ function convertRichText(text: string): string {
   let result = text;
   result = result.replace(/\*\*(.+?)\*\*/g, '\\textbf{$1}');
   result = result.replace(/(?<!\*)\*([^*]+)\*(?!\*)/g, '\\textit{$1}');
-  result = result.replace(/__(.+?)__/g, '\\uline{$1}');
+  // [^_]+? (not .+?) — see escaper.ts and variable-chip-editor.tsx for
+  // the matching change. Prevents `__________` fill-in-the-blank runs
+  // from being partially consumed into `\uline{_}` markup. Issue #14.
+  result = result.replace(/__([^_]+?)__/g, '\\uline{$1}');
 
   // Enclosure references: "Enclosure (1)", "enclosure (1)", "Encl (1)" → \enclref{1}
   result = result.replace(/[Ee]nclosure\s*\((\d+)\)/g, '\\enclref{$1}');


### PR DESCRIPTION
Closes #14. The VariableChipEditor's markdown-to-HTML pass uses `__(.+?)__` to convert `__foo__` into a `<u>foo</u>` underline tag. The non-greedy `(.+?)` is permissive enough to match across underscore boundaries — so a row of 3+ underscores like `Signature: __________` (a fill-in-the-blank line) gets partially consumed as `<u></u>` instead of staying as literal text. Users see their underscore lines silently shortened or visually corrupted.

**The same buggy pattern lives in three places that all process the same user input:**

| File | Stage |
|---|---|
| `src/components/ui/variable-chip-editor.tsx` | Editor display |
| `src/services/latex/escaper.ts` | PDF export pipeline |
| `src/services/latex/flat-generator.ts` | DOCX export pipeline |

The original PR draft claimed PDF/DOCX output was unaffected — that was wrong. A user typing fill-in-the-blank underscores into a Remarks field would have the run corrupted in the exported PDF and DOCX too, not just in the editor. (The hardcoded `'\_'.repeat(24)` signature line in `flat-generator.ts:678` IS safe — that's a separate code path with no regex involved.)

This PR fixes all three sites.

## Fix

Tighten the inner group from `(.+?)` to `([^_]+?)`:

```diff
- /__(.+?)__/g
+ /__([^_]+?)__/g
```

Now `__foo__` still matches (no underscore between the markers), but `_____` and similar runs no longer match anything and pass through as literal text.

## Side effect (round-trip caveat)

TipTap's Underline mark imposes no character restriction — a user CAN underline text containing an underscore (e.g. `foo_bar`). Before this PR, `editorToText` would emit `__foo_bar__` and `lineToHtml` would re-detect it as underline on next render. After this PR, the underline mark is **lost on save + reload** for that rare case. The user has to write `foo bar` instead.

The fill-in-the-blank case is far more common in naval correspondence (every 6105 entry, every counseling form has a signature line), so we accept the trade.

## Reproduction

1. NAVMC 118(11) (or any other doc with the rich text editor)
2. Click into Remarks
3. Type `Signature: __________` (10+ underscores)
4. Before fix: row of underscores gets visually corrupted in editor; PDF/DOCX export shows `\uline{_}` markup instead of literal underscores
5. After fix: literal text preserved everywhere

## Verification

- `tsc --noEmit` clean
- `eslint`: 41 problems (matches main baseline)
- `vite build` succeeds; bundle size unchanged
- Independent code review: NEEDS DISCUSSION on first commit (caught the missing PDF/DOCX sites), READY after follow-up commit
- Version bumped 1.1.13 → 1.1.14