### PR TITLE
fix: NAVMC default dates use military format + pocEmail through safeUrl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.16",
+      "version": "1.1.17",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.16",
+  "version": "1.1.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -16,6 +16,36 @@ interface DocumentStore {
 
 // const PARAGRAPH_INDENT_SPACES = 4; // Used in getBodyText for plain text output
 
+/**
+ * Validate a Point-of-Contact email before it gets embedded in the
+ * `\setPOC{}` macro (which the LaTeX template wraps in
+ * `\href{mailto:\POCEmail}{...}`).
+ *
+ * The scheme is forced to `mailto:` by the template so there's no
+ * scheme-injection risk, but a malformed email (no `@`, weird
+ * whitespace, paste with control chars, etc.) still produces a broken
+ * hyperlink in the rendered PDF. Routing through `safeUrl()` reuses
+ * the same chokepoint that validates reference URLs, so any future
+ * tightening of email validation lives in one place.
+ *
+ * Returns the cleaned bare email (no `mailto:` prefix — the template
+ * adds that), or empty string when invalid. Empty string preserves
+ * the prior behavior for unset/missing pocEmail; the LaTeX template
+ * already handles `\setPOC{}` with empty content gracefully.
+ */
+function validatedPocEmail(raw: string | undefined | null): string {
+  if (!raw) return '';
+  // The user might paste `mailto:foo@bar.com` — strip the prefix so
+  // safeUrl validates the bare email path.
+  const stripped = raw.trim().replace(/^mailto:/i, '');
+  if (!stripped) return '';
+  const safe = safeUrl(stripped);
+  if (safe && safe.startsWith('mailto:')) {
+    return safe.slice('mailto:'.length);
+  }
+  return '';
+}
+
 function getParagraphLabel(level: number, count: number): string {
   const patterns = [
     (n: number) => `${n}.`,
@@ -143,7 +173,7 @@ ${data.showSubjectOnContinuation ? `\\setContinuationSubject{${subjectLine}}` : 
 \\setBusinessSalutation{${escapeLatex((data.salutation || 'Dear Sir or Madam:').trim())}}
 \\setBusinessClose{${escapeLatex(data.complimentaryClose || 'Sincerely,')}}
 
-\\setPOC{${escapeLatex(data.pocEmail)}}
+\\setPOC{${escapeLatex(validatedPocEmail(data.pocEmail))}}
 `;
 
   // Memorandum For: addressee is embedded in the title ("MEMORANDUM FOR [addressee]")
@@ -688,7 +718,7 @@ export function generateClassificationTex(store: DocumentStore): string {
 \\setCUICategory{${escapeLatex(data.cuiCategory)}}
 \\setCUIDissemination{${escapeLatex(data.cuiDissemination)}}
 \\setCUIDistStatement{${escapeLatex(data.cuiDistStatement)}}
-\\setPOC{${escapeLatex(data.pocEmail)}}
+\\setPOC{${escapeLatex(validatedPocEmail(data.pocEmail))}}
 `;
   }
 
@@ -719,7 +749,7 @@ export function generateClassificationTex(store: DocumentStore): string {
 \\setDerivedFrom{${escapeLatex(data.derivedFrom)}}
 \\setDeclassifyOn{${escapeLatex(data.declassifyOn)}}
 \\setClassificationReason{${escapeLatex(data.classReason)}}
-\\setPOC{${escapeLatex(data.classifiedPocEmail)}}
+\\setPOC{${escapeLatex(validatedPocEmail(data.classifiedPocEmail))}}
 `;
 }
 

--- a/src/stores/formStore.ts
+++ b/src/stores/formStore.ts
@@ -1,4 +1,16 @@
 import { create } from 'zustand';
+import { format } from 'date-fns';
+
+// SECNAV M-5216.5 / MCO 1070.12K abbreviated military date format.
+// Mirrors `formatMilitaryDate` in documentStore.ts and the DatePicker
+// component default. Used for NAVMC form date defaults below so a fresh
+// form pre-populates with "25 Apr 26" instead of ISO "2026-04-25".
+//
+// Without this, a user who opens a NAVMC form for the first time and
+// downloads without touching the date field gets a non-compliant PDF
+// — DatePicker's `parseFlexibleDate` only re-formats on user blur,
+// which never fires if the user accepts the pre-filled value as-is.
+const formatMilitaryDate = (d: Date): string => format(d, 'd MMM yy');
 
 export interface Navmc11811Data {
   // Marine identification
@@ -95,7 +107,7 @@ const EMPTY_NAVMC_11811: Navmc11811Data = {
 const DEFAULT_NAVMC_10274: NavmcForm10274Data = {
   actionNo: '001-25',
   ssicFileNo: '1610',
-  date: new Date().toISOString().split('T')[0],
+  date: formatMilitaryDate(new Date()),
   from: 'SSgt John A. Smith 1234567890/0311 USMC',
   via: '(1) XO, HQCO (2) CO, HQBN',
   orgStation: 'Alpha Company, 1st Battalion\n1st Marine Regiment\nCamp Pendleton, CA',
@@ -169,7 +181,7 @@ Acknowledged receipt of NAVMC 10274 dtd 15 Jan 25.
 //S//
 J. A. SMITH, SSgt, USMC`,
   remarksTextRight: '',
-  entryDate: new Date().toISOString().split('T')[0],
+  entryDate: formatMilitaryDate(new Date()),
   box11: '01',
 };
 


### PR DESCRIPTION
Two follow-up items from earlier PR audits, both small and contained.

## A. NAVMC default dates use military format

Issue #15 (closed by PR #45) swapped the date INPUTS in the two
NAVMC form sections from raw HTML `<input type="date">` to the
existing `DatePicker` component, so user-entered dates render as
"25 Apr 26" per SECNAV M-5216.5 / MCO 1070.12K.

But `formStore.ts:98, 172` still initialized the NAVMC default dates
with ISO format:

  date: new Date().toISOString().split('T')[0],         // "2026-04-25"
  entryDate: new Date().toISOString().split('T')[0],    // "2026-04-25"

A user opening a NAVMC form for the first time would see the date
pre-populated correctly-looking, never edit it, hit Download, and
get a non-compliant PDF with the ISO date.

DatePicker's `parseFlexibleDate` only re-formats on user blur of
the input -- accepting the pre-fill as-is doesn't trigger reformat.

Fix: import `format` from date-fns (already a dep), define a small
`formatMilitaryDate(d)` helper mirroring the one in documentStore.ts,
and use it for both defaults. Result: fresh form pre-populates with
"25 Apr 26".

## B. pocEmail validation through safeUrl

PR #47 (closed #17) added the `safeUrl()` chokepoint that validates
URL schemes before embedding them in PDF/DOCX hyperlinks. Wired
into `mergeEnclosures.ts` (PDF /URI annotations) and
`generator.ts:498` (LaTeX `\setRefURL{}`).

POC emails flow through a separate path: three `\setPOC{}` sites
in `generator.ts` (default config block, CUI block, classified
block), each consumed by the LaTeX template at
`latex-templates.js:1511` which wraps them in
`\href{mailto:\POCEmail}{...}`. The `mailto:` prefix is hardcoded
by the template, so there's no scheme-injection risk -- but the
field can still produce a broken hyperlink if the email is
malformed (no `@`, weird whitespace, control chars from a
malicious imported session).

Fix: new `validatedPocEmail()` helper at the top of generator.ts.
Strips a leading `mailto:` if the user pasted one, runs through
`safeUrl()` (which validates email shape and returns
`mailto:<bare>` or null), strips the prefix back. Returns the
cleaned bare email or empty string.

Wired into all three `\setPOC{}` sites:
  - default config (`pocEmail`)
  - CUI block (`pocEmail`)
  - classified block (`classifiedPocEmail`)

Empty input still produces `\setPOC{}` (preserves prior behavior
for unset pocEmail). Malformed input now produces `\setPOC{}`
instead of a broken clickable hyperlink.

DOCX path (`flat-generator.ts:800, 813`) renders both `pocEmail`
and `classifiedPocEmail` as plain text with no `\href{}` wrapper,
so no injection surface there. Left unchanged.

## Verification

- tsc clean
- eslint 41 problems (matches main baseline)
- vite build succeeds; main bundle 2,172 KB raw / 699 KB gz
  (inherits PR #48's lazy-load reduction now that this branch is
  rebased onto current main)
- Version bumped 1.1.16 -> 1.1.17 (1.1.16 was taken by PR #48)