### PR TITLE
chore(lint): clear 16 trivial ESLint findings (41 -> 25)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,5 +19,19 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      // Standard convention: an underscore prefix on a destructured key,
+      // catch binding, or function arg signals "I know this is unused on
+      // purpose" (e.g. omitting a key with `const { [k]: _omit, ...rest } = obj`).
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          varsIgnorePattern: '^_',
+          argsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
+    },
   },
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.17",
+      "version": "1.1.18",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.17",
+  "version": "1.1.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/editor/ClassificationSection.tsx
+++ b/src/components/editor/ClassificationSection.tsx
@@ -24,7 +24,8 @@ import {
 import {
   getDomainClassificationRestriction,
   getDomainRestrictionMessage,
-  type ClassificationLevel
+  type ClassificationLevel,
+  type ClassificationRestriction,
 } from '@/lib/domainClassification';
 import { useEffect, useState } from 'react';
 import { getClassificationConfig } from '@/config/classification';
@@ -63,7 +64,7 @@ const DISTRIBUTION_STATEMENTS = [
 export function ClassificationSection() {
   const { formData, setField } = useDocumentStore();
   const classLevel = formData.classLevel || 'unclassified';
-  const [configOverride, setConfigOverride] = useState<{ restriction?: any; message?: string } | null>(null);
+  const [configOverride, setConfigOverride] = useState<{ restriction?: ClassificationRestriction; message?: string } | null>(null);
   const [configLoaded, setConfigLoaded] = useState(false);
 
   // Load config file override if available (async)

--- a/src/components/modals/LogViewerModal.tsx
+++ b/src/components/modals/LogViewerModal.tsx
@@ -46,7 +46,7 @@ export function LogViewerModal() {
       await navigator.clipboard.writeText(text);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
+    } catch {
       // Fallback for browsers without clipboard API or in non-secure contexts
       const textArea = document.createElement('textarea');
       textArea.value = text;

--- a/src/components/ui/variable-autocomplete.tsx
+++ b/src/components/ui/variable-autocomplete.tsx
@@ -135,7 +135,7 @@ export function useVariableAutocomplete({
 
     // Find the last @ that starts a variable mention
     // @ must be at start of input OR preceded by whitespace/punctuation
-    const atMatches = [...textBeforeCursor.matchAll(/(^|[\s\n([\-])@([A-Za-z0-9_]*)$/g)];
+    const atMatches = [...textBeforeCursor.matchAll(/(^|[\s\n([-])@([A-Za-z0-9_]*)$/g)];
 
     if (atMatches.length > 0) {
       const match = atMatches[atMatches.length - 1];

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -139,7 +139,7 @@ function capitalizeWord(word: string | undefined): string {
 /** Strip punctuation from paragraph headers per SECNAV formatting rules.
  * Dashes (-, –, —) are preserved; all other punctuation is removed. */
 function stripHeaderPunctuation(text: string): string {
-  return text.replace(/[(),.;:!?'"\/\\]/g, '').replace(/\s+/g, ' ').trim();
+  return text.replace(/[(),.;:!?'"/\\]/g, '').replace(/\s+/g, ' ').trim();
 }
 
 /** Underline entire header text using ulem's \uline for proper positioning. */
@@ -632,7 +632,7 @@ function buildBusinessSignature(data: Partial<DocumentData>): string {
   }
 
   // Use tabularX{XcX} for centering (pandoc ignores \begin{center})
-  let sig = `\\vspace{24pt}
+  const sig = `\\vspace{24pt}
 \\noindent
 \\begin{tabularx}{\\textwidth}{@{}XcX@{}}
  & ${close} & \\\\

--- a/src/services/pdf/addSignatureField.ts
+++ b/src/services/pdf/addSignatureField.ts
@@ -107,7 +107,7 @@ function extractTextFromPage(
 
     // Find all TJ arrays and their positions
     // Format: "[(text)(text)...]TJ"
-    const tjRegex = /\[((?:[^\[\]]*|\([^)]*\))*)\]TJ/g;
+    const tjRegex = /\[((?:[^[\]]*|\([^)]*\))*)\]TJ/g;
 
     // Build ordered list of operations
     interface Operation {

--- a/src/services/pdf/mergeEnclosures.ts
+++ b/src/services/pdf/mergeEnclosures.ts
@@ -1023,7 +1023,7 @@ function createUriLinkAnnotations(pdfDoc: PDFDocument, positions: ReferencePosit
 
     // Add to page's Annots array
     const linkRef = pdfDoc.context.register(linkAnnotation);
-    let annots = page.node.lookup(PDFName.of('Annots'));
+    const annots = page.node.lookup(PDFName.of('Annots'));
 
     if (annots instanceof PDFArray) {
       annots.push(linkRef);

--- a/src/services/pii/detector.ts
+++ b/src/services/pii/detector.ts
@@ -36,9 +36,9 @@ const EDIPI_PATTERN = /\b\d{10}\b/g;
 
 // DOB patterns: Various date formats
 const DOB_PATTERNS = [
-  /\b(0[1-9]|1[0-2])[/\-](0[1-9]|[12]\d|3[01])[/\-](19|20)\d{2}\b/g, // MM/DD/YYYY or MM-DD-YYYY
-  /\b(0[1-9]|[12]\d|3[01])[/\-](0[1-9]|1[0-2])[/\-](19|20)\d{2}\b/g, // DD/MM/YYYY or DD-MM-YYYY
-  /\b(19|20)\d{2}[/\-](0[1-9]|1[0-2])[/\-](0[1-9]|[12]\d|3[01])\b/g, // YYYY-MM-DD
+  /\b(0[1-9]|1[0-2])[/-](0[1-9]|[12]\d|3[01])[/-](19|20)\d{2}\b/g, // MM/DD/YYYY or MM-DD-YYYY
+  /\b(0[1-9]|[12]\d|3[01])[/-](0[1-9]|1[0-2])[/-](19|20)\d{2}\b/g, // DD/MM/YYYY or DD-MM-YYYY
+  /\b(19|20)\d{2}[/-](0[1-9]|1[0-2])[/-](0[1-9]|[12]\d|3[01])\b/g, // YYYY-MM-DD
 ];
 
 // Phone patterns: Various US phone formats


### PR DESCRIPTION
Pre-existing hygiene findings on main, none introduced by recent PRs.
This PR clears the safe/mechanical subset; the remaining 25 (HMR-only
react-refresh, perf-hint set-state-in-effect, and 4 bug-risk hooks
issues) need per-site judgment and are left for follow-up.

## What's fixed (16 problems)

### no-useless-escape (9)
Backslash escapes inside `[...]` regex character classes that don't
need escaping. The character is already literal inside a class.

  - `src/services/pii/detector.ts` (6) -- `[/\-]` -> `[/-]` in three
    DOB date regexes (MM/DD/YYYY, DD/MM/YYYY, YYYY-MM-DD).
  - `src/components/ui/variable-autocomplete.tsx` (1) -- `[\s\n([\-]`
    -> `[\s\n([-]` in the @-mention trigger regex.
  - `src/services/latex/flat-generator.ts` (1) -- `[(),.;:!?'"\/\\]`
    -> `[(),.;:!?'"/\\]` in the SECNAV header punctuation stripper.
  - `src/services/pdf/addSignatureField.ts` (1) -- `[^\[\]]` ->
    `[^[\]]` in the PDF TJ-operator regex (the `[` doesn't need
    escaping inside a class; the `]` still does).

All regex behavior is identical -- character classes match the same
set with or without the backslashes.

### prefer-const (2)
Variables declared `let` but never reassigned.

  - `src/services/latex/flat-generator.ts:635` -- `sig` template
    literal builder.
  - `src/services/pdf/mergeEnclosures.ts:1026` -- `annots` PDF
    annotation lookup result.

### no-unused-vars (4)
The four destructured / catch-bound vars that are intentionally
unused (omitting a key from a destructure, ignoring a catch error
on a fallback path).

  - `eslint.config.js` -- adds `varsIgnorePattern: '^_'` and friends
    to `@typescript-eslint/no-unused-vars`. Standard JS/TS
    convention: `_prefix` signals "I know this is unused on
    purpose." Picks up:
      * `src/components/modals/BatchModal.tsx:244` (`_templatesLoading`
        -- only the setter is used)
      * `src/stores/profileStore.ts:66` (`_deleted`) and `:77`
        (`_removed`) -- both are the canonical
        `const { [k]: _omit, ...rest } = obj` destructure-omit
        idiom.
  - `src/components/modals/LogViewerModal.tsx:49` -- `} catch (err) {`
    -> `} catch {` (modern TS optional-binding syntax). The catch
    body is a fallback that doesn't need the error object.

### no-explicit-any (1)
`src/components/editor/ClassificationSection.tsx:66` -- the
`configOverride.restriction` field was typed `any`. The shape is
already exported from `domainClassification.ts` as
`ClassificationRestriction` (`{ maxLevel, allowedLevels }`).
Switched to that type; the `setConfigOverride(...)` call site
already produces a matching shape.

## Out of scope (deferred)

  - 10 `react-refresh/only-export-components` -- shadcn pattern
    (`buttonVariants` co-exported with `Button`). Fixing means
    restructuring shadcn imports site-wide. Won't fix without a
    deliberate design decision.
  - 8 `react-hooks/set-state-in-effect` -- mostly intentional init
    patterns (`useEffect(() => setX(...), [])` for one-time
    hydration from localStorage / async config). Each needs a
    per-site check before changing.
  - 3 `react-hooks/preserve-manual-memoization` -- React Compiler
    perf hints, need judgment.
  - 3 `react-hooks/exhaustive-deps` + 1 `react-hooks/refs` -- the four
    actual bug-risk findings. Naively adding deps can cause
    infinite render loops; the ref-during-render in
    `useServiceWorker.ts:63` needs a real refactor into an effect.
    These get a separate focused issue/PR for proper investigation.

## Verification

  - `tsc --noEmit` clean
  - `eslint`: 25 problems remaining (down from 41), all in the
    deferred categories above
  - `vite build` succeeds; no bundle-size or runtime change
  - no behavior change -- all edits are mechanical (regex
    cleanup, literal-character match preserved, type-only fix,
    `let`->`const`, eslint config tweak)
  - Version bumped 1.1.17 -> 1.1.18