### PR TITLE
security: harden pdf.js viewers against CVE-2024-4367

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.19",
+      "version": "1.1.20",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.19",
+  "version": "1.1.20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/modals/MobilePreviewModal.tsx
+++ b/src/components/modals/MobilePreviewModal.tsx
@@ -127,6 +127,36 @@ pdfjs.GlobalWorkerOptions.workerSrc = `${import.meta.env.BASE_URL}lib/pdf.worker
 // Worker URL for react-pdf-viewer (iOS)
 const PDFJS_WORKER_URL = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js`;
 
+/**
+ * Hardened pdf.js options. Both viewers below preview user-supplied PDFs
+ * (compiled main + uploaded enclosures), so we force the safer code path.
+ *
+ * `isEvalSupported: false` mitigates CVE-2024-4367: PDF.js's eval-based
+ * font glyph renderer can be coerced into executing arbitrary JavaScript
+ * by a maliciously crafted PDF. Disabling it routes glyph rendering
+ * through the slower-but-safe non-eval path. The desktop preview uses an
+ * `<iframe>` and the browser's native PDF viewer, so it isn't affected;
+ * this hardening is specifically for the mobile path which renders
+ * pdf.js in our origin.
+ *
+ * `@react-pdf-viewer/core@3.12.0` pulls in the vulnerable
+ * `pdfjs-dist@3.11.174` transitively (`react-pdf@10` is fine on 5.x);
+ * upstream is dormant so a version bump isn't currently available. Until
+ * we migrate `MobilePreviewModal` off `@react-pdf-viewer`, this option
+ * closes the active exploit path.
+ *
+ * Note: defined at module scope so that `<Document options={...}>` gets
+ * a referentially stable object — react-pdf reprocesses the document
+ * when `options` changes by identity.
+ */
+const HARDENED_PDF_OPTIONS = { isEvalSupported: false } as const;
+const transformPdfParamsHardened = (
+  options: Record<string, unknown>,
+): Record<string, unknown> => ({
+  ...options,
+  isEvalSupported: false,
+});
+
 interface MobilePreviewModalProps {
   pdfUrl: string | null;
   isCompiling: boolean;
@@ -248,6 +278,7 @@ function IOSPdfViewer({ pdfUrl, onClose, onDownload, isPhone }: {
               fileUrl={pdfUrl}
               plugins={[defaultLayoutPluginInstance]}
               defaultScale={isPhone ? 0.5 : 1}
+              transformGetDocumentParams={transformPdfParamsHardened}
             />
           </div>
         </Worker>
@@ -455,6 +486,7 @@ export function MobilePreviewModal({ pdfUrl, isCompiling, error }: MobilePreview
           >
             <Document
               file={pdfUrl}
+              options={HARDENED_PDF_OPTIONS}
               onLoadSuccess={onDocumentLoadSuccess}
               onLoadError={onDocumentLoadError}
               loading={


### PR DESCRIPTION
Closes the open Dependabot HIGH alert: arbitrary JavaScript execution
in PDF.js when rendering a malicious PDF. The CVE is exploitable via
PDF.js's eval-based font glyph renderer; setting
`isEvalSupported: false` on `getDocument()` routes glyph rendering
through the safe non-eval path and closes the exploit.

## Why this needs hardening (not just a version bump)

`@react-pdf-viewer/core@3.12.0` pulls in `pdfjs-dist@3.11.174`
transitively. The CVE affects `pdfjs-dist <= 4.1.392`, fixed in
4.2.67. `npm audit` says "no fix available" -- `@react-pdf-viewer`
is unmaintained upstream, with peer-dep range `^2.16.105 || ^3.0.279`
that won't formally accept 4.x or 5.x. A migration off
`@react-pdf-viewer` is queued for a follow-up PR but takes a real UI
rewrite to land.

`react-pdf@10.3.0` is on `pdfjs-dist@5.4.296` (already patched), but
sets the same `isEvalSupported: false` defensively so the mitigation
is consistent across both code paths.

The desktop preview uses `<iframe>` + the browser's native PDF
viewer, which has its own sandboxing -- no change needed there.

## Threat model

`MobilePreviewModal` renders two classes of PDFs in pdf.js:

  1. The compiled main document (produced by SwiftLaTeX in our own
     origin) -- low risk, but defense-in-depth applies
  2. Uploaded enclosure PDFs that get merged into the final preview
     via `mergeEnclosures.ts` -- HIGH risk, this is the actual
     exploit path. A user opens a malicious enclosure (received
     from anyone -- email attachment, file share, download), drops
     it in as an enclosure, and on preview the embedded JS executes
     in our origin with full access to localStorage (profiles,
     session, etc.)

## Implementation

Single file changed: `src/components/modals/MobilePreviewModal.tsx`.

Added two module-scope constants:

  - `HARDENED_PDF_OPTIONS = { isEvalSupported: false }` -- passed to
    react-pdf's `<Document options={...}>`. Module-scope is required;
    react-pdf compares `options` by reference and reprocesses the
    document on identity change, so an inline object literal would
    cause a reload on every render.
  - `transformPdfParamsHardened` -- merges `isEvalSupported: false`
    into the params @react-pdf-viewer passes to `pdfjs.getDocument`.
    Wired via `<Viewer transformGetDocumentParams={...}>`.

Both viewer call sites updated. No other pdfjs entry points exist in
the codebase (verified via grep for `from 'pdfjs-dist'`,
`from 'react-pdf'`, `from '@react-pdf-viewer'` -- all live in this
single file).

## Source-level proof the CVE path is dead

Traced the option through the actual installed vulnerable
`pdfjs-dist@3.11.174` to confirm it isn't silently dropped:

```
node_modules/pdfjs-dist/build/pdf.js
14066:  const isEvalSupported = src.isEvalSupported !== false;
        // ... flows through transportParams to FontFaceObject ...
6197:    if (this.isEvalSupported && _util.FeatureTest.isEvalSupported) {
6203:      return this.compiledGlyphs[character] = new Function(...);
                                                   ^^^^^^^^^^^^
                                                   the exact CVE exploit path
```

With `isEvalSupported: false`, line 6197's guard fails and line 6203's
`new Function()` is never reached. The same gating exists in patched
`pdfjs-dist@5.4.296` (line 14066), so the defensive setting is
consistent across both viewers.

## Verification

  - tsc clean -- TypeScript accepts both signatures
  - eslint: 25 problems remaining (identical to main baseline, no new
    findings introduced)
  - vite build succeeds; bundle size unchanged
  - `isEvalSupported` appears 5 times in the built
    `MobilePreviewModal-*.js` chunk -- shipping, not tree-shaken
  - All 4 GitHub CI checks pass: CodeQL javascript-typescript, CodeQL
    python, Cloudflare Pages, Workers Builds
  - Threat surface confirmed contained: only `MobilePreviewModal`
    instantiates pdf.js viewers; `mergeEnclosures.ts` and the SwiftLaTeX
    pipeline use `pdf-lib` and the WASM compiler respectively, neither
    of which touches pdf.js's font renderer
  - Version bumped 1.1.19 -> 1.1.20

## What this PR does NOT do

This is a mitigation, not a version bump. The vulnerable
`pdfjs-dist@3.11.174` still ships in `@react-pdf-viewer/core`; the
exploit path is just gated. The Dependabot alert may stay open until
`@react-pdf-viewer` can be dropped entirely, which is a separate PR
involving a real UI rewrite of `MobilePreviewModal` onto `react-pdf`
alone. A follow-up issue tracking that migration would be appropriate.