### PR TITLE
fix(ui): resolve hover/static color conflicts in header + dropdowns + selects (closes #29)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.22",
+      "version": "1.1.23",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.22",
+  "version": "1.1.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/editor/DocumentTypeSelector.tsx
+++ b/src/components/editor/DocumentTypeSelector.tsx
@@ -137,7 +137,13 @@ export function DocumentTypeSelector() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-6 px-2 bg-primary/10 border border-primary/30 text-primary hover:text-primary/80 hover:bg-primary/20"
+                      // Tinting the bg with --primary (USMC red at 10% opacity)
+                      // produced a peach/mustard look against the form panel
+                      // and clashed with the red text. Keep the brand-tinted
+                      // border for a subtle accent, but use neutral readable
+                      // foreground/muted bg so the button reads cleanly against
+                      // any panel background -- closes #29.
+                      className="h-6 px-2 border border-primary/30 text-foreground hover:bg-accent hover:text-accent-foreground"
                       onClick={() => setTemplateLoaderOpen(true)}
                     >
                       <FolderOpen className="h-3.5 w-3.5 mr-1" />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -651,7 +651,7 @@ export function Header({
                 <Eraser className="h-4 w-4 mr-2" />
                 Clear Fields (Keep Letterhead)
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setShowResetDialog(true)} className="text-destructive">
+              <DropdownMenuItem onClick={() => setShowResetDialog(true)} variant="destructive">
                 <RotateCcw className="h-4 w-4 mr-2" />
                 Reset All Fields
               </DropdownMenuItem>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,7 +13,12 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 hover:scale-[1.02] focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-sm hover:bg-accent hover:text-accent-foreground hover:scale-[1.02] hover:shadow-md active:shadow-none dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          // In dark mode, --accent is only marginally lighter than --background
+          // (HSL 220 10% 16% vs 220 14% 10%), so hover-bg defaults are nearly
+          // invisible. Use a translucent foreground overlay for a clearly-visible
+          // hover state that doesn't depend on the accent token's contrast --
+          // closes #29 ("top-level buttons hover dark on dark").
+          "border bg-background shadow-sm hover:bg-accent hover:text-accent-foreground hover:scale-[1.02] hover:shadow-md active:shadow-none dark:bg-input/30 dark:border-input dark:hover:bg-foreground/10 dark:hover:text-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:scale-[1.02]",
         ghost:

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -72,7 +72,11 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        // Icons without an explicit text-* class default to muted-foreground, but
+        // on focus/hover they should follow the parent's text color so they stay
+        // legible against the accent background (otherwise muted-gray icons can
+        // visually disappear into a light hover state -- closes #29).
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground focus:[&_svg:not([class*='text-'])]:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -209,7 +213,11 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        // Same icon-color-on-focus fix as DropdownMenuItem above. SubTrigger
+        // has both `focus` (hovered/keyboard-focused) and `data-state=open`
+        // (the sub-menu is currently expanded) accent states; icons should
+        // follow the parent text color in either case.
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus:[&_svg:not([class*='text-'])]:text-accent-foreground data-[state=open]:[&_svg:not([class*='text-'])]:text-accent-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -35,7 +35,11 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        // Same dark-hover contrast issue as the outline button variant: the
+        // default `dark:hover:bg-input/50` only differs from the static
+        // `dark:bg-input/30` by opacity, so hover is barely perceptible. Use
+        // a translucent foreground overlay for a clearly-visible hover state.
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-foreground/10 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -107,7 +111,12 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        // Same icon-color-on-focus issue as DropdownMenuItem: icons without an
+        // explicit text-* class default to muted-foreground, but on focus they
+        // need to follow the parent text color so they stay legible against
+        // the accent background. Without this, muted-gray icons can wash out
+        // on a light hover bg in either theme. Mirror the DropdownMenuItem fix.
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus:[&_svg:not([class*='text-'])]:text-accent-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className
       )}
       {...props}


### PR DESCRIPTION
Fixes #29 — three UI color/contrast bugs the user reported, plus
the same bugs everywhere else they existed.

## What's fixed

1. **Header Preview / Save / Download buttons** — dark-mode hover
   was barely visible (only opacity differed from static state).
   Now uses a translucent foreground overlay for a clear hover.
2. **Templates button** (next to doc-type label) — red text on a
   10%-opacity red background read as muddy peach/mustard. Now
   uses neutral text + brand-tinted border.
3. **Help dropdown row icons** — stayed muted-gray when the row
   was hovered, even as the text changed color. Icons now follow
   the text color on hover.
4. **Reset All Fields** menu item — switched from
   `className="text-destructive"` to `variant="destructive"` so
   the full destructive hover treatment (red bg + red icon)
   works.

## Same bugs found and fixed across the rest of the UI

The two underlying CSS patterns existed in more places than the
user reported. One fix per pattern, applied at the shadcn
component level, covers everything:

  - **Better dark-mode hover** -- 61 `<Button variant="outline">`
    + 22 `<SelectTrigger>` call sites
  - **Icons follow focus color** -- 41 `<DropdownMenuItem>` + 57
    `<SelectItem>` + future `<DropdownMenuSubTrigger>` usage

= 181+ UI surfaces fixed by ~30 lines of CSS in three shadcn
components.

## Files

  - `src/components/ui/button.tsx`
  - `src/components/ui/dropdown-menu.tsx`
  - `src/components/ui/select.tsx`
  - `src/components/editor/DocumentTypeSelector.tsx`
  - `src/components/layout/Header.tsx`
  - `package.json` / `package-lock.json` (1.1.22 -> 1.1.23)

## Verification

  - tsc clean, eslint 25 (= main baseline, no new findings)
  - vite build succeeds, PWA precache identical to main
  - All 4 GitHub CI checks pass
  - Final pattern sweep: zero remaining unfixed instances of
    either bug across `src/components/ui/`
  - All edits use semantic theme tokens, so custom color schemes
    set via uiStore continue to work

## Out of scope (flagged for later)

  - "Clear" button next to Templates uses the same tinted-on-tinted
    pattern but with orange (more readable); user didn't report
  - "Compiling..." pill in PreviewPanel has the same pattern; tiny
    status indicator, not a primary action