### PR TITLE
fix(hooks): close 4 React-hooks bug-risk lint findings (PR #51 followup)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.23",
+      "version": "1.1.24",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.23",
+  "version": "1.1.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -475,6 +475,7 @@ function App() {
     // `compilePdf` is intentionally NOT a dep — it captures documentStore via
     // getState(), and we don't want a new compilePdf identity (e.g. from pdfUrl
     // changing) to kick off an unrelated debounce cycle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isReady,
     docType,

--- a/src/components/modals/FindReplaceModal.tsx
+++ b/src/components/modals/FindReplaceModal.tsx
@@ -110,7 +110,11 @@ export function FindReplaceModal() {
         matchCount++;
       }
     }
-  }, [matches, currentMatchIndex, findText, replaceText, paragraphs, formData, updateParagraph, setField]);
+    // `totalMatches` is derived from `matches` via useMemo so it's
+    // already covered by the `matches` dep, but exhaustive-deps wants
+    // it spelled out explicitly. It's a memoized number — re-listing
+    // it adds no extra invalidations.
+  }, [matches, totalMatches, currentMatchIndex, findText, replaceText, paragraphs, formData, updateParagraph, setField]);
 
   const handleReplaceAll = useCallback(() => {
     if (totalMatches === 0 || !findText.trim()) return;
@@ -148,7 +152,11 @@ export function FindReplaceModal() {
         }
       }
     });
-  }, [findText, replaceText, caseSensitive, paragraphs, formData, updateParagraph, setField]);
+    // Same as handleReplace above: `totalMatches` is derived from
+    // `matches` (via useMemo) so re-listing it is redundant but
+    // satisfies exhaustive-deps without changing invalidation
+    // behavior.
+  }, [totalMatches, findText, replaceText, caseSensitive, paragraphs, formData, updateParagraph, setField]);
 
   // Keyboard shortcuts
   useEffect(() => {

--- a/src/hooks/useServiceWorker.ts
+++ b/src/hooks/useServiceWorker.ts
@@ -59,8 +59,23 @@ export function useServiceWorker() {
     };
   }, []);
 
-  // Store updateServiceWorker in ref for use in effects
-  updateServiceWorkerRef.current = updateServiceWorker;
+  // Sync the latest updateServiceWorker callback into a ref so the
+  // needRefresh effect below can call it without listing it as a dep.
+  // (Adding the callback to that effect's deps would cause spurious
+  // re-runs on every render where useRegisterSW returns a new closure
+  // identity, which can flip needRefresh handling mid-cycle.)
+  //
+  // Setting `ref.current` in render directly works in practice but
+  // violates the React rule against side-effects during render and
+  // is brittle under concurrent rendering -- React may discard a
+  // render and re-run it, leaving the ref pointing at a stale closure
+  // from the discarded attempt. Move the assignment into useEffect so
+  // it runs after the render commits. The ref consumer below is also
+  // a useEffect and is declared after this one, so React runs them in
+  // order and the ref is always populated before the consumer reads it.
+  useEffect(() => {
+    updateServiceWorkerRef.current = updateServiceWorker;
+  }, [updateServiceWorker]);
 
   // Mark session as active after 5 seconds of being on the page
   // This means: fresh visit = auto-update, active session = prompt
@@ -72,12 +87,24 @@ export function useServiceWorker() {
     return () => clearTimeout(timer);
   }, []);
 
-  // When needRefresh is true, either auto-update or show prompt
+  // When needRefresh is true, either auto-update or show prompt.
+  //
+  // Legitimate "synchronize React state with an external system" pattern:
+  // useRegisterSW exposes `needRefresh` as a derived value (not a stream
+  // or listener callback), so our effect mirrors it into local UI state
+  // when it flips true. The react-hooks/set-state-in-effect rule docs
+  // explicitly call out "subscribe for updates from some external system,
+  // calling setState when external state changes" as legitimate -- this
+  // is the same shape, just expressed via a value-prop API rather than
+  // a callback-listener API. The rule is conservative about flagging
+  // synchronous setState in the effect body, so the disable is at the
+  // setShowUpdatePrompt call.
   useEffect(() => {
     if (needRefresh) {
       if (isActiveSession) {
         // User is actively working - show prompt
         console.log('[SW] Update available, prompting user (active session)');
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setShowUpdatePrompt(true);
       } else {
         // Fresh visit - auto-update silently


### PR DESCRIPTION
Closes 4 React-hooks lint findings deferred from PR #51 because
each needed per-site reasoning. Lint count drops 25 -> 19.

## Fixes

1. **`useServiceWorker.ts:63`** — ref mutation during render
   moved into `useEffect`. Surfaced a pre-existing
   `set-state-in-effect` for `setShowUpdatePrompt` (legitimate
   "sync React state with external system" pattern); suppressed
   with rationale.

2. **`App.tsx:478`** — `compilePdf` is intentionally omitted
   from the compile-trigger effect's deps (existing comment
   explains why). Added `eslint-disable-next-line` to respect
   the deliberate choice.

3+4. **`FindReplaceModal.tsx:113, 151`** — added `totalMatches`
   to deps in `handleReplace` and `handleReplaceAll`. Redundant
   relative to `matches` (already in deps), but lint-clean. Zero
   behavior change.

## What about Option D (TOCTOU race fix)?

Already implemented. `useLatexEngine.ts:79, 442-444` has a
promise-queue around `engine.compileLaTeX()`, with a comment
explicitly naming it as the audit's TOCTOU fix. PR scope was
just C.

## Verification

  - tsc clean, eslint 19 (was 25; closed 4 target + 2 bonus
    `preserve-manual-memoization`); zero new findings
  - vite build succeeds, PWA precache identical to main
  - All 4 GitHub CI checks pass
  - Behavior preserved at all 4 sites (verified ordering for the
    ref-mutation move, including first-render and StrictMode
    double-mount)
  - Version bumped 1.1.23 -> 1.1.24

## Out of scope

The 19 remaining findings are all in deferred categories:

  - 10 `react-refresh/only-export-components` (shadcn co-export
    pattern, design decision)
  -  9 `react-hooks/set-state-in-effect` (mostly intentional
    init patterns; each needs per-site review)

Tracked in PR #51's deferred list.