### PR TITLE
fix(ui): finish color-readability sweep — Clear button + Compiling pill + NIST badge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.25",
+      "version": "1.1.26",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.25",
+  "version": "1.1.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/editor/DocumentTypeSelector.tsx
+++ b/src/components/editor/DocumentTypeSelector.tsx
@@ -161,7 +161,14 @@ export function DocumentTypeSelector() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-6 px-2 bg-orange-500/10 border border-orange-500/30 text-orange-600 hover:text-orange-700 hover:bg-orange-500/20 dark:text-orange-400 dark:hover:text-orange-300 dark:hover:bg-orange-500/20"
+                      // Same readability fix as the Templates button next to
+                      // this one (PR #57): drop the tinted bg (orange-500/10
+                      // tint over the form-panel bg can read as muddy and
+                      // washes out the orange text) and keep just the orange
+                      // border + orange text. Hover gets a faint orange bg
+                      // to signal interactivity. Preserves the warning
+                      // aesthetic for the destructive action.
+                      className="h-6 px-2 border border-orange-500/30 text-orange-600 hover:bg-orange-500/10 dark:text-orange-400 dark:hover:bg-orange-500/15"
                       onClick={() => setShowClearDialog(true)}
                     >
                       <Eraser className="h-3.5 w-3.5 mr-1" />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -536,7 +536,13 @@ export function Header({
           {/* NIST 800-171 Compliance Badge - icon only below lg, full badge on lg+ */}
           <button
             onClick={() => setNistModalOpen(true)}
-            className="flex items-center justify-center gap-1.5 rounded-md bg-green-500/10 border border-green-500/30 text-green-600 dark:text-green-400 text-xs cursor-pointer hover:bg-green-500/20 transition-colors p-1.5 lg:px-2 lg:py-1 shrink-0"
+            // Same readability fix as the Clear button + Compiling pill in
+            // this PR (and the Templates button in PR #57): drop the
+            // tinted bg (green-500/10 over the header card-bg muddied the
+            // green text). Keep the green border + green text for the
+            // "compliant/safe" status identity, hover gets the faint green
+            // bg as the interactivity signal.
+            className="flex items-center justify-center gap-1.5 rounded-md border border-green-500/30 text-green-600 dark:text-green-400 text-xs cursor-pointer hover:bg-green-500/10 dark:hover:bg-green-500/15 transition-colors p-1.5 lg:px-2 lg:py-1 shrink-0"
             title="Click to learn about NIST 800-171 compliance"
           >
             <Shield className="h-4 w-4 lg:h-3 lg:w-3" />

--- a/src/components/layout/PreviewPanel.tsx
+++ b/src/components/layout/PreviewPanel.tsx
@@ -110,7 +110,11 @@ export function PreviewPanel({ pdfUrl, isCompiling, error }: PreviewPanelProps) 
             {isCompiling ? 'Compiling document...' : 'Compilation complete'}
           </div>
           {isCompiling && (
-            <div className="flex items-center gap-1.5 text-xs text-primary bg-primary/10 px-2 py-0.5 rounded-full" aria-hidden="true">
+            // Same readability pattern as PR #57's Templates button fix:
+            // dropping the tinted bg (primary/10 over the card bg reads as
+            // muddy and washes out the primary text). Status pill is
+            // read-only so no hover state to worry about.
+            <div className="flex items-center gap-1.5 text-xs text-primary border border-primary/30 px-2 py-0.5 rounded-full" aria-hidden="true">
               <Loader2 className="h-3 w-3 animate-spin" />
               <span>Compiling...</span>
             </div>


### PR DESCRIPTION
Followup to PR #57. Closes the same `text-X bg-X/10
border-X/30 hover:bg-X/20` anti-pattern at the surfaces flagged
in PR #57's "out of scope" list, plus one more instance the
verification sweep caught.

## Fixes

All three use the same fix: drop the tinted bg (which muddies
against the panel/card bg and washes out the colored text),
keep the colored border + colored text for identity, hover gets
the faint bg as the interactivity signal.

  - **Clear button** (`DocumentTypeSelector.tsx:158`) — orange,
    sits next to the Templates button from PR #57
  - **"Compiling..." status pill** (`PreviewPanel.tsx:113`) —
    primary (USMC red); read-only, no hover state
  - **NIST 800-171 compliance badge** (`Header.tsx:539`) — green,
    surfaced during the verification sweep (not in PR #57's
    original list but identical category)

## Zero remaining instances of the anti-pattern

Re-swept all `*.tsx` for `text-X + bg-X/Y` combos (excluding
hover-only bg uses):

  - `text-primary + bg-primary/X`              : 0
  - `text-orange + bg-orange/X`                : 0
  - `text-green + bg-green/X`                  : 0
  - `text-purple + bg-purple/X`                : 0
  - `text-{red,amber,blue}-800 + bg-X-100/X-500/10` : retained
    intentionally in `PIIWarningModal` + `ShareModal` — these
    are high-contrast alert-callout boxes (very dark text on
    very light tint), structurally different from the bug
    pattern (medium text on same-color faint tint)

The bug shape `text-X-{500-700} + bg-X-{500}/10-20` is fully
eliminated.

## Verification

  - `tsc --noEmit` clean
  - `eslint`: 11 problems (= main baseline, no new findings)
  - `vite build` succeeds; PWA precache 396 entries / 13,344 KiB
    (essentially identical to main)
  - All 4 GitHub CI checks pass
  - Version bumped 1.1.25 -> 1.1.26