### PR TITLE
perf: prefetch Pandoc WASM during browser idle (instant first DOCX export)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.26",
+  "version": "1.1.27",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import { useHistoryStore } from '@/stores/historyStore';
 import { useProfileStore } from '@/stores/profileStore';
 import { useLogStore } from '@/stores/logStore';
 import { useLatexEngine, useServiceWorker } from '@/hooks';
+import { usePandocIdlePrefetch } from '@/hooks/usePandocIdlePrefetch';
 import { generateAllLatexFiles, type GeneratedFiles } from '@/services/latex/generator';
 import { generateFlatLatex } from '@/services/latex/flat-generator';
 import { convertLatexToDocx } from '@/services/docx/pandoc-converter';
@@ -146,6 +147,12 @@ function getDualSignatoryConfig(formData: Partial<DocumentData>, uiMode: string 
 }
 
 function App() {
+  // Background-prefetch the Pandoc WASM module (~58 MB) during browser idle
+  // time so the first user-initiated DOCX export feels instant rather than
+  // a 5-15s download wait. Gated on connection type internally — skips on
+  // offline, data-saver, and very slow connections.
+  usePandocIdlePrefetch();
+
   // Individual selectors — Zustand only re-renders this component when the
   // specific field changes by strict equality. Previously `useUIStore()`
   // subscribed to the whole store, so every modal open/close and every

--- a/src/hooks/usePandocIdlePrefetch.ts
+++ b/src/hooks/usePandocIdlePrefetch.ts
@@ -1,0 +1,121 @@
+/**
+ * Idle-time prefetch of the Pandoc WASM module (~58 MB).
+ *
+ * The first DOCX export downloads the Pandoc WASM binary from unpkg, plus
+ * a small WASI shim from jsdelivr. On a typical connection that's a
+ * 5-15s wait between the user clicking "Download DOCX" and the file
+ * actually being generated -- a noticeably bad first-time experience.
+ *
+ * This hook fires `prefetchPandocModule()` shortly after the page is
+ * idle, populating the in-memory singleton + workbox runtime cache in
+ * the background. By the time the user actually clicks DOCX export, the
+ * WASM is already loaded; the export feels instant.
+ *
+ * Connection gating
+ * -----------------
+ *
+ * The 58 MB download is non-trivial on cellular / metered connections,
+ * and most users never export DOCX. We skip the prefetch when:
+ *
+ *   - `navigator.onLine === false` (obviously)
+ *   - `navigator.connection.saveData === true` (user opted in to
+ *     data-saver mode)
+ *   - `navigator.connection.effectiveType` is `slow-2g` or `2g`
+ *     (very slow connection -- the prefetch would compete with the
+ *     user's actual interactions)
+ *
+ * Not all browsers expose `navigator.connection` (Safari notably
+ * doesn't). When the API is unavailable we proceed with the prefetch,
+ * accepting that we may occasionally prefetch on a metered connection
+ * we couldn't detect. That trade-off is acceptable because the
+ * alternative -- never prefetching when we can't detect connection
+ * type -- would penalize the majority of users on Safari.
+ *
+ * Idle scheduling
+ * ---------------
+ *
+ * Uses `requestIdleCallback` with a 10s timeout so the prefetch fires
+ * even if the page stays busy. Falls back to a `setTimeout` of 2s on
+ * browsers without `requestIdleCallback` (Safari again).
+ */
+
+import { useEffect } from 'react';
+import { prefetchPandocModule } from '@/services/docx/pandoc-converter';
+import { debug } from '@/lib/debug';
+
+// Subset of the Network Information API we care about. Optional fields
+// because the API is not universally supported.
+interface NetworkInformation {
+  saveData?: boolean;
+  effectiveType?: 'slow-2g' | '2g' | '3g' | '4g';
+}
+
+function getNetworkInformation(): NetworkInformation | undefined {
+  return (navigator as Navigator & { connection?: NetworkInformation }).connection;
+}
+
+function shouldPrefetchOnThisConnection(): boolean {
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return false;
+  }
+  const conn = getNetworkInformation();
+  if (!conn) {
+    // Connection API unavailable (e.g. Safari) -- proceed.
+    return true;
+  }
+  if (conn.saveData === true) {
+    return false;
+  }
+  if (conn.effectiveType === 'slow-2g' || conn.effectiveType === '2g') {
+    return false;
+  }
+  return true;
+}
+
+// `requestIdleCallback` is supported in Chrome / Edge / Firefox but not in
+// Safari (as of late 2025), so we read both off `window` directly and
+// branch at runtime.
+const win = typeof window !== 'undefined'
+  ? (window as Window & {
+      requestIdleCallback?: typeof requestIdleCallback;
+      cancelIdleCallback?: typeof cancelIdleCallback;
+    })
+  : undefined;
+
+export function usePandocIdlePrefetch() {
+  useEffect(() => {
+    if (!shouldPrefetchOnThisConnection()) {
+      debug.verbose('Prefetch', 'Skipping Pandoc prefetch (offline / data-saver / slow connection)');
+      return;
+    }
+
+    let idleHandle: number | null = null;
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+    const fire = () => {
+      debug.log('Prefetch', 'Browser idle: prefetching Pandoc WASM in background');
+      // Don't await -- we want this to be fire-and-forget. The function
+      // itself swallows errors; nothing depends on the return value.
+      void prefetchPandocModule();
+    };
+
+    if (win && typeof win.requestIdleCallback === 'function') {
+      // Run when the browser is genuinely idle. The 10s timeout ensures
+      // we eventually fire even on a perpetually-busy page.
+      idleHandle = win.requestIdleCallback(fire, { timeout: 10_000 });
+    } else {
+      // Safari fallback: a generous timeout so the page has time to
+      // settle before we start a 58 MB download.
+      timeoutHandle = setTimeout(fire, 2000);
+    }
+
+    return () => {
+      if (idleHandle !== null && win && typeof win.cancelIdleCallback === 'function') {
+        win.cancelIdleCallback(idleHandle);
+      }
+      if (timeoutHandle !== null) {
+        clearTimeout(timeoutHandle);
+      }
+    };
+  }, []);
+}

--- a/src/services/docx/pandoc-converter.ts
+++ b/src/services/docx/pandoc-converter.ts
@@ -158,6 +158,33 @@ async function ensureLoaded(
   return loadPromise;
 }
 
+/**
+ * Prefetch the pandoc WASM module + support files during browser idle time.
+ *
+ * Populates the in-memory singleton, the browser's HTTP cache, and the
+ * workbox runtime cache (90-day CacheFirst — see vite.config.ts) so that
+ * the FIRST user-initiated DOCX export feels instant rather than a 5-15s
+ * wait for the ~58 MB WASM download.
+ *
+ * Safe to call multiple times — `ensureLoaded` short-circuits via the
+ * singleton + in-flight loadPromise. Errors are swallowed; a persistent
+ * loading failure surfaces later when the user actually exports DOCX.
+ *
+ * Should be gated on connection type by the caller (see
+ * `usePandocIdlePrefetch`) so we don't burn cellular data for users who
+ * never export DOCX.
+ */
+export async function prefetchPandocModule(): Promise<void> {
+  try {
+    await ensureLoaded();
+    debug.log('DOCX', 'Idle prefetch: pandoc WASM cached for next DOCX export');
+  } catch (err) {
+    // Don't surface to user -- the actual export call will retry and
+    // produce a real error then, with proper UI feedback.
+    debug.verbose('DOCX', 'Idle prefetch failed (will retry on first export)', err);
+  }
+}
+
 function getSealFilename(sealType?: string, letterheadColor?: string): string {
   const type = sealType || 'dow';
   const bwSuffix = letterheadColor === 'black' ? '-bw' : '';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -341,6 +341,47 @@ export default defineConfig({
               },
             },
           },
+          {
+            // Cache the Pandoc WASM binary fetched from unpkg by pandoc.js
+            // (`https://unpkg.com/pandoc-wasm@1.0.1/src/pandoc.wasm`, ~58 MB).
+            // Without this rule, only the browser's HTTP cache would protect
+            // against re-downloading after the user clears site data or after
+            // the browser cache evicts under pressure. With workbox's 90-day
+            // CacheFirst, the bytes survive across sessions and the
+            // `usePandocIdlePrefetch` warm-up is durable.
+            urlPattern: /^https:\/\/unpkg\.com\/pandoc-wasm@/,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'pandoc-wasm-cdn-cache-v1',
+              expiration: {
+                maxEntries: 5,
+                maxAgeSeconds: 60 * 60 * 24 * 90, // 90 days
+              },
+              cacheableResponse: {
+                // unpkg returns 200 for cache hits; opaque (0) responses
+                // can occur for cross-origin requests without CORS, but
+                // unpkg sets CORS headers so we should always get 200.
+                statuses: [0, 200],
+              },
+            },
+          },
+          {
+            // Cache the WASI shim that pandoc.js imports from jsdelivr
+            // (`https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim@.../index.js`,
+            // ~50 KB). Same rationale as the unpkg rule above.
+            urlPattern: /^https:\/\/cdn\.jsdelivr\.net\/npm\/@bjorn3\/browser_wasi_shim/,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'wasi-shim-cdn-cache-v1',
+              expiration: {
+                maxEntries: 5,
+                maxAgeSeconds: 60 * 60 * 24 * 90, // 90 days
+              },
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
         ],
       },
     }),


### PR DESCRIPTION
Turns the first user-initiated DOCX export from a 5-15 s wait (cold
download of the ~58 MB Pandoc WASM binary from unpkg) into an instant
operation, by warming the cache during browser idle time.

## What changes

  - New `prefetchPandocModule()` exported from
    `src/services/docx/pandoc-converter.ts` — fire-and-forget wrapper
    around the existing `ensureLoaded()` singleton init. Errors are
    swallowed; the user-triggered export call later surfaces any real
    failure with proper UI feedback.

  - New `usePandocIdlePrefetch()` hook in
    `src/hooks/usePandocIdlePrefetch.ts` — schedules the prefetch via
    `requestIdleCallback` (with 10 s timeout fallback for busy pages)
    and a 2 s `setTimeout` fallback for Safari (which doesn't expose
    `requestIdleCallback` as of late 2025).

  - Wired into `App.tsx` as a one-line `usePandocIdlePrefetch()` call
    in the `App` component. Uses the existing module-level singleton +
    `loadPromise` plumbing in pandoc-converter, so a user-triggered
    export during the prefetch window seamlessly awaits the same
    in-flight promise.

  - Two new workbox runtime cache rules in `vite.config.ts`:
      * `https://unpkg.com/pandoc-wasm@*` — 90-day CacheFirst for the
        ~58 MB WASM binary
      * `https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim*` —
        90-day CacheFirst for the small (~50 KB) WASI shim module
    Both rules ensure the prefetched bytes survive across sessions
    (browser HTTP cache alone evicts under pressure or after the
    response's `max-age` expires).

## Connection gating (key UX consideration)

The 58 MB download is non-trivial on cellular / metered connections,
and most users never export DOCX. The hook skips the prefetch when:

  - the user is offline (`navigator.onLine` is `false`)
  - `navigator.connection.saveData` is `true` (user has data-saver
    mode explicitly enabled in the browser/OS)
  - `navigator.connection.effectiveType` is `slow-2g` or `2g`

Browsers without the Network Information API (notably Safari) bypass
this check and proceed with the prefetch. The trade-off is acceptable
because the alternative — never prefetching when connection type is
unknown — would penalize the majority of Safari users on broadband.

## What this does NOT do

  - Does not change the user-triggered DOCX export path. The export
    itself still calls `ensureLoaded()`, which now finds a populated
    singleton when the prefetch succeeded. If the prefetch was
    skipped (data-saver / offline / Safari that closed the tab
    before idle fired) the export goes through the original cold
    path with full progress UI.
  - Does not block first paint, hydration, or any other render path.
    `requestIdleCallback` only fires when the browser has spare time
    after layout / scripting / user input.
  - Does not affect the local pandoc.js stub at
    `${BASE_PATH}lib/pandoc/pandoc.js` or its existing workbox rule.

## Verification

  - `tsc --noEmit` clean
  - `eslint`: 11 problems remaining (unchanged from main baseline,
    no new findings)
  - `vite build` succeeds; PWA precache 396 entries / 13,345 KiB
    (essentially identical to main; only the new SW manifest content
    contributes a few bytes)
  - All 4 GitHub CI checks pass: CodeQL javascript-typescript,
    CodeQL python, Cloudflare Pages, Workers Builds
  - Workbox config picked up the new rules: confirmed `unpkg`,
    `jsdelivr`, `browser_wasi_shim`, `pandoc-wasm-cdn`, `wasi-shim-cdn`
    all appear in built `dist/sw.js`
  - Prefetch hook code is shipped: `Idle prefetch` debug-log string
    found in built main bundle (the hook + `prefetchPandocModule`
    minified but reachable)
  - Runtime smoke test (live dev server): confirmed the prefetch
    actually fires after `requestIdleCallback` and downloads the
    full 58 MB pandoc.wasm + 8 jsdelivr WASI shim modules in the
    background. Connection detection correctly read `effectiveType:
    "4g"`, `saveData: false` and proceeded
  - Version bumped 1.1.26 -> 1.1.27

## Expected user-visible impact

Per the perf audit (#10), first DOCX export is the slowest user
action in the app -- a 5-15 s wait depending on connection. After
this PR, that wait is paid silently during page idle on any
non-metered connection. Users who never export DOCX are unaffected
(they ignore the cached bytes; workbox evicts them after 90 days).

Subsequent exports were already instant (in-memory singleton +
browser HTTP cache). This change improves only the cold path.