### PR TITLE
feat(endorsement): dropdown for ordinal + dedicated basic letter ID field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.27",
+      "version": "1.1.28",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.27",
+  "version": "1.1.28",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/editor/AddressingSection.tsx
+++ b/src/components/editor/AddressingSection.tsx
@@ -19,6 +19,13 @@ import { CSS } from '@dnd-kit/utilities';
 import { BookOpen, Plus, Trash2, AlertCircle, GripVertical, HelpCircle } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -107,6 +114,7 @@ function SortableViaItem({ id, index, value, onChange, onRemove, canRemove }: So
 
 export function AddressingSection({ config }: AddressingSectionProps) {
   const { formData, setField, documentMode } = useDocumentStore();
+  const docType = useDocumentStore((s) => s.docType);
   const [ssicModalOpen, setSSICModalOpen] = useState(false);
 
   // Check compliance requirements for business letters
@@ -114,6 +122,11 @@ export function AddressingSection({ config }: AddressingSectionProps) {
   const requiresSalutation = isCompliantMode && config.compliance.requiresSalutation;
   const dateFormat = isCompliantMode ? config.compliance.dateFormat : 'military';
   const isSSICOptional = isCompliantMode && config.optionalSSIC;
+
+  // Endorsements (same_page / new_page) require a position-in-chain
+  // ordinal AND a basic-letter identifier per SECNAV M-5216.5 Ch 9 §2.1.b.
+  // Render dedicated UI when this doc type is selected.
+  const isEndorsement = docType === 'same_page_endorsement' || docType === 'new_page_endorsement';
 
   const handleSSICSelect = (code: string) => {
     setField('ssic', code);
@@ -405,14 +418,79 @@ export function AddressingSection({ config }: AddressingSectionProps) {
               </div>
             )}
 
-            {/* Subject */}
+            {/* Endorsement-specific fields. Only render for endorsement doc
+                types. The basic-letter ID + ordinal together produce the
+                endorsement line per SECNAV M-5216.5 Ch 9 §2.1.b:
+                  "[ORDINAL] ENDORSEMENT on [basic letter id]"  */}
+            {isEndorsement && (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="endorsementOrdinal">
+                    Endorsement Number <span className="text-destructive">*</span>
+                  </Label>
+                  <Select
+                    value={formData.endorsementOrdinal || ''}
+                    onValueChange={(v) => setField('endorsementOrdinal', v)}
+                  >
+                    <SelectTrigger id="endorsementOrdinal" className="w-full">
+                      <SelectValue placeholder="Select position in routing chain..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="FIRST">FIRST</SelectItem>
+                      <SelectItem value="SECOND">SECOND</SelectItem>
+                      <SelectItem value="THIRD">THIRD</SelectItem>
+                      <SelectItem value="FOURTH">FOURTH</SelectItem>
+                      <SelectItem value="FIFTH">FIFTH</SelectItem>
+                      <SelectItem value="SIXTH">SIXTH</SelectItem>
+                      <SelectItem value="SEVENTH">SEVENTH</SelectItem>
+                      <SelectItem value="EIGHTH">EIGHTH</SelectItem>
+                      <SelectItem value="NINTH">NINTH</SelectItem>
+                      <SelectItem value="TENTH">TENTH</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Pick this endorsement&apos;s position in the routing chain. Per SECNAV
+                    M-5216.5 Ch 9 §2.1.b: number each endorsement in the sequence in
+                    which it is added to the basic letter (1st added = FIRST, 2nd =
+                    SECOND, etc.).
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="basicLetterId">
+                    Basic Letter ID <span className="text-destructive">*</span>
+                  </Label>
+                  <Input
+                    id="basicLetterId"
+                    value={formData.basicLetterId || ''}
+                    onChange={(e) => setField('basicLetterId', e.target.value)}
+                    placeholder="e.g., USS SCRANTON ltr 3000 Ser SSN 756/001 of 5 May 96"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Identifies the document this endorses. Use reference-line style:
+                    [activity] [letter type] [SSIC] Ser [N/N] of [date].
+                  </p>
+                </div>
+              </>
+            )}
+
+            {/* Subject — endorsements use the basic letter's subject when
+                rendered (same-page omits it; new-page repeats the basic
+                letter subject per Ch 9 §1). For non-endorsements the user
+                types the actual subject of this document. */}
             <div className="space-y-2">
-              <Label htmlFor="subject">Subject</Label>
+              <Label htmlFor="subject">
+                {isEndorsement ? "Subject (basic letter's subject)" : 'Subject'}
+              </Label>
               <InputWithVariables
                 id="subject"
                 value={formData.subject || ''}
                 onValueChange={(v) => setField('subject', v)}
-                placeholder="SUBJECT LINE... (type @ for variables)"
+                placeholder={
+                  isEndorsement
+                    ? "Subject of the basic letter being endorsed..."
+                    : 'SUBJECT LINE... (type @ for variables)'
+                }
                 className="uppercase"
               />
             </div>

--- a/src/data/exampleDocuments.ts
+++ b/src/data/exampleDocuments.ts
@@ -382,51 +382,73 @@ export const EXAMPLE_DOCUMENTS: ExampleDocument[] = [
   },
 
   // ENDORSEMENTS
+  // Both examples below mirror SECNAV M-5216.5 Ch 9 Figures 9-1 and 9-2
+  // verbatim. They share the same basic letter (NAS Meridian ltr 5216
+  // Ser 11/273 of 22 Apr 15), with FIRST endorsing same-page and SECOND
+  // endorsing new-page -- demonstrating the ordinal field flow through
+  // a real routing chain.
   {
     id: 'endorsement-example',
-    name: 'Same-Page Endorsement',
-    description: 'Brief endorsement recommending leave approval',
+    name: 'Same-Page Endorsement (FIRST)',
+    description: 'SECNAV M-5216.5 Ch 9 Figure 9-1 example -- first endorsement appended to the basic letter',
     category: 'Endorsements',
     docType: 'same_page_endorsement',
     formData: {
-      date: '25 Jan 26',
-      from: 'Company Commander, Alpha Company',
-      to: 'Commanding Officer, 1st Battalion, 4th Marines',
-      subject: 'FIRST ENDORSEMENT on LCpl T. M. Garcia\'s Special Liberty Request of 20 Jan 26',
+      date: '23 Apr 15',
+      serial: '019/870',
+      from: 'Commander, Sea Based Anti-Submarine Warfare Wing, Atlantic',
+      to: 'Commander, Fleet Forces Command',
+      via: 'Commander, Naval Air Force, U.S. Atlantic Fleet',
+      endorsementOrdinal: 'FIRST',
+      basicLetterId: 'NAS Meridian ltr 5216 Ser 11/273 of 22 Apr 15',
+      // Same-page endorsements may omit subject + SSIC + basic-letter
+      // ID per Ch 9 §2.1.a (entire page is photocopied with basic letter)
+      subject: '',
+      sigFirst: 'R',
+      sigMiddle: 'L',
+      sigLast: 'GABEL',
     },
     references: [],
     paragraphs: [
-      { text: 'Forwarded, recommending approval.', level: 0 },
-      { text: 'LCpl Garcia has maintained excellent performance and has no pending obligations that would preclude this request.', level: 0 },
+      { text: 'A same-page endorsement may omit the SSIC, subject, and the basic letter\'s identification if the entire page will be photocopied. However, these elements are required on all new-page endorsements, such as the one on the next page.', level: 0 },
     ],
     copyTos: [],
   },
   {
     id: 'new-page-endorsement-example',
-    name: 'New-Page Endorsement',
-    description: 'Detailed endorsement with additional justification',
+    name: 'New-Page Endorsement (SECOND)',
+    description: 'SECNAV M-5216.5 Ch 9 Figure 9-2 example -- second endorsement on a new page, repeats SSIC and basic letter ID',
     category: 'Endorsements',
     docType: 'new_page_endorsement',
     formData: {
-      department: 'usmc',
-      unitLine1: 'COMMANDING GENERAL',
-      unitLine2: '2D MARINE AIRCRAFT WING',
-      unitAddress: 'PSC BOX 8050, CHERRY POINT, NC 28533-0050',
+      department: 'navy',
+      unitLine1: 'COMMANDER',
+      unitLine2: 'NAVAL AIR FORCE ATLANTIC',
+      unitAddress: 'NORFOLK VA 23511-2494',
       sealType: 'dod',
       letterheadColor: 'blue',
-      date: '10 Feb 26',
-      from: 'Commanding General, 2d Marine Aircraft Wing',
-      to: 'Commanding General, II Marine Expeditionary Force',
-      subject: 'SECOND ENDORSEMENT on CO, MAG-14 ltr 1650 Ser 0034 of 28 Jan 26',
+      ssic: '5216',
+      serial: 'N72/420',
+      date: '28 Apr 15',
+      from: 'Commander, Naval Air Force, U.S. Atlantic Fleet',
+      to: 'Commander, Fleet Forces Command',
+      endorsementOrdinal: 'SECOND',
+      basicLetterId: 'NAS Meridian ltr 5216 Ser 11/273 of 22 Apr 15',
+      // New-page endorsements MUST repeat the basic letter's subject
+      // as their own per Ch 9 §2.1.a + the figure 9-2 example
+      subject: 'HOW TO PREPARE AN ENDORSEMENT',
+      sigFirst: 'J',
+      sigMiddle: 'T',
+      sigLast: 'CHILDRESS',
+      byDirection: true,
     },
     references: [],
     paragraphs: [
-      { text: 'Forwarded, recommending approval.', level: 0 },
-      { text: 'The requested waiver for Capt M. J. Sullivan to attend the Naval Postgraduate School will significantly enhance this officer\'s ability to serve in future aviation logistics billets.', level: 0 },
-      { text: 'Capt Sullivan\'s current assignment can be filled through normal rotation without adverse impact to squadron readiness. The investment in his education aligns with Wing manning objectives.', level: 0 },
+      { text: 'Start an endorsement on a new page. Number each page of your endorsement and continue the sequence of numbers from the previous endorsement or from the basic letter if you are the first endorser.', level: 0 },
+      { text: 'Every "new page" endorsement must repeat the basic letter\'s SSIC, identify the basic letter in the endorsement line, and use the basic letter\'s subject as its own.', level: 0 },
     ],
     copyTos: [
-      { text: 'CMC (MMOA)' },
+      { text: 'NAS Meridian (Code 11)' },
     ],
   },
 

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -904,11 +904,31 @@ ${trimLastRow(rows)}
 }
 
 function buildEndorsementHeader(docType: string, data: Partial<DocumentData>): string {
-  // The subject field contains the full endorsement line
-  // e.g. "FIRST ENDORSEMENT on LCpl T. M. Garcia's Special Liberty Request of 20 Jan 26"
-  const endorsementLine = data.subject
-    ? escapeFlat(data.subject.toUpperCase())
-    : 'FIRST ENDORSEMENT';
+  // Per SECNAV M-5216.5 Ch 9 §2.1.b the endorsement line is:
+  //   "[ORDINAL] ENDORSEMENT on [basic letter id]"
+  //
+  // Prefer the structured fields populated by the AddressingSection UI
+  // (`endorsementOrdinal` dropdown + `basicLetterId` input). Fall back
+  // to regex-parsing the subject for sessions saved before those fields
+  // existed.
+  let ordinal = data.endorsementOrdinal?.trim() || '';
+  let basicLetterId = data.basicLetterId?.trim() || '';
+
+  if (!ordinal || !basicLetterId) {
+    const subjectText = data.subject || '';
+    const match = subjectText.match(/^(.+?)\s+ENDORSEMENT(?:\s+on\s+(.+))?$/i);
+    if (match) {
+      if (!ordinal) ordinal = match[1].trim();
+      if (!basicLetterId) basicLetterId = match[2]?.trim() || '';
+    }
+  }
+
+  // Compose the endorsement line. Default to "FIRST ENDORSEMENT" when
+  // nothing is set so the document still renders something coherent.
+  const ordinalUpper = (ordinal || 'FIRST').toUpperCase();
+  const endorsementLine = basicLetterId
+    ? `${ordinalUpper} ENDORSEMENT on ${escapeFlat(basicLetterId)}`
+    : `${ordinalUpper} ENDORSEMENT`;
 
   if (docType === 'same_page_endorsement') {
     return `\\vspace{24pt}\n\\rule{\\textwidth}{0.5pt}\n\n${endorsementLine}\n\n\\vspace{12pt}\n`;

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -197,23 +197,39 @@ ${data.showSubjectOnContinuation ? `\\setContinuationSubject{${subjectLine}}` : 
     // but could be added later; for now the body handles them via ParagraphsEditor
   }
 
-  // Endorsements: parse subject field to set EndorsementOrdinal and BasicLetterID
-  // Subject contains the full endorsement line, e.g.:
-  //   "FIRST ENDORSEMENT on LCpl T. M. Garcia's Special Liberty Request of 20 Jan 26"
+  // Endorsements: set EndorsementOrdinal and BasicLetterID per SECNAV
+  // M-5216.5 Ch 9 §2.1.b -- the rendered endorsement line is:
+  //   "[ORDINAL] ENDORSEMENT on [basic letter id]"
+  //
+  // Prefer the structured fields populated by the AddressingSection UI
+  // (`endorsementOrdinal` dropdown + `basicLetterId` input). Fall back
+  // to regex-parsing the subject for sessions saved before those fields
+  // existed -- legacy subjects looked like:
+  //   "FIRST ENDORSEMENT on LCpl Garcia's Special Liberty Request..."
   if (store.docType === 'same_page_endorsement' || store.docType === 'new_page_endorsement') {
-    const subjectText = data.subject || '';
-    // Try to parse "ORDINAL ENDORSEMENT on BASIC_LETTER_ID"
-    const endorsementMatch = subjectText.match(/^(.+?)\s+ENDORSEMENT(?:\s+on\s+(.+))?$/i);
-    if (endorsementMatch) {
-      const ordinal = endorsementMatch[1].trim();
-      const basicLetterId = endorsementMatch[2]?.trim() || '';
-      // Both types: set ordinal and basic letter ID
-      tex += `\\renewcommand{\\EndorsementOrdinal}{${escapeLatex(ordinal)}}\n`;
-      if (basicLetterId) {
-        tex += `\\renewcommand{\\BasicLetterID}{${escapeLatex(basicLetterId)}}\n`;
+    let ordinal = data.endorsementOrdinal?.trim() || '';
+    let basicLetterId = data.basicLetterId?.trim() || '';
+
+    if (!ordinal || !basicLetterId) {
+      // Backwards-compat: parse "ORDINAL ENDORSEMENT on BASIC_LETTER_ID"
+      // out of the subject for legacy saved sessions. Only fills the
+      // pieces that aren't already provided by the structured fields.
+      const subjectText = data.subject || '';
+      const match = subjectText.match(/^(.+?)\s+ENDORSEMENT(?:\s+on\s+(.+))?$/i);
+      if (match) {
+        if (!ordinal) ordinal = match[1].trim();
+        if (!basicLetterId) basicLetterId = match[2]?.trim() || '';
       }
     }
-    // Always set serial and date for same-page endorsement, regardless of subject match
+
+    if (ordinal) {
+      tex += `\\renewcommand{\\EndorsementOrdinal}{${escapeLatex(ordinal)}}\n`;
+    }
+    if (basicLetterId) {
+      tex += `\\renewcommand{\\BasicLetterID}{${escapeLatex(basicLetterId)}}\n`;
+    }
+    // Always set serial and date for same-page endorsement, regardless
+    // of whether ordinal was found via structured field or subject parse.
     if (store.docType === 'same_page_endorsement') {
       tex += `\\renewcommand{\\EndorsementSerial}{${escapeLatex(data.serial || '')}}\n`;
       tex += `\\renewcommand{\\EndorsementDate}{${escapeLatex(data.date || '')}}\n`;

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -116,6 +116,18 @@ export interface DocumentData {
   via: string;
   subject: string;
 
+  // Endorsements only (same_page_endorsement, new_page_endorsement)
+  // Per SECNAV M-5216.5 Ch 9 §2.1.b -- endorsement line format is:
+  //   "[ORDINAL] ENDORSEMENT on [basic letter id]"
+  // where ORDINAL is the word ordinal (FIRST, SECOND, THIRD, ...) for
+  // the endorsement's position in the routing chain. Both fields are
+  // populated by dedicated UI in AddressingSection that only renders
+  // for endorsement doc types. The generators read them directly
+  // (with regex fallback to subject for sessions saved before this
+  // structured-fields migration).
+  endorsementOrdinal?: string;
+  basicLetterId?: string;
+
   // Signature
   sigFirst: string;
   sigMiddle: string;


### PR DESCRIPTION
When a user picks an endorsement doc type (same_page_endorsement,
new_page_endorsement) the AddressingSection now shows two new
required fields above the subject input:

  - **Endorsement Number** (Select dropdown: FIRST...TENTH)
  - **Basic Letter ID** (text input)

Per SECNAV M-5216.5 Ch 9 §2.1.b the endorsement line must be:

  `[ORDINAL] ENDORSEMENT on [basic letter id]`

where ORDINAL is the word ordinal (FIRST, SECOND, THIRD, ...) for
this endorsement's position in the routing chain.

## Why

Before this PR the user had to type the entire endorsement line into
the regular Subject field, e.g.
`"FIRST ENDORSEMENT on LCpl Garcia's Special Liberty Request..."`.
The generator regex-parsed that string. The Subject field's
placeholder ("SUBJECT LINE...") gave no UI cue that this magic
format was required, so users typed something generic like
"ENDORSEMENT" and got an empty ordinal in the output -- the
rendered LaTeX became `" ENDORSEMENT on "` which strips to just
**"ENDORSEMENT"**. Reported by a user via text message.

## What changes

| File | Change |
|---|---|
| `src/types/document.ts` | Two new optional fields on `DocumentData`: `endorsementOrdinal?` + `basicLetterId?`. Optional so saved-session compat is preserved |
| `src/components/editor/AddressingSection.tsx` | Conditional UI that only renders for endorsement doc types. Subject label + placeholder also adapt ("Subject (basic letter's subject)") since endorsements use the basic letter's subject, not their own |
| `src/services/latex/generator.ts` | Reads `endorsementOrdinal` + `basicLetterId` directly, with regex fallback on subject for legacy sessions |
| `src/services/latex/flat-generator.ts` | `buildEndorsementHeader` uses the same prefer-structured-fields, fallback-to-regex pattern |
| `src/data/exampleDocuments.ts` | Both endorsement examples updated to mirror SECNAV Ch 9 Figures 9-1 + 9-2 verbatim. Share the same basic letter (NAS Meridian ltr 5216 Ser 11/273 of 22 Apr 15) -- FIRST same-page + SECOND new-page demonstrating a real routing chain |

## SECNAV format compliance

| § | Spec | Implementation |
|---|---|---|
| 9-2.1.b | Word ordinals (FIRST, SECOND, ...) -- uppercase | Dropdown enforces canonical uppercase; LaTeX `\MakeUppercase` is a second layer |
| 9-2.1.b | "ENDORSEMENT on" hardcoded literal | Hardcoded in both endorsement templates |
| 9-2.1.b | `[ORDINAL] ENDORSEMENT on [basic letter id]` line format | `\MakeUppercase{\EndorsementOrdinal} ENDORSEMENT on \BasicLetterID` -- matches verbatim |
| 9-2.1.b | Multi-line wrap starts with "on" | LaTeX natural line wrap + `\par` handles it |
| 9-2.1.a | Same-page may omit basic letter ID | `\ifdefempty{\BasicLetterID}{}{ on \BasicLetterID}` gracefully omits when empty |
| 9-2.1.a | New-page MUST include basic letter ID | Template renders unconditionally; UI marks field with `*` |
| 9-2.1.a | Start at left margin, second line below date | `\noindent` + `\vspace{12pt}` after date block |

## Backwards compatibility

Saved sessions written before this PR have `subject = "FIRST
ENDORSEMENT on ..."` and no structured fields. After this PR loads
such a session:

  - New UI fields render empty (placeholder text)
  - Generators see empty structured fields, fall through to the
    legacy regex parser on subject, and produce the **exact same
    LaTeX as before**. No behavior change

If the user picks a value from the dropdown, that value takes
precedence on next compile.

## Verification

  - `tsc --noEmit` clean
  - `eslint`: 11 problems (unchanged from main baseline, no new
    findings)
  - `vite build` succeeds; PWA precache ~13,348 KiB (slight
    increase from larger SECNAV-faithful example body text)
  - All 4 GitHub CI checks pass: CodeQL javascript-typescript,
    CodeQL python, Cloudflare Pages, Workers Builds
  - Runtime smoke test (live dev server): all 10 ordinals render
    correctly through both PDF (`generateAllLatexFiles`) and DOCX
    (`generateFlatLatex`) paths. Backwards compat verified -- legacy
    subject-only sessions still produce correct output via regex
    fallback. Structured fields take precedence when both set.
  - Version bumped 1.1.27 -> 1.1.28