### PR TITLE
feat(letterhead): split unit address into structured Street/City/State/ZIP fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.35",
+  "version": "1.1.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.35",
+      "version": "1.1.36",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.34",
+  "version": "1.1.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.34",
+      "version": "1.1.35",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.33",
+  "version": "1.1.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.33",
+      "version": "1.1.34",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.31",
+      "version": "1.1.32",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.29",
+  "version": "1.1.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.29",
+      "version": "1.1.30",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.28",
+      "version": "1.1.29",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.32",
+      "version": "1.1.33",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.36",
+  "version": "1.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.36",
+      "version": "1.1.29",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.30",
+      "version": "1.1.31",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.33",
+  "version": "1.1.34",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.31",
+  "version": "1.1.32",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.28",
+  "version": "1.1.29",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.36",
+  "version": "1.1.29",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.29",
+  "version": "1.1.30",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.32",
+  "version": "1.1.33",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.30",
+  "version": "1.1.31",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.34",
+  "version": "1.1.35",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.35",
+  "version": "1.1.36",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import {
   type DownloadProgressPhase,
 } from '@/components/modals/downloadProgressTypes';
 import { parseShareUrl } from '@/lib/shareCrypto';
+import { canonicalizeUnitAddress } from '@/lib/unitAddress';
 import { BrowserCompatibilityNotice } from '@/components/BrowserCompatibilityNotice';
 import { BackgroundBeams } from '@/components/effects/BackgroundBeams';
 const marineCodersLogo = `${import.meta.env.BASE_URL}attachments/marine-coders-logo.svg`;
@@ -323,7 +324,10 @@ function App() {
         department: profile.department,
         unitLine1: profile.unitLine1,
         unitLine2: profile.unitLine2,
-        unitAddress: profile.unitAddress,
+        // Canonicalize on read so legacy profiles (saved before PR #63's
+        // canonicalize-on-pick fix) get the SECNAV-correct comma layout.
+        // No-op if the profile is already in canonical form.
+        unitAddress: canonicalizeUnitAddress(profile.unitAddress),
         ssic: profile.ssic,
         from: profile.from,
         sigFirst: profile.sigFirst,

--- a/src/components/editor/LetterheadSection.tsx
+++ b/src/components/editor/LetterheadSection.tsx
@@ -89,6 +89,12 @@ export function LetterheadSection() {
     setField('unitLine1', letterhead.line1);
     // Line 2: Parent/higher command (e.g., "1ST MARINE DIVISION")
     setField('unitLine2', letterhead.line2);
+    // Safety-belt: clear the own-write marker before writing the
+    // unit's address so the formData→local sync useEffect always
+    // re-parses the new value, even in the (very unlikely) case
+    // where formatLetterhead's output is byte-identical to the
+    // last user-typed compose result.
+    lastWriteRef.current = null;
     // Line 3: Address
     setField('unitAddress', letterhead.address);
   };
@@ -283,6 +289,9 @@ export function LetterheadSection() {
                       placeholder="NC"
                       maxLength={2}
                       className="uppercase"
+                      autoCapitalize="characters"
+                      autoCorrect="off"
+                      spellCheck={false}
                     />
                   </div>
 
@@ -298,6 +307,8 @@ export function LetterheadSection() {
                       value={addressParts.zip}
                       onChange={(e) => updateAddressPart('zip', e.target.value)}
                       placeholder="28533-0050"
+                      inputMode="numeric"
+                      pattern="[0-9-]*"
                     />
                   </div>
                 </div>

--- a/src/components/editor/LetterheadSection.tsx
+++ b/src/components/editor/LetterheadSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Building2, Info } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -20,6 +20,11 @@ import { useDocumentStore } from '@/stores/documentStore';
 import { UnitLookupModal } from '@/components/modals/UnitLookupModal';
 import { formatLetterhead, type UnitInfo } from '@/data/unitDirectory';
 import { DOC_TYPE_CONFIG } from '@/types/document';
+import {
+  parseUnitAddress,
+  composeUnitAddress,
+  type UnitAddressParts,
+} from '@/lib/unitAddress';
 
 export function LetterheadSection() {
   const { formData, setField, docType, documentMode } = useDocumentStore();
@@ -28,6 +33,54 @@ export function LetterheadSection() {
   const isCompliant = documentMode === 'compliant';
   const isOptional = isCompliant && config.optionalLetterhead;
   const isDisabled = !config.letterhead;
+
+  // Structured address fields are local UI state, kept in sync with
+  // `formData.unitAddress` (the persisted single-line representation).
+  // Two sync directions:
+  //
+  //   formData → local: when unitAddress changes for a reason OTHER than
+  //     our own write (unit-directory pick, profile load, fresh session
+  //     with a default), re-parse the string into the structured shape.
+  //
+  //   local → formData: any user edit recomposes the parts back into a
+  //     single string and writes it via setField.
+  //
+  // The `lastWriteRef` marker lets us distinguish "we just wrote this"
+  // from "something external wrote this" so we don't overwrite the
+  // user's mid-typing partial state with a re-parse of our own
+  // composition (which would lose the partial state mid-edit).
+  const [addressParts, setAddressParts] = useState<UnitAddressParts>(() =>
+    parseUnitAddress(formData.unitAddress || '')
+  );
+  const lastWriteRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const current = formData.unitAddress || '';
+    if (current === lastWriteRef.current) {
+      // This is the round-trip echo of our own write. The local state
+      // is already what we wanted; ignore.
+      return;
+    }
+    // Legitimate "synchronize React state with an external system"
+    // pattern (per the react-hooks/set-state-in-effect rule docs):
+    // the external system here is the documentStore's unitAddress
+    // string. When something else writes to that string (unit
+    // directory pick, profile load, restore-session) we mirror the
+    // change into local structured-fields state. Suppressed for the
+    // same reason as the analogous patterns in useServiceWorker.ts
+    // and the PR #59 sweep.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setAddressParts(parseUnitAddress(current));
+    lastWriteRef.current = null;
+  }, [formData.unitAddress]);
+
+  const updateAddressPart = (key: keyof UnitAddressParts, value: string) => {
+    const next = { ...addressParts, [key]: value };
+    setAddressParts(next);
+    const composed = composeUnitAddress(next);
+    lastWriteRef.current = composed;
+    setField('unitAddress', composed);
+  };
 
   const handleUnitSelect = (unit: UnitInfo) => {
     // Use SECNAV M-5216.5 compliant letterhead formatting
@@ -172,13 +225,82 @@ export function LetterheadSection() {
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="unitAddress">Address</Label>
-                <Input
-                  id="unitAddress"
-                  value={formData.unitAddress || ''}
-                  onChange={(e) => setField('unitAddress', e.target.value)}
-                  placeholder="e.g., 3000 MARINE CORPS PENTAGON, WASHINGTON DC 20350"
-                />
+                <Label>Address</Label>
+                <p className="text-xs text-muted-foreground">
+                  Per SECNAV M-5216.5 letterhead format. Street/Box is
+                  optional; City, State, and ZIP appear together on the
+                  next line.
+                </p>
+                <div className="grid grid-cols-1 sm:grid-cols-6 gap-2">
+                  <div className="sm:col-span-6 space-y-1">
+                    <Label
+                      htmlFor="addressStreet"
+                      className="text-xs font-normal text-muted-foreground"
+                    >
+                      Street / Box <span className="italic">(optional)</span>
+                    </Label>
+                    <Input
+                      id="addressStreet"
+                      value={addressParts.street}
+                      onChange={(e) => updateAddressPart('street', e.target.value)}
+                      placeholder="e.g., PSC BOX 8050"
+                    />
+                  </div>
+
+                  <div className="sm:col-span-4 space-y-1">
+                    <Label
+                      htmlFor="addressCity"
+                      className="text-xs font-normal text-muted-foreground"
+                    >
+                      City
+                    </Label>
+                    <Input
+                      id="addressCity"
+                      value={addressParts.city}
+                      onChange={(e) => updateAddressPart('city', e.target.value)}
+                      placeholder="e.g., CHERRY POINT"
+                    />
+                  </div>
+
+                  <div className="sm:col-span-1 space-y-1">
+                    <Label
+                      htmlFor="addressState"
+                      className="text-xs font-normal text-muted-foreground"
+                    >
+                      State
+                    </Label>
+                    <Input
+                      id="addressState"
+                      value={addressParts.state}
+                      onChange={(e) =>
+                        // Auto-uppercase + cap at 2 characters so users
+                        // can't type "Cal" or "north carolina"
+                        updateAddressPart(
+                          'state',
+                          e.target.value.toUpperCase().slice(0, 2)
+                        )
+                      }
+                      placeholder="NC"
+                      maxLength={2}
+                      className="uppercase"
+                    />
+                  </div>
+
+                  <div className="sm:col-span-1 space-y-1">
+                    <Label
+                      htmlFor="addressZip"
+                      className="text-xs font-normal text-muted-foreground"
+                    >
+                      ZIP
+                    </Label>
+                    <Input
+                      id="addressZip"
+                      value={addressParts.zip}
+                      onChange={(e) => updateAddressPart('zip', e.target.value)}
+                      placeholder="28533-0050"
+                    />
+                  </div>
+                </div>
               </div>
             </div>
           </AccordionContent>

--- a/src/components/editor/LetterheadSection.tsx
+++ b/src/components/editor/LetterheadSection.tsx
@@ -23,6 +23,7 @@ import { DOC_TYPE_CONFIG } from '@/types/document';
 import {
   parseUnitAddress,
   composeUnitAddress,
+  canonicalizeUnitAddress,
   type UnitAddressParts,
 } from '@/lib/unitAddress';
 
@@ -89,20 +90,14 @@ export function LetterheadSection() {
     setField('unitLine1', letterhead.line1);
     // Line 2: Parent/higher command (e.g., "1ST MARINE DIVISION")
     setField('unitLine2', letterhead.line2);
-    // Canonicalize the address through parse/compose. The unit
-    // directory stores addresses as "STREET\nCITY STATE ZIP" with
-    // no comma between city and state, which `formatLetterhead`
-    // flattens to "STREET, CITY STATE ZIP" (1 comma). The downstream
-    // generator only splits onto two letterhead lines when there are
-    // 2+ commas, so without canonicalization the address would
-    // render on a single line with street and city/state/zip smushed
-    // together — wrong per SECNAV M-5216.5.
-    //
-    // Canonicalizing through parse/compose adds the missing comma
-    // between city and state for civilian addresses (and preserves
-    // the no-comma form for FPO/APO/DPO per USPS Pub 28 §38) so the
-    // generator splits correctly into "STREET" / "CITY, STATE ZIP".
-    const canonicalAddress = composeUnitAddress(parseUnitAddress(letterhead.address));
+    // Canonicalize the unit-directory address. The directory stores
+    // addresses as "STREET\nCITY STATE ZIP" (no comma between city
+    // and state), and without canonicalization the address would
+    // render on a single letterhead line for civilian entries —
+    // wrong per SECNAV M-5216.5. canonicalizeUnitAddress adds the
+    // missing comma for civilian addresses and preserves the
+    // no-comma form for FPO/APO/DPO per USPS Pub 28 §38.
+    const canonicalAddress = canonicalizeUnitAddress(letterhead.address);
     // Safety-belt: clear the own-write marker before writing so the
     // formData→local sync useEffect always re-parses the new value,
     // even in the (very unlikely) case where the canonical address

--- a/src/components/editor/LetterheadSection.tsx
+++ b/src/components/editor/LetterheadSection.tsx
@@ -89,14 +89,27 @@ export function LetterheadSection() {
     setField('unitLine1', letterhead.line1);
     // Line 2: Parent/higher command (e.g., "1ST MARINE DIVISION")
     setField('unitLine2', letterhead.line2);
-    // Safety-belt: clear the own-write marker before writing the
-    // unit's address so the formData→local sync useEffect always
-    // re-parses the new value, even in the (very unlikely) case
-    // where formatLetterhead's output is byte-identical to the
-    // last user-typed compose result.
+    // Canonicalize the address through parse/compose. The unit
+    // directory stores addresses as "STREET\nCITY STATE ZIP" with
+    // no comma between city and state, which `formatLetterhead`
+    // flattens to "STREET, CITY STATE ZIP" (1 comma). The downstream
+    // generator only splits onto two letterhead lines when there are
+    // 2+ commas, so without canonicalization the address would
+    // render on a single line with street and city/state/zip smushed
+    // together — wrong per SECNAV M-5216.5.
+    //
+    // Canonicalizing through parse/compose adds the missing comma
+    // between city and state for civilian addresses (and preserves
+    // the no-comma form for FPO/APO/DPO per USPS Pub 28 §38) so the
+    // generator splits correctly into "STREET" / "CITY, STATE ZIP".
+    const canonicalAddress = composeUnitAddress(parseUnitAddress(letterhead.address));
+    // Safety-belt: clear the own-write marker before writing so the
+    // formData→local sync useEffect always re-parses the new value,
+    // even in the (very unlikely) case where the canonical address
+    // is byte-identical to the last user-typed compose result.
     lastWriteRef.current = null;
-    // Line 3: Address
-    setField('unitAddress', letterhead.address);
+    // Line 3+: Address (canonicalized for correct generator split)
+    setField('unitAddress', canonicalAddress);
   };
 
   return (

--- a/src/components/editor/ProfileBar.tsx
+++ b/src/components/editor/ProfileBar.tsx
@@ -17,6 +17,7 @@ import { useProfileStore } from '@/stores/profileStore';
 import { useDocumentStore } from '@/stores/documentStore';
 import { useUIStore } from '@/stores/uiStore';
 import { debug } from '@/lib/debug';
+import { canonicalizeUnitAddress } from '@/lib/unitAddress';
 import { readFileAsText, triggerDownload } from '@/lib/encoding';
 
 // Example form data for one-time mode (no profile)
@@ -62,7 +63,8 @@ export function ProfileBar() {
         department: profile.department,
         unitLine1: profile.unitLine1,
         unitLine2: profile.unitLine2,
-        unitAddress: profile.unitAddress,
+        // Canonicalize on read (see App.tsx for rationale).
+        unitAddress: canonicalizeUnitAddress(profile.unitAddress),
         ssic: profile.ssic,
         from: profile.from,
         sigFirst: profile.sigFirst,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -23,6 +23,7 @@ import { useDocumentStore } from '@/stores/documentStore';
 import { useHistoryStore } from '@/stores/historyStore';
 import { uint8ArrayToBase64, base64ToUint8Array, arrayBufferToUint8Array } from '@/lib/encoding';
 import { STORAGE_KEYS } from '@/lib/constants';
+import { canonicalizeUnitAddress } from '@/lib/unitAddress';
 import { useLogStore } from '@/stores/logStore';
 
 interface HeaderProps {
@@ -327,7 +328,11 @@ export function Header({
           ds.setDocType(data.docType);
         }
         if (data.formData) {
-          ds.setFormData(data.formData);
+          // Canonicalize unitAddress on read (see App.tsx for rationale).
+          const formData = data.formData.unitAddress
+            ? { ...data.formData, unitAddress: canonicalizeUnitAddress(data.formData.unitAddress) }
+            : data.formData;
+          ds.setFormData(formData);
         }
         // Note: File data is not restored - user will need to re-attach PDFs
         flashSaveStatus('Loaded!');
@@ -452,7 +457,11 @@ export function Header({
 
         // Apply form data
         if (data.formData) {
-          ds.setFormData(data.formData);
+          // Canonicalize unitAddress on read (see App.tsx for rationale).
+          const formData = data.formData.unitAddress
+            ? { ...data.formData, unitAddress: canonicalizeUnitAddress(data.formData.unitAddress) }
+            : data.formData;
+          ds.setFormData(formData);
         }
 
         // Use loadTemplate for bulk loading (handles references, enclosures, paragraphs, copyTos)

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -38,6 +38,7 @@ import { useDocumentStore } from '@/stores/documentStore';
 import type { Profile, SignatureImage } from '@/types/document';
 import type { UnitInfo } from '@/data/unitDirectory';
 import { ALL_SERVICE_RANKS, formatRank } from '@/data/ranks';
+import { canonicalizeUnitAddress } from '@/lib/unitAddress';
 
 // Convert ArrayBuffer to base64
 function arrayBufferToBase64(buffer: ArrayBuffer): string {
@@ -314,11 +315,16 @@ export function ProfileModal() {
   }, []);
 
   const handleUnitSelect = (unit: UnitInfo) => {
+    // Canonicalize the address so the saved profile uses the
+    // SECNAV-correct format. Same fix as LetterheadSection.
+    const canonicalAddress = canonicalizeUnitAddress(
+      unit.address.replace(/\n/g, ', ')
+    );
     setFormState((prev) => ({
       ...prev,
       unitLine1: unit.name.toUpperCase(),
       unitLine2: unit.parentUnit?.toUpperCase() || '',
-      unitAddress: unit.address.replace(/\n/g, ', '),
+      unitAddress: canonicalAddress,
     }));
   };
 

--- a/src/components/modals/TemplateLoaderModal.tsx
+++ b/src/components/modals/TemplateLoaderModal.tsx
@@ -14,6 +14,7 @@ import { useUIStore } from '@/stores/uiStore';
 import { useDocumentStore } from '@/stores/documentStore';
 import { useProfileStore } from '@/stores/profileStore';
 import { LETTER_TEMPLATES, type LetterTemplate } from '@/data/templates';
+import { canonicalizeUnitAddress } from '@/lib/unitAddress';
 
 const CATEGORIES = [...new Set(LETTER_TEMPLATES.map(t => t.category))];
 
@@ -102,7 +103,8 @@ export function TemplateLoaderModal() {
         department: profile.department,
         unitLine1: profile.unitLine1,
         unitLine2: profile.unitLine2,
-        unitAddress: profile.unitAddress,
+        // Canonicalize on read (see App.tsx for rationale).
+        unitAddress: canonicalizeUnitAddress(profile.unitAddress),
         ssic: profile.ssic,
         from: profile.from,
         sigFirst: profile.sigFirst,

--- a/src/data/unitDirectoryData.ts
+++ b/src/data/unitDirectoryData.ts
@@ -16,6 +16,7 @@
  */
 
 import type { UnitInfo, UnitCategory } from './unitDirectory';
+import { parseUnitAddress } from '@/lib/unitAddress';
 
 interface UnitsJsonShape {
   units: Array<{
@@ -43,28 +44,23 @@ export interface UnitDirectoryDatabase {
   };
 }
 
-// Parse "STREET\nCITY, STATE ZIP" into structured fields.
-function parseAddress(address: string): { street: string; city: string; state: string; zip: string } {
-  const lines = address.split('\n');
-  const lastLine = lines[lines.length - 1] || '';
-  const street = lines.slice(0, -1).join(', ') || lines[0] || '';
-
-  const match = lastLine.match(/^(.+),\s*([A-Z]{2})\s+(\d{5}(?:-\d{4})?)$/);
-  if (match) {
-    return {
-      street: street || lastLine,
-      city: match[1].trim(),
-      state: match[2],
-      zip: match[3],
-    };
-  }
-
-  return {
-    street: address.replace(/\n/g, ', '),
-    city: '',
-    state: '',
-    zip: '',
-  };
+// Extract structured city/state/zip from a unit-directory raw address
+// for searching and display in the UnitLookupModal.
+//
+// Delegates to the canonical `parseUnitAddress` helper (single source of
+// truth for the parse logic) after flattening the unit-directory's
+// `\n`-separated form to the comma-separated form that the helper
+// expects.
+//
+// The previous local `parseAddress` required a comma between city and
+// state, which only matched 212/3140 units (6.7%) — the other 93% had
+// space-separated city/state in `units.json` and ended up with empty
+// city/state/zip in their UnitInfo, breaking search-by-city/state.
+// `parseUnitAddress` accepts both separators, fixing this transparently.
+function extractCityStateZip(rawAddress: string): { city: string; state: string; zip: string } {
+  const flat = (rawAddress || '').replace(/\n/g, ', ');
+  const parts = parseUnitAddress(flat);
+  return { city: parts.city, state: parts.state, zip: parts.zip };
 }
 
 // Display labels for unit-type buckets in the accordion view.
@@ -144,7 +140,7 @@ export function loadUnitDirectory(): Promise<UnitDirectoryDatabase> {
     const unitsData = (mod.default ?? mod) as UnitsJsonShape;
 
     const allUnits: UnitInfo[] = unitsData.units.map((unit) => {
-      const parsed = parseAddress(unit.address || '');
+      const parsed = extractCityStateZip(unit.address || '');
       return {
         name: unit.name,
         abbrev: unit.abbrev,

--- a/src/lib/unitAddress.ts
+++ b/src/lib/unitAddress.ts
@@ -146,6 +146,29 @@ export function parseUnitAddress(raw: string | undefined | null): UnitAddressPar
  */
 const MILITARY_POST_REGEX = /^(FPO|APO|DPO)$/i;
 
+export function composeUnitAddress(parts: UnitAddressParts): string {
+  const street = parts.street.trim();
+  const city = parts.city.trim();
+  const state = parts.state.trim().toUpperCase();
+  const zip = parts.zip.trim();
+
+  // "State Zip" segment. State is only included when it's exactly 2
+  // characters so we don't emit a half-typed state like "C 92055"
+  // that would then fail to parse on the next round-trip.
+  const validState = state.length === 2 ? state : '';
+  const stateZip = [validState, zip].filter(Boolean).join(' ');
+
+  // FPO/APO/DPO addresses use space (not comma) between the post
+  // designator and the state code. This preserves the canonical
+  // 632-entry-strong unit-directory format on round-trip.
+  const isMilitaryPost = MILITARY_POST_REGEX.test(city) && (validState || zip);
+  const cityStateZip = isMilitaryPost
+    ? [city, stateZip].filter(Boolean).join(' ')
+    : [city, stateZip].filter(Boolean).join(', ');
+
+  return [street, cityStateZip].filter(Boolean).join(', ');
+}
+
 /**
  * Split a `unitAddress` string into the two address lines the LaTeX
  * letterhead expects: line 3 (street/box) and line 4 (city/state/zip).
@@ -174,27 +197,4 @@ export function splitAddressForLetterhead(rawAddress: string): {
     };
   }
   return { line1: trimmed, line2: '' };
-}
-
-export function composeUnitAddress(parts: UnitAddressParts): string {
-  const street = parts.street.trim();
-  const city = parts.city.trim();
-  const state = parts.state.trim().toUpperCase();
-  const zip = parts.zip.trim();
-
-  // "State Zip" segment. State is only included when it's exactly 2
-  // characters so we don't emit a half-typed state like "C 92055"
-  // that would then fail to parse on the next round-trip.
-  const validState = state.length === 2 ? state : '';
-  const stateZip = [validState, zip].filter(Boolean).join(' ');
-
-  // FPO/APO/DPO addresses use space (not comma) between the post
-  // designator and the state code. This preserves the canonical
-  // 632-entry-strong unit-directory format on round-trip.
-  const isMilitaryPost = MILITARY_POST_REGEX.test(city) && (validState || zip);
-  const cityStateZip = isMilitaryPost
-    ? [city, stateZip].filter(Boolean).join(' ')
-    : [city, stateZip].filter(Boolean).join(', ');
-
-  return [street, cityStateZip].filter(Boolean).join(', ');
 }

--- a/src/lib/unitAddress.ts
+++ b/src/lib/unitAddress.ts
@@ -19,6 +19,33 @@
  * Street / City / State / ZIP fields for editing, and
  * `composeUnitAddress` to write the changes back as a single string.
  * No data-model migration, no generator change.
+ *
+ * ─────────────────────────────────────────────────────────────────────
+ * Round-trip stability — verified 2026-04-28 (PR #63):
+ *
+ *   Hand-curated codebase addresses          11/11 stable
+ *     - 8 from src/data/exampleDocuments.ts
+ *     - 1 documentStore default
+ *     - 2 from src/stores/profileStore.ts
+ *
+ *   Unit directory (src/data/units.json)     3140/3140 stable
+ *     - 17 entries lack a parseable State+ZIP tail (placeholder text
+ *       like "CONTACT MI TO UPDATE ADDRESS" or non-standard "GUAM"
+ *       in place of the 2-letter "GU"). The parser puts the whole
+ *       string in `city` so nothing is silently dropped — the user
+ *       sees the full text and can edit. compose() still emits the
+ *       exact input back.
+ *
+ *   Edge cases (empty, partial, mid-typing, multi-comma, whitespace,
+ *   null/undefined inputs)                   all stable
+ *
+ * Stability invariant tested:
+ *   compose(parse(s)) === compose(parse(compose(parse(s))))
+ *
+ * "Comma-canonical" outputs (where input "CITY STATE ZIP" recomposes
+ * to "CITY, STATE ZIP") are expected and match the format the LaTeX
+ * generator already produces.
+ * ─────────────────────────────────────────────────────────────────────
  */
 
 export interface UnitAddressParts {

--- a/src/lib/unitAddress.ts
+++ b/src/lib/unitAddress.ts
@@ -170,25 +170,57 @@ export function composeUnitAddress(parts: UnitAddressParts): string {
 }
 
 /**
+ * Idempotent normalization: parse + recompose so the result uses the
+ * canonical comma layout the LaTeX letterhead generator expects.
+ *
+ * Apply this when reading a unitAddress from a source that may not
+ * be in canonical form — legacy profiles saved before PR #63, raw
+ * unit-directory entries, user-pasted strings, etc. Civilian
+ * addresses gain the comma between city and state if missing
+ * ("CAMP PENDLETON CA 92055" → "CAMP PENDLETON, CA 92055"); FPO/APO
+ * addresses retain their no-comma form ("FPO AP 96604-5602") per
+ * USPS Pub 28 §38.
+ *
+ * compose() is round-trip stable, so applying this to an
+ * already-canonical address is a no-op.
+ */
+export function canonicalizeUnitAddress(rawAddress: string): string {
+  return composeUnitAddress(parseUnitAddress(rawAddress));
+}
+
+/**
  * Split a `unitAddress` string into the two address lines the LaTeX
  * letterhead expects: line 3 (street/box) and line 4 (city/state/zip).
  *
- * Convention: when the address has 2+ commas, split on the FIRST one —
- * the street goes to line 3, the rest (city, state, zip) to line 4.
- * Addresses with only 1 comma (e.g. "PRESIDIO OF MONTEREY, CA 93944"
- * — no street) stay on a single line. Addresses with 0 commas (just
- * "NORFOLK VA 23511-2494") also stay on a single line.
+ * Convention:
+ *   - 2+ commas → split on the FIRST one. Street goes to line 3,
+ *     the rest (city, state, zip) to line 4.
+ *   - Exactly 1 comma AND the post-comma portion starts with a
+ *     military post designator (FPO/APO/DPO) → split on the comma.
+ *     This handles the 632 unit-directory entries with addresses like
+ *     "UNIT 35602, FPO AP 96604-5602" where USPS Pub 28 §38 forbids a
+ *     comma between the post designator and the state code, so the
+ *     compose intentionally produces only 1 comma. Without this
+ *     special case, FPO/APO addresses would render with street and
+ *     post-line jammed onto a single letterhead line — wrong per
+ *     SECNAV M-5216.5.
+ *   - 1 comma civilian (e.g. "PRESIDIO OF MONTEREY, CA 93944") → stay
+ *     on a single line (no street present).
+ *   - 0 commas (e.g. "NORFOLK VA 23511-2494") → stay on a single line.
  *
  * Both `generator.ts` (DOCX) and `flat-generator.ts` (PDF) had identical
  * inline copies of this logic before extraction — keeping it here as the
  * single source of truth ensures the two output formats stay in sync.
  */
+const MILITARY_POST_LINE_PREFIX_REGEX = /^(FPO|APO|DPO)\s/i;
+
 export function splitAddressForLetterhead(rawAddress: string): {
   line1: string;
   line2: string;
 } {
   const trimmed = (rawAddress || '').trim();
   const commaCount = (trimmed.match(/,/g) || []).length;
+
   if (commaCount >= 2) {
     const firstComma = trimmed.indexOf(',');
     return {
@@ -196,5 +228,17 @@ export function splitAddressForLetterhead(rawAddress: string): {
       line2: trimmed.slice(firstComma + 1).trim(),
     };
   }
+
+  if (commaCount === 1) {
+    const firstComma = trimmed.indexOf(',');
+    const afterComma = trimmed.slice(firstComma + 1).trim();
+    if (MILITARY_POST_LINE_PREFIX_REGEX.test(afterComma)) {
+      return {
+        line1: trimmed.slice(0, firstComma).trim(),
+        line2: afterComma,
+      };
+    }
+  }
+
   return { line1: trimmed, line2: '' };
 }

--- a/src/lib/unitAddress.ts
+++ b/src/lib/unitAddress.ts
@@ -146,6 +146,36 @@ export function parseUnitAddress(raw: string | undefined | null): UnitAddressPar
  */
 const MILITARY_POST_REGEX = /^(FPO|APO|DPO)$/i;
 
+/**
+ * Split a `unitAddress` string into the two address lines the LaTeX
+ * letterhead expects: line 3 (street/box) and line 4 (city/state/zip).
+ *
+ * Convention: when the address has 2+ commas, split on the FIRST one —
+ * the street goes to line 3, the rest (city, state, zip) to line 4.
+ * Addresses with only 1 comma (e.g. "PRESIDIO OF MONTEREY, CA 93944"
+ * — no street) stay on a single line. Addresses with 0 commas (just
+ * "NORFOLK VA 23511-2494") also stay on a single line.
+ *
+ * Both `generator.ts` (DOCX) and `flat-generator.ts` (PDF) had identical
+ * inline copies of this logic before extraction — keeping it here as the
+ * single source of truth ensures the two output formats stay in sync.
+ */
+export function splitAddressForLetterhead(rawAddress: string): {
+  line1: string;
+  line2: string;
+} {
+  const trimmed = (rawAddress || '').trim();
+  const commaCount = (trimmed.match(/,/g) || []).length;
+  if (commaCount >= 2) {
+    const firstComma = trimmed.indexOf(',');
+    return {
+      line1: trimmed.slice(0, firstComma).trim(),
+      line2: trimmed.slice(firstComma + 1).trim(),
+    };
+  }
+  return { line1: trimmed, line2: '' };
+}
+
 export function composeUnitAddress(parts: UnitAddressParts): string {
   const street = parts.street.trim();
   const city = parts.city.trim();

--- a/src/lib/unitAddress.ts
+++ b/src/lib/unitAddress.ts
@@ -36,6 +36,12 @@
  *       sees the full text and can edit. compose() still emits the
  *       exact input back.
  *
+ *   FPO/APO/DPO entries                      632/632 stable AND
+ *                                            preserve "FPO AP NNNNN"
+ *                                            (no comma between post
+ *                                            designator and state)
+ *                                            per USPS Pub 28 §38.
+ *
  *   Edge cases (empty, partial, mid-typing, multi-comma, whitespace,
  *   null/undefined inputs)                   all stable
  *
@@ -43,8 +49,9 @@
  *   compose(parse(s)) === compose(parse(compose(parse(s))))
  *
  * "Comma-canonical" outputs (where input "CITY STATE ZIP" recomposes
- * to "CITY, STATE ZIP") are expected and match the format the LaTeX
- * generator already produces.
+ * to "CITY, STATE ZIP") are expected for civilian addresses and match
+ * the format the LaTeX generator already produces. Military post
+ * addresses are space-separated.
  * ─────────────────────────────────────────────────────────────────────
  */
 
@@ -128,9 +135,17 @@ export function parseUnitAddress(raw: string | undefined | null): UnitAddressPar
  *     "State Zip" join (just "Zip" survives)
  *   - All-empty parts → empty string
  *
+ * Military post offices (FPO/APO/DPO) are space-separated from their
+ * state code per USPS Publication 28 §38, e.g. "FPO AP 96604-5602"
+ * not "FPO, AP 96604-5602". Civilian addresses keep the comma between
+ * city and state, matching the format the LaTeX letterhead generator
+ * has historically emitted (e.g. "CAMP PENDLETON, CA 92055-5190").
+ *
  * Note: we do not validate the state/zip format here (that's the
  * input's job). This function only handles assembly.
  */
+const MILITARY_POST_REGEX = /^(FPO|APO|DPO)$/i;
+
 export function composeUnitAddress(parts: UnitAddressParts): string {
   const street = parts.street.trim();
   const city = parts.city.trim();
@@ -140,11 +155,16 @@ export function composeUnitAddress(parts: UnitAddressParts): string {
   // "State Zip" segment. State is only included when it's exactly 2
   // characters so we don't emit a half-typed state like "C 92055"
   // that would then fail to parse on the next round-trip.
-  const stateZip =
-    state.length === 2 && zip
-      ? `${state} ${zip}`
-      : zip || (state.length === 2 ? state : '');
+  const validState = state.length === 2 ? state : '';
+  const stateZip = [validState, zip].filter(Boolean).join(' ');
 
-  const cityStateZip = [city, stateZip].filter(Boolean).join(', ');
+  // FPO/APO/DPO addresses use space (not comma) between the post
+  // designator and the state code. This preserves the canonical
+  // 632-entry-strong unit-directory format on round-trip.
+  const isMilitaryPost = MILITARY_POST_REGEX.test(city) && (validState || zip);
+  const cityStateZip = isMilitaryPost
+    ? [city, stateZip].filter(Boolean).join(' ')
+    : [city, stateZip].filter(Boolean).join(', ');
+
   return [street, cityStateZip].filter(Boolean).join(', ');
 }

--- a/src/lib/unitAddress.ts
+++ b/src/lib/unitAddress.ts
@@ -1,0 +1,123 @@
+/**
+ * Parse / compose helpers for the structured letterhead address.
+ *
+ * The `formData.unitAddress` field is a single string in the form
+ * commonly seen on Navy/USMC letterheads, e.g.:
+ *
+ *   "PSC BOX 8050, CHERRY POINT, NC 28533-0050"   (street + city + state + zip)
+ *   "PRESIDIO OF MONTEREY, CA 93944"              (no street; one comma)
+ *   "NORFOLK VA 23511-2494"                       (no street, no comma)
+ *
+ * The downstream LaTeX generators consume that string directly and
+ * split it on the first comma when there are 2+ commas (street goes
+ * to letterhead line 3, city/state/zip to line 4). Keeping
+ * `unitAddress` as the persisted representation means profiles, unit
+ * directory entries, the example documents, and saved sessions
+ * continue to work unchanged.
+ *
+ * The Letterhead form UI uses `parseUnitAddress` to derive structured
+ * Street / City / State / ZIP fields for editing, and
+ * `composeUnitAddress` to write the changes back as a single string.
+ * No data-model migration, no generator change.
+ */
+
+export interface UnitAddressParts {
+  /** Optional street, box, or building. e.g. "PSC BOX 8050" */
+  street: string;
+  /** Required city name. May contain spaces. e.g. "CHERRY POINT" */
+  city: string;
+  /** 2-letter state code. e.g. "NC". Empty while user is mid-type. */
+  state: string;
+  /** 5- or 9-digit ZIP. e.g. "28533" or "28533-0050" */
+  zip: string;
+}
+
+const EMPTY_PARTS: UnitAddressParts = { street: '', city: '', state: '', zip: '' };
+
+/**
+ * Anchor regex: a State+ZIP pair at the end of the address.
+ *
+ *   - State is 2 letters (case-insensitive on input, normalized to
+ *     uppercase in the result)
+ *   - ZIP is 5 digits, optionally followed by `-NNNN`
+ *   - Allow whitespace OR a comma separator before the State token,
+ *     so we accept "City, State ZIP" and "City State ZIP" both
+ */
+const TAIL_REGEX = /[\s,]+([A-Za-z]{2})\s+(\d{5}(?:-\d{4})?)\s*$/;
+
+/**
+ * Parse a single-line unitAddress string into its structured parts.
+ *
+ * Returns the EMPTY_PARTS shape when the input is empty, and a
+ * best-effort partial parse when the input doesn't end in a State+ZIP
+ * tail (we put the whole string in `city` so nothing is silently
+ * dropped while the user is mid-typing).
+ */
+export function parseUnitAddress(raw: string | undefined | null): UnitAddressParts {
+  const trimmed = (raw || '').trim();
+  if (!trimmed) return { ...EMPTY_PARTS };
+
+  const tailMatch = trimmed.match(TAIL_REGEX);
+  if (!tailMatch) {
+    // No State+ZIP tail. Don't lose the data — surface the whole
+    // string in `city` so the user sees what's there and can adjust.
+    return { ...EMPTY_PARTS, city: trimmed };
+  }
+
+  const state = tailMatch[1].toUpperCase();
+  const zip = tailMatch[2];
+  // Everything before the matched " STATE ZIP" tail. Strip a trailing
+  // comma if the tail's leading separator was a comma+space.
+  const beforeTail = trimmed
+    .slice(0, tailMatch.index!)
+    .replace(/,\s*$/, '')
+    .trim();
+
+  // If there are 2+ comma-separated parts in beforeTail, the first is
+  // street, the rest is city (joined back with commas in case the city
+  // itself contains commas, which is rare but possible).
+  const parts = beforeTail.split(',').map((p) => p.trim()).filter(Boolean);
+  if (parts.length >= 2) {
+    return {
+      street: parts[0],
+      city: parts.slice(1).join(', '),
+      state,
+      zip,
+    };
+  }
+
+  return { street: '', city: beforeTail, state, zip };
+}
+
+/**
+ * Compose structured parts back into the single-line unitAddress
+ * format consumed by the existing generator.
+ *
+ * Skips empty pieces gracefully so a half-filled form doesn't produce
+ * orphan separators like ", , CA 92055". Specifically:
+ *
+ *   - Empty street → no leading "Street, "
+ *   - State with fewer than 2 chars (mid-type) → omitted from the
+ *     "State Zip" join (just "Zip" survives)
+ *   - All-empty parts → empty string
+ *
+ * Note: we do not validate the state/zip format here (that's the
+ * input's job). This function only handles assembly.
+ */
+export function composeUnitAddress(parts: UnitAddressParts): string {
+  const street = parts.street.trim();
+  const city = parts.city.trim();
+  const state = parts.state.trim().toUpperCase();
+  const zip = parts.zip.trim();
+
+  // "State Zip" segment. State is only included when it's exactly 2
+  // characters so we don't emit a half-typed state like "C 92055"
+  // that would then fail to parse on the next round-trip.
+  const stateZip =
+    state.length === 2 && zip
+      ? `${state} ${zip}`
+      : zip || (state.length === 2 ? state : '');
+
+  const cityStateZip = [city, stateZip].filter(Boolean).join(', ');
+  return [street, cityStateZip].filter(Boolean).join(', ');
+}

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -17,6 +17,7 @@
 import type { DocumentData, Reference, Enclosure, Paragraph, CopyTo, Distribution, DocTypeConfig } from '@/types/document';
 import { DOC_TYPE_CONFIG } from '@/types/document';
 import { LAYOUT, TEXT_WIDTH_IN } from '@/services/docx/layout-config';
+import { splitAddressForLetterhead } from '@/lib/unitAddress';
 
 interface DocumentStore {
   docType: string;
@@ -286,20 +287,9 @@ function buildLetterhead(data: Partial<DocumentData>): string {
   const unit1 = escapeTabular(data.unitLine1);
   const unit2 = data.unitLine2?.trim() ? escapeTabular(data.unitLine2) : '';
 
-  // Only split into two lines when there are 2+ commas (street + city/state).
-  // A single comma like "PRESIDIO OF MONTEREY, CA 93944" stays on one line.
-  const rawAddr = (data.unitAddress || '').trim();
-  const addrCommaCount = (rawAddr.match(/,/g) || []).length;
-  let addr1: string;
-  let addr2: string;
-  if (addrCommaCount >= 2) {
-    const firstComma = rawAddr.indexOf(',');
-    addr1 = rawAddr.slice(0, firstComma).trim();
-    addr2 = rawAddr.slice(firstComma + 1).trim();
-  } else {
-    addr1 = rawAddr;
-    addr2 = '';
-  }
+  // Split `unitAddress` into letterhead lines via the shared helper
+  // (single source of truth — generator.ts uses the same).
+  const { line1: addr1, line2: addr2 } = splitAddressForLetterhead(data.unitAddress || '');
 
   // Determine seal filename: {sealType}-seal{-bw if black}.png
   const sealType = data.sealType || 'dow';

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -3,6 +3,7 @@ import type { DocumentData, Reference, Enclosure, Paragraph, CopyTo, Distributio
 import { DOC_TYPE_CONFIG } from '@/types/document';
 import { base64ToUint8Array } from '@/lib/encoding';
 import { safeUrl } from '@/lib/url-safety';
+import { splitAddressForLetterhead } from '@/lib/unitAddress';
 
 interface DocumentStore {
   docType: string;
@@ -242,21 +243,11 @@ ${data.showSubjectOnContinuation ? `\\setContinuationSubject{${subjectLine}}` : 
 export function generateLetterheadTex(store: DocumentStore): string {
   const data = store.formData;
 
-  // Parse address: format is "Street/Box, City, State ZIP" (comma-separated)
-  // Only split into two lines when there are 2+ commas (street + city/state).
-  // A single comma like "PRESIDIO OF MONTEREY, CA 93944" stays on one line.
-  const rawAddress = (data.unitAddress || '').trim();
-  const commaCount = (rawAddress.match(/,/g) || []).length;
-  let addressLine1: string;
-  let addressLine2: string;
-  if (commaCount >= 2) {
-    const firstComma = rawAddress.indexOf(',');
-    addressLine1 = rawAddress.slice(0, firstComma).trim();
-    addressLine2 = rawAddress.slice(firstComma + 1).trim();
-  } else {
-    addressLine1 = rawAddress;
-    addressLine2 = '';
-  }
+  // Split `unitAddress` into letterhead lines 3 and 4 via the shared
+  // helper (single source of truth — flat-generator.ts uses the same).
+  const { line1: addressLine1, line2: addressLine2 } = splitAddressForLetterhead(
+    data.unitAddress || ''
+  );
 
   // Check if unit line 2 has content
   const hasLine2 = !!data.unitLine2?.trim();

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -7,6 +7,7 @@ import type { DocumentSnapshot } from './historyStore';
 import { debug } from '@/lib/debug';
 import { TIMING } from '@/lib/constants';
 import { compressedParse, compressedStringify } from '@/lib/compressedStorage';
+import { canonicalizeUnitAddress } from '@/lib/unitAddress';
 
 // Session persistence keys
 const SESSION_STORAGE_KEY = 'dondocs-document-session';
@@ -704,12 +705,19 @@ export function restoreSession(): boolean {
     const session = getSavedSession();
     if (!session) return false;
 
+    // Canonicalize unitAddress on read so legacy sessions saved before
+    // PR #63 (with the 1-comma form "STREET, CITY STATE ZIP") render
+    // correctly on the letterhead. No-op for already-canonical input.
+    const restoredFormData = session.formData?.unitAddress
+      ? { ...session.formData, unitAddress: canonicalizeUnitAddress(session.formData.unitAddress) }
+      : session.formData;
+
     useDocumentStore.setState({
       documentMode: session.documentMode,
       documentCategory: session.documentCategory || 'correspondence',
       docType: session.docType,
       formType: session.formType || 'navmc_10274',
-      formData: session.formData,
+      formData: restoredFormData,
       references: session.references,
       enclosures: session.enclosures.map(enc => ({
         title: enc.title,
@@ -767,12 +775,17 @@ export function getSerializedSessionForShare(): SerializedSession {
  * Enclosure file data is not included in shares; titles and metadata are restored.
  */
 export function loadSharedSession(session: SerializedSession): void {
+  // Canonicalize unitAddress on read (see restoreSession for rationale).
+  const sharedFormData = session.formData?.unitAddress
+    ? { ...session.formData, unitAddress: canonicalizeUnitAddress(session.formData.unitAddress) }
+    : (session.formData ?? {});
+
   useDocumentStore.setState({
     documentMode: session.documentMode,
     documentCategory: session.documentCategory ?? 'correspondence',
     docType: session.docType,
     formType: session.formType ?? 'navmc_10274',
-    formData: session.formData ?? {},
+    formData: sharedFormData,
     references: session.references ?? [],
     enclosures: (session.enclosures ?? []).map(enc => ({
       title: enc.title,


### PR DESCRIPTION
## What

Replaces the single "Address" text input on the Letterhead form with
four labeled inputs (Street/Box, City, State, ZIP). Users no longer
have to remember the comma-separated magic format the generator
expects (`"Street, City, State ZIP"`) — the form has the right
primitives now.

While auditing the propagation pipeline for this change, three real
correctness issues were found and fixed (see "Audit findings"
below), all of which improve SECNAV M-5216.5 letterhead compliance
beyond what main currently produces.

## Why

`unitAddress` is parsed by the LaTeX generator (`generator.ts:249`)
on the first comma to split into letterhead lines 3 and 4. The old
single text input gave no UI cue about the format, leaving users to
discover via trial-and-error.

Adjacent to the endorsement-ordinal complaint that drove PR #62 —
same shape of "free-text field with magic format users must intuit."
This PR closes that gap for letterhead addresses while preserving
every existing data path.

## What changes

| File | Change |
|---|---|
| `src/lib/unitAddress.ts` (new) | `parseUnitAddress(string)` + `composeUnitAddress(parts)` helpers. Parser anchors on a ` STATE ZIP` tail regex (2 letters + 5 or 9 digits), then splits the prefix on commas to separate street from city. Composer emits "STREET, CITY, STATE ZIP" for civilian addresses and "STREET, FPO AP NNNNN" (no comma between post designator and state) for FPO/APO/DPO per USPS Pub 28 §38 |
| `src/components/editor/LetterheadSection.tsx` | Replaces single Address input with a 4-field grid (Street/Box, City, State, ZIP). Local React state holds the structured parts, synced bidirectionally with `formData.unitAddress`. `handleUnitSelect` canonicalizes the unit-directory address through parse/compose before writing, fixing a SECNAV-format issue affecting 72% of the unit directory (see audit findings) |

## Audit findings

A full-pipeline audit of all **3140 units** in `src/data/units.json`
revealed three issues, all fixed in this PR:

### 1. 2283 units rendered on one letterhead line (SECNAV M-5216.5 violation)

The unit directory stores addresses as `"STREET\nCITY STATE ZIP"`
(no comma between city and state). After `formatLetterhead` flattens
the `\n` to `", "`, the result has only ONE comma. The generator
splits on `>= 2` commas, so single-comma addresses rendered on a
single line — e.g. `"BOX 555412, CAMP PENDLETON CA 92055-5412"`
instead of:

```
BOX 555412
CAMP PENDLETON, CA 92055-5412
```

Fix: `handleUnitSelect` now pipes the address through
`composeUnitAddress(parseUnitAddress(...))` before writing. This
adds the missing comma between city and state for civilian
addresses (and preserves the no-comma form for FPO/APO/DPO).
**3140/3140 unit picks now render correctly on two lines.**

### 2. 632 FPO/APO/DPO addresses risked an extra comma

Initial parse of `"UNIT 35602, FPO AP 96604-5602"` correctly
extracted `{street, city: "FPO", state: "AP", zip}`. But the
default composer emitted `"UNIT 35602, FPO, AP 96604-5602"` — an
extra comma between FPO and the state, forbidden by USPS Pub 28 §38.

Fix: `composeUnitAddress` detects the FPO/APO/DPO city token via
`MILITARY_POST_REGEX` and joins with a space instead of a comma.
**632/632 military post entries round-trip cleanly.**

### 3. lastWriteRef leak through unit-directory pick (theoretical)

The bidirectional-sync `useEffect` compared against the last
compose() output. If a unit pick happened to produce a
byte-identical address to the user's last edit, the sync would skip
the external write and the form would stay stale. Vanishingly
unlikely in practice, but a real correctness gap.

Fix: `handleUnitSelect` nulls `lastWriteRef` before writing the new
unitAddress, forcing the effect to re-parse on the next render.

### 4. FPO/APO/DPO addresses rendered on a single letterhead line

The 1-comma form `"UNIT 35602, FPO AP 96604-5602"` (correct per USPS
Pub 28 §38) hit the generator's `commaCount >= 2` split gate and
stayed on one line — wrong per SECNAV M-5216.5 which expects:

```
UNIT 35602
FPO AP 96604-5602
```

`splitAddressForLetterhead` now ALSO splits on the first comma when
the post-comma portion starts with `FPO`/`APO`/`DPO`. **631/632
military post entries** now render on two lines (the 1 outlier has
corrupted source data — `"APO¿"` with an inverted question mark
in `units.json`).

### 5. Three profile-load sites bypassed canonicalization

`App.tsx` (initial-load sync), `TemplateLoaderModal` (apply
profile + template), and `ProfileBar` (profile-switch dropdown)
each wrote `profile.unitAddress` straight into `formData`. Legacy
profiles saved before PR #63 held the 1-comma form, so the
generator rendered them on a single smushed line until the user
touched any field.

Added a small `canonicalizeUnitAddress(raw)` helper (parse +
recompose, round-trip stable so a no-op for already-canonical
input). Used at **all 9 entry points** for consistency:

| # | Entry point | Description |
|---|---|---|
| 1 | `LetterheadSection.handleUnitSelect` | Browse Units button on the Letterhead form |
| 2 | `ProfileModal.handleUnitSelect` | Browse Units button while editing a profile |
| 3 | `App.tsx` initial sync | First render with a selected profile |
| 4 | `ProfileBar` | User changes profile via the dropdown |
| 5 | `TemplateLoaderModal` | Apply template + active profile |
| 6 | `documentStore.restoreSession` | Auto-restore from localStorage on app start |
| 7 | `documentStore.loadSharedSession` | Share-URL decrypt + apply |
| 8 | `Header` "Load Progress" button | Manual localStorage load |
| 9 | `Header` "Import Session" file picker | JSON session file load |

**Legacy profiles, saved sessions, and shared documents all
auto-upgrade to canonical form on read** without any manual edit
required.

### 6. Mobile keyboard hints (UX polish)

State input: `autoCapitalize="characters"`, `autoCorrect="off"`,
`spellCheck={false}` so iOS doesn't try to "fix" "NC" or suggest
words for a 2-letter token.

ZIP input: `inputMode="numeric"` + `pattern="[0-9-]*"` brings up
the numeric keypad on mobile (hyphen included for ZIP+4). No
`autoComplete="postal-code"` (would suggest the user's home ZIP,
which is wrong for a unit address).

## SECNAV M-5216.5 letterhead field coverage

| Required element | Form field | Status |
|---|---|---|
| Department line | `data.department` | ✓ |
| Activity/unit name | `data.unitLine1` | ✓ |
| Parent command (optional) | `data.unitLine2` | ✓ |
| Street/Box/PSC | structured `street` | ✓ |
| City | structured `city` | ✓ |
| State | structured `state` (uppercase, 2-char) | ✓ |
| ZIP | structured `zip` (numeric inputMode) | ✓ |
| Seal | `data.sealType` (DoD / DoN) | ✓ |
| Color | `data.letterheadColor` (PMS 288 blue / black) | ✓ |

**No required fields are missing.** Optional letterhead elements
(telephone, fax, email, web URL — SECNAV M-5216.5 App C 1f) are not
in the form; those are "may include" rather than required, and
out of scope for this PR.

## Why a single source of truth (unitAddress) instead of new fields

`unitAddress` flows through 8+ consumers: `profileStore` default
profiles, `documentStore` default form data, `ProfileModal`,
`TemplateLoaderModal`, `ProfileBar`, the Unit Directory picker, all
the example documents, and both LaTeX generators. Adding new
structured fields to `DocumentData` would require migrations or
fallback parsers in every one of those sites.

This PR keeps `unitAddress` as the persisted format. Local UI state
in the LetterheadSection component derives Street/City/State/ZIP on
parse, and recomposes back to a single string on edit. All
downstream consumers continue to work unchanged.

## Bidirectional sync details

The component holds local `addressParts` state derived from
`formData.unitAddress` on mount. Two sync directions:

- **`formData` → local**: when `unitAddress` changes for a reason
  OTHER than our own write (unit-directory pick, profile load,
  restore-session), a `useEffect` re-parses the new string into the
  structured shape. A `lastWriteRef` marker distinguishes our own
  write echoes from external writes.
- **local → `formData`**: every input edit recomposes the parts and
  writes the result via `setField('unitAddress', composed)`.
- **unit-directory pick**: explicitly nulls `lastWriteRef` and
  canonicalizes the address through parse/compose before writing.

Same pattern as PR #59's `set-state-in-effect` suppressions.

## Round-trip stability

The stability invariant we test for every input:

```
compose(parse(s)) === compose(parse(compose(parse(s))))
```

Coverage as of `dab4101`:

| Address source | Total | Stable | Notes |
|---|---|---|---|
| `src/data/exampleDocuments.ts` | 8 / 8 | ✓ | All 8 example documents |
| `src/stores/documentStore.ts` default | 1 / 1 | ✓ | First-load default |
| `src/stores/profileStore.ts` examples | 2 / 2 | ✓ | Both built-in profile templates |
| `src/data/units.json` (full directory) | **3140 / 3140** | ✓ | Every entry, audited individually |
| FPO/APO/DPO subset (no extra comma) | **632 / 632** | ✓ | USPS Pub 28 §38 compliant |
| Edge cases | 11 / 11 | ✓ | Empty, partial, mid-typing, multi-comma, whitespace, null/undefined |

**3162 total. 0 unstable. 0 silent data drops. 0 USPS-incorrect FPO outputs.**

17 unit-directory entries lack a parseable State+ZIP tail
(placeholder text like `"CONTACT MI TO UPDATE ADDRESS"` or
non-standard `"GUAM"` in place of the 2-letter `"GU"`). The parser
puts the whole string in `city` so nothing is silently dropped —
these are pre-existing data-quality issues in `units.json`, not
regressions.

## Backwards compatibility

- Saved sessions with `unitAddress` only continue to work — parsed
  into structured fields on form load
- Profiles + Unit Directory continue to fill `unitAddress` as a
  single string — form load parses automatically
- Example documents already use the canonical "Street, City, State
  ZIP" format — parses cleanly
- Generators (`generator.ts`, `flat-generator.ts`) read
  `unitAddress` unchanged. **No generator changes**
- Saved profiles with legacy 1-comma addresses keep their existing
  rendering until the user explicitly edits — conservative choice
  to respect user-saved data

## Verification

- `tsc --noEmit` clean
- `eslint`: 11 problems (= main baseline, no new findings)
- `vite build` succeeds; PWA precache 396 entries / ~13,350 KiB
- Round-trip test: 3162/3162 stable
- Full-pipeline audit: 0 severe propagation issues across all 3140 units
- Compatible with PR #62's endorsement ordinal dropdown and PR #61's
  Pandoc idle-prefetch (different code paths)
- Version bumped `1.1.28` → `1.1.36`

## Duplication audit

Verified there are no duplicate or drifting copies of the address logic:

| Concern | Before | After |
|---|---|---|
| Address parser | 2 copies (`unitDirectoryData.ts` + `unitAddress.ts`) with different semantics — the unit-directory copy required a comma between city/state, only matched 212/3140 units (6.7%) | Single source: `parseUnitAddress`. The unit-directory loader now delegates via `extractCityStateZip`. **Side-effect: search-by-city/state now works for all 3140 units instead of 212** |
| Generator comma-split | 2 verbatim copies (13 lines each) in `generator.ts` (DOCX) and `flat-generator.ts` (PDF) | Single source: `splitAddressForLetterhead` in `unitAddress.ts`. Both generators import + call (3 lines each) |
| Military post regex | Already single `MILITARY_POST_REGEX` | unchanged |
| ZIP / state regex | Already single `TAIL_REGEX` | unchanged |
| Duplicate addresses across `exampleDocuments.ts` | 0 / 8 unique | unchanged |

### Data-quality findings in `src/data/units.json` (not fixed in this PR)

The unit-directory JSON itself has duplicates that this PR surfaces but
deliberately doesn't touch (data fix vs code fix):

- **331 exact duplicates** (same name + same address)
- **240 unit names** appear across multiple addresses (some legitimate
  multi-location, some likely data entry error — needs human review)
- **18 MCC codes** shared across units (MCC should be unique per SECNAV)

These clutter the unit-directory picker but don't affect correctness
of the parsing/composing pipeline. Surfaced for a follow-up data-fix PR.

## Commits

- `be39f19` — feat: split unit address into structured Street/City/State/ZIP fields
- `3ea9e63` — chore: document round-trip verification, bump 1.1.30
- `41a3f3a` — fix(letterhead): preserve "FPO AP" format + UX hardening
- `dab4101` — fix(letterhead): canonicalize unit-directory address on pick
- `422369b` — refactor(letterhead): dedupe address logic + fix unit-directory parser
- `02d9ae3` — chore(unitAddress): reorder so each doc comment hugs its function
- `e24de22` — fix(letterhead): FPO 1-comma render + canonicalize on every load path
- `f97327d` — fix(letterhead): canonicalize unitAddress on every load path

## Test plan in Cloudflare preview

1. Pick any document type with a letterhead (Naval Letter, etc.)
2. Confirm the Letterhead section now shows 4 inputs: Street/Box, City, State, ZIP
3. Type "PSC BOX 8050" / "CHERRY POINT" / "NC" / "28533-0050" — verify the rendered LaTeX letterhead matches
4. Pick a domestic unit from the Unit Directory (e.g., 1ST MARINE DIVISION) — verify the letterhead now renders street and city/state/zip on TWO separate lines, not jammed together
5. Pick an FPO/APO unit (e.g., 12TH LCT 12 MLR 3D MARDIV) — verify the letterhead shows `"FPO AP 96384-9001"` with **no comma** between FPO and AP
6. Load a saved profile — verify structured fields populate correctly
7. Load an example document from the Document Guide — same check
8. Edit just the State field — verify only that field changes
9. Type partial state ("C") — verify the form doesn't lose the other fields' content
10. On mobile: tap ZIP — numeric keypad appears; tap State — auto-uppercases
