### PR TITLE
fix(navmc-forms): preserve SECNAV hanging indent on wrapped paragraphs (closes #24)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.30",
+      "version": "1.1.31",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.30",
+  "version": "1.1.31",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/editor/Form11811Section.tsx
+++ b/src/components/editor/Form11811Section.tsx
@@ -162,6 +162,7 @@ export function Form11811Section() {
                   onChange={(v) => setNavmc11811Field('remarksText', v)}
                   placeholder="Type @ or click + for variables. Example: On {{ENTRY_DATE}}, {{NAME}} [describe the incident]..."
                   rows={16}
+                  tabInsertsSpaces
                 />
               </div>
               <div className="space-y-2">
@@ -171,6 +172,7 @@ export function Form11811Section() {
                   onChange={(v) => setNavmc11811Field('remarksTextRight', v)}
                   placeholder="[Continuation or additional entry...] (type @ or click + for variables)"
                   rows={16}
+                  tabInsertsSpaces
                 />
               </div>
             </div>

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -264,6 +264,7 @@ export function Form6105Section() {
                 onChange={(v) => setNavmc10274Field('supplementalInfo', v)}
                 placeholder="Full counseling statement (type @ or click + for variables)..."
                 rows={12}
+                tabInsertsSpaces
               />
             </div>
 
@@ -274,6 +275,7 @@ export function Form6105Section() {
                 onChange={(v) => setNavmc10274Field('proposedAction', v)}
                 placeholder="e.g., 'Request entry of adverse Page 11 (6105) entry per MCO 1610.7A' (type @ or click + for variables)"
                 rows={3}
+                tabInsertsSpaces
               />
             </div>
           </AccordionContent>

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -615,8 +615,28 @@ export function VariableChipEditor({
     content: textToEditorHtml(value),
     editorProps: {
       attributes: {
-        class: 'prose prose-sm dark:prose-invert max-w-none focus:outline-none px-3 py-2',
+        // `whitespace-pre-wrap` overrides Tailwind's `prose` default
+        // (white-space: normal) so multiple spaces typed by the user —
+        // both via the Space key and via the Tab handler below — render
+        // literally instead of collapsing to a single space. The PDF
+        // generator already preserves them; this just keeps the editor
+        // visually faithful to what gets generated.
+        class: 'prose prose-sm dark:prose-invert max-w-none focus:outline-none px-3 py-2 whitespace-pre-wrap',
         style: `min-height: ${rows * 24}px`,
+      },
+      // Tab key inserts 4 spaces (matching the SECNAV 0.25" / wrap-helper
+      // `TAB_AS_SPACES` convention) so users can indent sub-paragraphs
+      // directly in Field 12 / 13 / Page-11 entries instead of having to
+      // type four spaces or paste pre-formatted text. Shift+Tab is left
+      // to its default (move focus to previous field) so keyboard
+      // navigation still works for getting out of the editor.
+      handleKeyDown(view, event) {
+        if (event.key === 'Tab' && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+          event.preventDefault();
+          view.dispatch(view.state.tr.insertText('    '));
+          return true;
+        }
+        return false;
       },
     },
     onUpdate: ({ editor }) => {

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -448,7 +448,12 @@ function editorToText(editor: ReturnType<typeof useEditor>): string {
     paragraphs.push(paraText);
   });
 
-  return paragraphs.join('\n').trim();
+  // Strip TRAILING newlines/whitespace only — never leading. The user is
+  // allowed to type "    test" or "\ta. ..." (leading whitespace is
+  // meaningful for SECNAV-style sub-paragraphs), and a blanket `.trim()`
+  // would silently delete it on every onUpdate, dropping the indent
+  // before the value reaches the store.
+  return paragraphs.join('\n').replace(/\s+$/, '');
 }
 
 // Convert a single line of text to HTML (escaping, LaTeX formatting, variables)
@@ -613,6 +618,15 @@ export function VariableChipEditor({
       VariableExtension,
     ],
     content: textToEditorHtml(value),
+    // Preserve consecutive whitespace through HTML parsing. ProseMirror's
+    // default parser uses HTML's "normal" whitespace rules — runs of
+    // spaces collapse to a single space — which would drop SECNAV-style
+    // sub-paragraph indents like "    a. ..." back to "a. ..." every
+    // time the editor reloads its content from the form store. With
+    // preserveWhitespace: 'full', the spaces survive parsing both for
+    // initial content and for `setContent` calls in the value-sync
+    // useEffect below.
+    parseOptions: { preserveWhitespace: 'full' },
     editorProps: {
       attributes: {
         // `whitespace-pre-wrap` overrides Tailwind's `prose` default
@@ -656,7 +670,13 @@ export function VariableChipEditor({
     if (!editor || value === lastValue.current) return;
     lastValue.current = value;
     currentValue.current = value;
-    editor.commands.setContent(textToEditorHtml(value));
+    // Same `preserveWhitespace: 'full'` as the initial parseOptions —
+    // setContent uses its own parse pass, so the option must be passed
+    // here too or every store-driven re-render would drop leading
+    // whitespace from sub-paragraphs.
+    editor.commands.setContent(textToEditorHtml(value), {
+      parseOptions: { preserveWhitespace: 'full' },
+    });
   }, [value, editor]);
 
   // Register any variables found in the initial value

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -579,6 +579,20 @@ interface VariableChipEditorProps {
   placeholder?: string;
   className?: string;
   rows?: number;
+  /**
+   * If true, pressing Tab inserts 4 literal spaces (matching the SECNAV
+   * 0.25" sub-paragraph indent and the wrap helper's TAB_AS_SPACES
+   * constant). Used by NAVMC 10274 / 118-11 form fields where users need
+   * to indent SECNAV-style sub-paragraphs directly in the textarea.
+   *
+   * Defaults to false so other consumers (e.g. correspondence body
+   * paragraphs in ParagraphsEditor, where indentation is controlled by
+   * `paragraph.level` rather than leading whitespace) keep the browser's
+   * native Tab → focus-next-element behavior. Without this gate, every
+   * VariableChipEditor in the app would swallow Tab, breaking keyboard
+   * navigation everywhere.
+   */
+  tabInsertsSpaces?: boolean;
 }
 
 export function VariableChipEditor({
@@ -587,6 +601,7 @@ export function VariableChipEditor({
   placeholder = 'Type @ to insert variables...',
   className,
   rows = 3,
+  tabInsertsSpaces = false,
 }: VariableChipEditorProps) {
   const [isFocused, setIsFocused] = useState(false);
   const lastValue = useRef(value);
@@ -644,8 +659,22 @@ export function VariableChipEditor({
       // type four spaces or paste pre-formatted text. Shift+Tab is left
       // to its default (move focus to previous field) so keyboard
       // navigation still works for getting out of the editor.
+      //
+      // Gated behind `tabInsertsSpaces` so consumers that DON'T want this
+      // (e.g. correspondence body paragraphs, where indentation is
+      // already handled via `paragraph.level`) keep Tab → focus-next-
+      // element. Without this gate, the shared component would swallow
+      // Tab in every editor instance, breaking keyboard navigation in
+      // the SECNAV correspondence flow.
       handleKeyDown(view, event) {
-        if (event.key === 'Tab' && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+        if (
+          tabInsertsSpaces &&
+          event.key === 'Tab' &&
+          !event.shiftKey &&
+          !event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey
+        ) {
           event.preventDefault();
           view.dispatch(view.state.tr.insertText('    '));
           return true;

--- a/src/services/pdf/navmc10274Generator.ts
+++ b/src/services/pdf/navmc10274Generator.ts
@@ -1,4 +1,5 @@
 import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
+import { wrapTextForForm } from './textWrap';
 
 // NAVMC 10274 - Administrative Action
 // This generator loads the official form templates and overlays text
@@ -201,46 +202,12 @@ const PAGE3_FIELDS = {
   },
 };
 
-/**
- * Wrap text to fit within a max width
- */
-function wrapText(
-  text: string,
-  maxWidth: number,
-  font: Awaited<ReturnType<typeof PDFDocument.prototype.embedFont>>,
-  fontSize: number
-): string[] {
-  const lines: string[] = [];
-  const paragraphs = text.split('\n');
-
-  for (const paragraph of paragraphs) {
-    if (!paragraph.trim()) {
-      lines.push('');
-      continue;
-    }
-
-    const words = paragraph.split(' ');
-    let currentLine = '';
-
-    for (const word of words) {
-      const testLine = currentLine ? `${currentLine} ${word}` : word;
-      const width = font.widthOfTextAtSize(testLine, fontSize);
-
-      if (width > maxWidth && currentLine) {
-        lines.push(currentLine);
-        currentLine = word;
-      } else {
-        currentLine = testLine;
-      }
-    }
-
-    if (currentLine) {
-      lines.push(currentLine);
-    }
-  }
-
-  return lines;
-}
+// `wrapText` previously lived here as an inline helper; it's now extracted
+// to `./textWrap.ts` (`wrapTextForForm`) and shared with navmc11811Generator.
+// The new implementation also fixes issue #24 — continuation lines of a
+// wrapped sub-paragraph now hang at the SECNAV-correct position instead of
+// dropping back to the box's left margin.
+const wrapText = wrapTextForForm;
 
 /**
  * Draw multi-line text on a page with placeholder highlighting

--- a/src/services/pdf/navmc11811Generator.ts
+++ b/src/services/pdf/navmc11811Generator.ts
@@ -1,4 +1,5 @@
 import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
+import { wrapTextForForm } from './textWrap';
 
 // NAVMC 118(11) - Administrative Remarks (Page 11 / 6105)
 // This generator loads the official form template and overlays text
@@ -168,46 +169,11 @@ const FIELDS = {
   },
 };
 
-/**
- * Wrap text to fit within a max width
- */
-function wrapText(
-  text: string,
-  maxWidth: number,
-  font: Awaited<ReturnType<typeof PDFDocument.prototype.embedFont>>,
-  fontSize: number
-): string[] {
-  const lines: string[] = [];
-  const paragraphs = text.split('\n');
-
-  for (const paragraph of paragraphs) {
-    if (!paragraph.trim()) {
-      lines.push('');
-      continue;
-    }
-
-    const words = paragraph.split(' ');
-    let currentLine = '';
-
-    for (const word of words) {
-      const testLine = currentLine ? `${currentLine} ${word}` : word;
-      const width = font.widthOfTextAtSize(testLine, fontSize);
-
-      if (width > maxWidth && currentLine) {
-        lines.push(currentLine);
-        currentLine = word;
-      } else {
-        currentLine = testLine;
-      }
-    }
-
-    if (currentLine) {
-      lines.push(currentLine);
-    }
-  }
-
-  return lines;
-}
+// `wrapText` was a duplicate copy of the same helper in navmc10274Generator;
+// both are now shared via `./textWrap.ts` (`wrapTextForForm`). The new
+// implementation fixes issue #24 — wrapped sub-paragraphs preserve their
+// SECNAV-style hanging indent on continuation lines.
+const wrapText = wrapTextForForm;
 
 /**
  * Generate a filled NAVMC 118(11) form

--- a/src/services/pdf/textWrap.ts
+++ b/src/services/pdf/textWrap.ts
@@ -40,6 +40,31 @@ interface PdfFontLike {
 const SECNAV_LABEL_REGEX = /^(\s*)((?:\d+\.|\([0-9a-zA-Z]+\)|[a-zA-Z]\.))(\s+)/;
 
 /**
+ * Tab → space normalization.
+ *
+ * pdf-lib's `widthOfTextAtSize` uses the embedded font's glyph table;
+ * tab characters typically don't have a glyph and either render as
+ * zero-width or get dropped silently — making the visual width
+ * unpredictable. The hanging-indent algorithm below treats the leading
+ * prefix as character-equivalent spaces, so a leading "\t" would be
+ * counted as 1 space (visually wrong: a tab is wider than a space in
+ * any font).
+ *
+ * Normalizing tab → 4 spaces up front gives:
+ *   - predictable rendering width
+ *   - correct hang-prefix computation
+ *   - consistent behavior whether the user typed spaces or pasted
+ *     tab-indented content from another editor
+ *
+ * 4 was picked as the common SECNAV-style sub-paragraph indent (Ch 7
+ * ¶13: "Each level indents 0.25" from the previous"). Most editors
+ * default to 4 too, so pasted content from Word / VSCode / etc.
+ * round-trips cleanly. The constant is here in case a future tweak
+ * (e.g. an 8-space convention for some forms) wants to override it.
+ */
+const TAB_AS_SPACES = '    ';
+
+/**
  * Split `text` into rendered lines that fit within `maxWidth` at the
  * given font/size. Preserves SECNAV-style hanging indent on
  * continuation lines: the same number of leading spaces as the
@@ -57,7 +82,9 @@ export function wrapTextForForm(
   fontSize: number
 ): string[] {
   const lines: string[] = [];
-  const paragraphs = text.split('\n');
+  // Normalize tabs to 4 spaces before any other processing — see
+  // TAB_AS_SPACES doc comment above.
+  const paragraphs = text.replace(/\t/g, TAB_AS_SPACES).split('\n');
 
   for (const para of paragraphs) {
     if (!para.trim()) {

--- a/src/services/pdf/textWrap.ts
+++ b/src/services/pdf/textWrap.ts
@@ -111,6 +111,16 @@ export function wrapTextForForm(
     const body = para.slice(leadingPrefix.length);
     const words = body.split(/\s+/).filter((w) => w.length > 0);
 
+    // No body words after the leading prefix — typically a label-only
+    // paragraph the user is mid-typing (e.g. "1. " or "   a. ") or an
+    // intentional empty list item between content paragraphs. Preserve
+    // the prefix as a standalone line; without this branch we'd drop
+    // the line entirely and the user's "1." would silently vanish.
+    if (words.length === 0) {
+      lines.push(leadingPrefix);
+      continue;
+    }
+
     let currentPrefix = leadingPrefix;
     let currentText = '';
 

--- a/src/services/pdf/textWrap.ts
+++ b/src/services/pdf/textWrap.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared text-wrap helper for NAVMC form PDF generators.
+ *
+ * Both NAVMC 10274 and NAVMC 118(11) overlay user-typed multi-paragraph
+ * text into fixed-width boxes on a pre-printed PDF. Wrapping needs to
+ * respect SECNAV M-5216.5 Ch 7 ¶13 and MCO 1070.12K paragraph rules
+ * (which 1070.12K incorporates by reference for personnel-record entries):
+ *
+ *   "Do not indent the continuation lines of a subparagraph."
+ *
+ * Meaning the continuation of a wrapped paragraph aligns with the
+ * START of the paragraph TEXT (the position immediately after the
+ * paragraph label, not at the box's left margin). For typed text
+ * with no SECNAV label, the continuation should at minimum preserve
+ * the user's leading whitespace.
+ *
+ * Issue #24 — before this helper, both NAVMC generators had identical
+ * `wrapText` functions that just did `currentLine = word` on wrap,
+ * dropping any leading whitespace + label prefix on every continuation
+ * line. Sub-paragraphs like "  a. Long text..." wrapped to "a." (level-2
+ * indent) on line 1 and column-0 on line 2 — wrong per MCO 1070.12K.
+ *
+ * SECNAV labels recognized at the start of a line (after optional
+ * leading whitespace):
+ *
+ *   "1." / "23."             — Arabic with period (level 1)
+ *   "a." / "Z."              — single letter with period (level 2)
+ *   "(1)" / "(23)"           — parenthesized arabic (level 3)
+ *   "(a)" / "(Z)"            — parenthesized letter (level 4)
+ *
+ * Underlined-numeric labels (levels 5+) only appear in the LaTeX layer
+ * (rendered via \uline{}); they don't show up in raw user-typed text in
+ * a form textarea, so they're not detected here.
+ */
+
+interface PdfFontLike {
+  widthOfTextAtSize(text: string, size: number): number;
+}
+
+const SECNAV_LABEL_REGEX = /^(\s*)((?:\d+\.|\([0-9a-zA-Z]+\)|[a-zA-Z]\.))(\s+)/;
+
+/**
+ * Split `text` into rendered lines that fit within `maxWidth` at the
+ * given font/size. Preserves SECNAV-style hanging indent on
+ * continuation lines: the same number of leading spaces as the
+ * original paragraph's `leading-whitespace + label + trailing-space`
+ * prefix (or just the leading whitespace if no label is detected).
+ *
+ * Empty paragraphs (blank lines in the input) survive as empty
+ * strings in the output, so the caller's `drawMultilineText` produces
+ * a visible blank line.
+ */
+export function wrapTextForForm(
+  text: string,
+  maxWidth: number,
+  font: PdfFontLike,
+  fontSize: number
+): string[] {
+  const lines: string[] = [];
+  const paragraphs = text.split('\n');
+
+  for (const para of paragraphs) {
+    if (!para.trim()) {
+      lines.push('');
+      continue;
+    }
+
+    // Compute the leading prefix and the hang prefix.
+    //
+    // labelMatch present  → leadingPrefix = "  a. " (whitespace + label
+    //                                                + trailing space)
+    //                       hangPrefix    = "     " (spaces, same width)
+    //
+    // No label, leading WS → leadingPrefix = hangPrefix = "  "
+    //
+    // No leading WS         → leadingPrefix = hangPrefix = ""
+    const labelMatch = para.match(SECNAV_LABEL_REGEX);
+    const leadingPrefix = labelMatch
+      ? labelMatch[0]
+      : (para.match(/^\s*/)?.[0] ?? '');
+    const hangPrefix = ' '.repeat(leadingPrefix.length);
+
+    // The body is everything after the leading prefix.
+    const body = para.slice(leadingPrefix.length);
+    const words = body.split(/\s+/).filter((w) => w.length > 0);
+
+    let currentPrefix = leadingPrefix;
+    let currentText = '';
+
+    for (const word of words) {
+      const candidate = currentText ? `${currentText} ${word}` : word;
+      const fullLine = currentPrefix + candidate;
+
+      if (font.widthOfTextAtSize(fullLine, fontSize) > maxWidth && currentText) {
+        // Wrap: push the current line, start a new continuation line.
+        lines.push(currentPrefix + currentText);
+        currentPrefix = hangPrefix;
+        currentText = word;
+      } else {
+        currentText = candidate;
+      }
+    }
+
+    if (currentText) {
+      lines.push(currentPrefix + currentText);
+    }
+  }
+
+  return lines;
+}


### PR DESCRIPTION
## Summary

Closes #24.

NAVMC 10274 (Administrative Action) and NAVMC 118(11) (Page 11 Entry) overlay user-typed multi-paragraph text into fixed-width boxes on pre-printed PDFs. Two layers were broken:

1. **PDF wrap** (duplicated per generator): dropped leading whitespace and SECNAV labels on continuation lines.
2. **Editor round-trip** (`VariableChipEditor`): silently stripped leading whitespace on every save/load and didn't accept the Tab key.

A sub-paragraph the user typed as

```
  a. Sub-paragraph long enough to wrap onto another line.
```

rendered as

```
  a. Sub-paragraph long enough to
wrap onto another line.            ← continuation at column 0 (WRONG)
```

instead of the SECNAV M-5216.5 Ch 7 ¶13 / MCO 1070.12K canonical:

```
  a. Sub-paragraph long enough to
     wrap onto another line.       ← hangs after label (CORRECT)
```

## What changes

### Wrap helper — new shared module

| File | Change |
|---|---|
| `src/services/pdf/textWrap.ts` (new) | Shared `wrapTextForForm` with SECNAV hanging-indent logic. Replaces the two duplicated inline helpers. Tabs normalized to 4 spaces up front for predictable rendering width. Label-only paragraphs (`"1. "`, `"   a. "`) survive as standalone lines. |
| `src/services/pdf/navmc10274Generator.ts` | Removed inline `wrapText`, imports the shared helper. |
| `src/services/pdf/navmc11811Generator.ts` | Same. |

Algorithm: detects an optional SECNAV label (`1.`, `a.`, `(1)`, `(a)`, capital and multi-digit variants — levels 1–4), computes a `hangPrefix` of equal-length spaces, prepends it to every continuation line so the wrap aligns with where the paragraph TEXT begins.

### Editor — Tab key + leading-whitespace round-trip

| File | Change |
|---|---|
| `src/components/ui/variable-chip-editor.tsx` | New `tabInsertsSpaces` opt-in prop: when true, Tab inserts 4 literal spaces (matching the wrap helper's `TAB_AS_SPACES`). `parseOptions: { preserveWhitespace: 'full' }` on initial parse and on `setContent`. `editorToText` strips trailing-only whitespace (was `.trim()`). `whitespace-pre-wrap` CSS overrides Tailwind `prose` so multi-spaces render literally. |
| `src/components/editor/Form6105Section.tsx` | Opt in to Tab→4-spaces on NAVMC 10274 Field 12 (supplementalInfo) and Field 13 (proposedAction). |
| `src/components/editor/Form11811Section.tsx` | Opt in to Tab→4-spaces on NAVMC 118(11) Page-11 left and right. |

The `tabInsertsSpaces` prop is opt-in (default `false`) so correspondence body paragraphs in `ParagraphsEditor` (where indent is handled by `paragraph.level` rather than leading whitespace) keep their default focus-next-element Tab behavior.

## Test coverage

- **13/13** unit probes pass (`/tmp/wrap-test.ts`): no-label, leading WS, level 1/2/3 labels, blank lines, tabs (leading single, leading double, mid-line), label-only paragraphs, mixed multi-paragraph.
- **19/19** edge-case probes inspected (`/tmp/wrap-edge-cases.ts`): empty string, whitespace-only paragraph, single-word longer than maxWidth, multi-digit / capital labels, non-SECNAV patterns (`"1.A"`, `". "`, `"1.1."`) correctly NOT detected, etc.
- **All default-content fields** (`/tmp/wrap-all-fields.ts`) wrap correctly with realistic NAVMC content.

## Verification

- `tsc --noEmit` clean
- `npm run build` clean
- `eslint` 11 problems = main baseline, no new findings
- All 4 CI checks green
- Version bumped `1.1.30` → `1.1.31`

## Test plan in Cloudflare preview

1. Open the app, switch to **Forms** category, select **NAVMC 10274 — Administrative Action**.
2. In **Supplemental Information**, paste:
   ```
   1. The Marine failed to meet PFT standards per MCO 6100.13A.

      a. Pull-ups: 2 (minimum 4 required)
      b. 3-Mile Run: 28:45 (28:00 max) — this paragraph is intentionally long enough to wrap onto multiple lines so we can verify hanging indent on continuation.

   2. Conclusion: remedial PT required.
   ```
   Verify the editor shows leading spaces literally (not stripped).
3. With cursor in the field, press **Tab** — 4 spaces should appear at the cursor position.
4. Click **Download** to generate the PDF. Verify:
   - `1.` and `2.` at the box's left margin
   - `a.` and `b.` indented one level under `1.`'s text
   - Long paragraphs wrap with continuation lines hanging at the START of the paragraph TEXT (not column 0)
5. Repeat for **NAVMC 118(11) — Page 11 Entry**.
6. Open the **SECNAV correspondence** flow, add a body paragraph, press Tab inside it — should still move focus to the next field (correspondence body uses `paragraph.level` for indent, not leading whitespace).
