### PR TITLE
docs: annotate CodeQL incomplete-sanitization false positives

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,10 @@ enableConsoleCapture()
 
 // Migrate legacy localStorage keys to current naming convention
 function migrateLocalStorage() {
+  // codeql[js/incomplete-sanitization]: false positive — these are hardcoded
+  // string constants, each containing exactly one `]` (the obfuscation sentinel
+  // that hides the legacy "libo" name from grep). Non-global replace is
+  // correct since each string has exactly one `]` to remove.
   const legacyPrefixes = ['l]ibo-secured-', 'l]ibo_', 'l]ibo-', 'L]IBO_'].map(p => p.replace(']', ''));
   const keysToMigrate: [string, string][] = [];
 

--- a/src/services/latex/escaper.ts
+++ b/src/services/latex/escaper.ts
@@ -21,6 +21,8 @@ export function escapeLatex(str: string | undefined | null): string {
   // Phase 2: Escape simple chars that don't introduce braces
   // Phase 3: Escape { and } from the original text
   // Phase 4: Replacements that introduce new { } (safe now — won't be re-escaped)
+  // codeql[js/incomplete-sanitization]: false positive — sentinel pattern
+  // (Phase 1 below) escapes all `\` from input before subsequent replaces add their own.
   let result = protectedStr
     .replace(/\\/g, 'ZZZTEXTBACKSLASHZZZ')
     .replace(/&/g, '\\&')
@@ -40,6 +42,8 @@ export function escapeLatex(str: string | undefined | null): string {
   // Restore placeholders with highlighted LaTeX rendering
   // Escape underscores in the placeholder name for LaTeX text mode
   for (const [key, name] of Object.entries(placeholderMap)) {
+    // codeql[js/incomplete-sanitization]: false positive — `name` is captured
+    // from /\{\{([A-Za-z0-9_]+)\}\}/, which cannot contain `\`.
     const escapedName = name.replace(/_/g, '\\_');
     result = result.replace(key, `\\fcolorbox{orange}{yellow!30}{\\textsf{\\small ${escapedName}}}`);
   }
@@ -152,6 +156,8 @@ export function formatAddressForLatex(address: string | undefined | null, maxLen
  */
 export function escapeLatexUrl(url: string | undefined | null): string {
   if (!url) return '';
+  // codeql[js/incomplete-sanitization]: false positive — sentinel pattern
+  // (Phase 1 below) escapes all `\` from input before subsequent replaces add their own.
   return url
     // Phase 1: backslash → sentinel (so the escape `\` below don't recurse).
     .replace(/\\/g, 'ZZZURLBACKSLASHZZZ')
@@ -219,7 +225,9 @@ export function convertRichTextToLatex(text: string): string {
 export function highlightPlaceholders(text: string): string {
   // Match {{PLACEHOLDER_NAME}} pattern (case insensitive)
   return text.replace(/\{\{([A-Za-z0-9_]+)\}\}/g, (_match, name) => {
-    // Escape underscores in the placeholder name for LaTeX text mode
+    // Escape underscores in the placeholder name for LaTeX text mode.
+    // codeql[js/incomplete-sanitization]: false positive — `name` is captured
+    // from /[A-Za-z0-9_]+/ above, which cannot contain `\`.
     const escapedName = name.replace(/_/g, '\\_');
     // Render as highlighted box with the placeholder name
     return `\\fcolorbox{orange}{yellow!30}{\\textsf{\\small ${escapedName}}}`;
@@ -255,6 +263,8 @@ export function processBodyText(text: string): string {
   // Now escape LaTeX special chars (but not our markers)
   // ORDER MATTERS: Use placeholders for replacements that introduce { }
   // so they don't get re-escaped by the { } escaping step.
+  // codeql[js/incomplete-sanitization]: false positive — sentinel pattern
+  // (first replace) escapes all `\` from input before subsequent replaces add their own.
   let result = converted
     .replace(/\\/g, 'ZZZTEXTBACKSLASHZZZ')
     .replace(/&/g, '\\&')
@@ -282,6 +292,8 @@ export function processBodyText(text: string): string {
   // Restore placeholders with highlighted LaTeX rendering
   // Escape underscores in the placeholder name for LaTeX text mode
   for (const [key, name] of Object.entries(placeholderMap)) {
+    // codeql[js/incomplete-sanitization]: false positive — `name` is captured
+    // from /\{\{([A-Za-z0-9_]+)\}\}/, which cannot contain `\`.
     const escapedName = name.replace(/_/g, '\\_');
     result = result.replace(key, `\\fcolorbox{orange}{yellow!30}{\\textsf{\\small ${escapedName}}}`);
   }

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -37,6 +37,8 @@ function escapeFlat(str: string | undefined | null): string {
   // in SwiftLaTeX. Pandoc also handles {\char36} correctly for DOCX.
   // ORDER MATTERS: Use placeholders for replacements that introduce { }
   // so they don't get re-escaped by the { } escaping step.
+  // codeql[js/incomplete-sanitization]: false positive — sentinel pattern
+  // (first replace) escapes all `\` from input before subsequent replaces add their own.
   return str
     .replace(/\\/g, 'ZZZTEXTBACKSLASHZZZ')
     .replace(/&/g, '\\&')
@@ -59,6 +61,8 @@ function escapeTabular(str: string | undefined | null): string {
   if (!str) return '';
   // ORDER MATTERS: Use placeholders for replacements that introduce { }
   // so they don't get re-escaped by the { } escaping step.
+  // codeql[js/incomplete-sanitization]: false positive — sentinel pattern
+  // (first replace) escapes all `\` from input before subsequent replaces add their own.
   return str
     .replace(/\\/g, 'ZZZTEXTBACKSLASHZZZ')
     .replace(/%/g, '\\%')
@@ -107,7 +111,10 @@ function processText(text: string): string {
     return key;
   });
 
-  // Escape LaTeX specials
+  // Escape LaTeX specials.
+  // codeql[js/incomplete-sanitization]: false positive — the first replace
+  // converts every `\` from input to `\textbackslash{}`, so subsequent replaces
+  // that add `\<char>` tokens don't double-escape original input backslashes.
   result = result
     .replace(/\\/g, '\\textbackslash{}')
     .replace(/&/g, '\\&')
@@ -125,6 +132,8 @@ function processText(text: string): string {
   // Restore placeholders with highlighted LaTeX rendering
   // The Lua filter converts \fcolorbox to bold {{NAME}} for DOCX
   for (const [key, name] of Object.entries(placeholderMap)) {
+    // codeql[js/incomplete-sanitization]: false positive — `name` is captured
+    // from /\{\{([A-Za-z0-9_]+)\}\}/, which cannot contain `\`.
     const escapedName = name.replace(/_/g, '\\_');
     result = result.replace(key, `\\fcolorbox{orange}{yellow!30}{\\textsf{\\small ${escapedName}}}`);
   }

--- a/tests/fuzz/semantic.fuzz.test.ts
+++ b/tests/fuzz/semantic.fuzz.test.ts
@@ -297,6 +297,8 @@ describe('LaTeX generator — semantic fuzz on the subject field', () => {
           // alphanumeric run "FUZZ_..._END" survives modulo case.
           const cleaned = subject.replace(/\s+/g, '').toLowerCase();
           const texCleaned = tex.replace(/\s+/g, '').toLowerCase();
+          // codeql[js/incomplete-sanitization]: false positive — test code
+          // mirroring the production escape, no untrusted input flows here.
           if (!texCleaned.includes(cleaned.replace(/_/g, '\\_'))
               && !texCleaned.includes(cleaned)) {
             throw new Error(


### PR DESCRIPTION
Adds inline `// codeql[js/incomplete-sanitization]: false positive — ...` comments at 12 sites that were dismissed via the GitHub UI in the CodeQL triage pass.

Each annotation documents why the site is a false positive so future contributors don't get tripped up by the chained-replace shape:

- **Sentinel pattern (6 sites)** — first replace converts `\\` from input to a sentinel before subsequent replaces add their own `\\`. `escapeLatex`, `escapeLatexUrl`, `processBodyText` (in `escaper.ts`), `escapeFlat`, `escapeTabular`, `processText` (in `flat-generator.ts`).
- **Charset-constrained input (4 sites)** — `name` is captured from `/\\{\\{([A-Za-z0-9_]+)\\}\\}/` and cannot contain backslashes.
- **Hardcoded constants (1 site)** — `legacyPrefixes` in `main.tsx` is a literal array of 4 strings, each with exactly one `]`.
- **Test code (1 site)** — fuzz-test assertion mirroring the production escape.

No behavior changes — comments only.

## Test plan

- [x] `tsc -b` clean
- [x] 1137 unit tests pass