### PR TITLE
chore(lint): fix 11 errors (preserve-caught-error, no-useless-assignment, react-hooks/immutability)

### DIFF
--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -403,8 +403,12 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
     return applyPlaceholdersToNavmc11811(useFormStore.getState().navmc11811, values);
   }, []);
 
-  // Generate PDF for a single row with retry logic for ENGINE_RESET_NEEDED
-  const generatePdfForRow = useCallback(async (values: PlaceholderValue, retryCount = 0): Promise<Uint8Array> => {
+  // Generate PDF for a single row with retry logic for ENGINE_RESET_NEEDED.
+  // Retry is implemented as an in-function loop rather than recursion so the
+  // useCallback doesn't need to refer to itself before initialization (which
+  // tripped react-hooks/immutability and required a Temporal-Dead-Zone-safe
+  // pattern that's only obvious at runtime, not to the React Compiler).
+  const generatePdfForRow = useCallback(async (values: PlaceholderValue): Promise<Uint8Array> => {
     // Forms mode: use pdf-lib form generators
     if (isFormsMode) {
       if (formType === 'navmc_10274') {
@@ -428,29 +432,32 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
       throw new Error(`Unknown form type: ${formType}`);
     }
 
-    // Correspondence mode: use LaTeX compilation
+    // Correspondence mode: use LaTeX compilation, retrying on ENGINE_RESET_NEEDED
     const modifiedStore = createModifiedStore(values);
     const { texFiles } = generateAllLatexFiles(modifiedStore);
 
-    try {
-      // Compile LaTeX to PDF
-      const pdf = await compile(texFiles);
-      if (!pdf) {
-        throw new Error('PDF compilation failed');
-      }
-      return pdf;
-    } catch (err) {
-      // Handle ENGINE_RESET_NEEDED with retry
-      if (err instanceof Error && err.message === 'ENGINE_RESET_NEEDED' && retryCount < MAX_RETRIES) {
-        debug.log('Batch', `Engine reset detected, waiting for ready and retrying (attempt ${retryCount + 1}/${MAX_RETRIES})...`);
-        const ready = await waitForReady(5000);
-        if (ready) {
-          return generatePdfForRow(values, retryCount + 1);
+    for (let retryCount = 0; retryCount <= MAX_RETRIES; retryCount++) {
+      try {
+        const pdf = await compile(texFiles);
+        if (!pdf) {
+          throw new Error('PDF compilation failed');
         }
-        throw new Error('Engine failed to recover after reset');
+        return pdf;
+      } catch (err) {
+        if (err instanceof Error && err.message === 'ENGINE_RESET_NEEDED' && retryCount < MAX_RETRIES) {
+          debug.log('Batch', `Engine reset detected, waiting for ready and retrying (attempt ${retryCount + 1}/${MAX_RETRIES})...`);
+          const ready = await waitForReady(5000);
+          if (ready) {
+            continue;
+          }
+          throw new Error('Engine failed to recover after reset', { cause: err });
+        }
+        throw err;
       }
-      throw err;
     }
+    // Unreachable: the loop either returns a pdf or throws within the catch.
+    // Present so TypeScript doesn't complain about a Promise<Uint8Array | undefined>.
+    throw new Error('Engine failed to recover after reset (max retries exceeded)');
   }, [createModifiedStore, createModifiedNavmc10274, createModifiedNavmc11811, compile, waitForReady, isFormsMode, formType, navmc10274Templates, navmc11811Template]);
 
   // Check if we're ready to generate (depends on mode)

--- a/src/lib/encoding.ts
+++ b/src/lib/encoding.ts
@@ -21,7 +21,7 @@ export function base64ToUint8Array(base64: string): Uint8Array {
     return bytes;
   } catch (err) {
     debug.error('Encoding', 'Failed to decode base64 string', err);
-    throw new Error('Invalid base64 string');
+    throw new Error('Invalid base64 string', { cause: err });
   }
 }
 
@@ -37,7 +37,7 @@ export function uint8ArrayToBase64(bytes: Uint8Array): string {
     return btoa(binary);
   } catch (err) {
     debug.error('Encoding', 'Failed to encode to base64', err);
-    throw new Error('Failed to encode bytes to base64');
+    throw new Error('Failed to encode bytes to base64', { cause: err });
   }
 }
 
@@ -57,7 +57,7 @@ export async function blobToUint8Array(blob: Blob): Promise<Uint8Array> {
     return new Uint8Array(arrayBuffer);
   } catch (err) {
     debug.error('Encoding', 'Failed to convert blob to Uint8Array', err);
-    throw new Error('Failed to read blob data');
+    throw new Error('Failed to read blob data', { cause: err });
   }
 }
 

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -258,7 +258,7 @@ function buildClassificationHeaders(data: Partial<DocumentData>): string {
   const classLevel = data.classLevel;
   if (!classLevel || classLevel === 'unclassified') return '';
 
-  let marking = '';
+  let marking: string;
   if (classLevel === 'cui') marking = 'CUI';
   else if (classLevel === 'custom' && data.customClassification) marking = data.customClassification;
   else {
@@ -656,8 +656,14 @@ ${trimLastRow(sigRows.map(r => ` & ${r} & \\\\`))}
  * MOA/MOU: overscored (horizontal rule above name) per SECNAV M-5216.5 Fig 10-5
  * Joint/Joint Memo: no overscoring per Ch 7 Fig 7-4 */
 function buildDualSignature(data: Partial<DocumentData>, variant: 'moa' | 'joint' | 'joint_memo'): string {
-  let juniorName = '', juniorRank = '', juniorTitle = '';
-  let seniorName = '', seniorRank = '', seniorTitle = '';
+  // juniorRank/seniorRank only populate in the 'moa' branch (joint variants
+  // don't carry rank); default to '' so the rank-row rendering below still
+  // works on joint variants. juniorName/Title and seniorName/Title are
+  // always assigned in both branches.
+  let juniorName: string, juniorTitle: string;
+  let seniorName: string, seniorTitle: string;
+  let juniorRank = '';
+  let seniorRank = '';
 
   if (variant === 'moa') {
     const junFirst = capitalizeWord(data.juniorSigName?.split(' ')[0]);

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -342,7 +342,7 @@ export function generateSignatoryTex(store: DocumentStore): string {
   // Set signature type and image
   // signatureType: 'none' = just typed name, 'image' = uploaded signature, 'digital' = empty field for CAC signing
   const signatureType = data.signatureType || 'none';
-  let signatureConfigTex = '';
+  let signatureConfigTex: string;
 
   if (signatureType === 'image' && data.signatureImage?.data) {
     // Use uploaded signature image


### PR DESCRIPTION
## Summary

Knocks down the 11 easiest lint errors. Lint goes from **33 → 22** problems.

## Changes

| Rule | Count | Files | Fix |
|--|--|--|--|
| `preserve-caught-error` | 4 | `encoding.ts` (3 sites), `BatchModal.tsx` (1 site) | Chain caught error via `new Error(msg, { cause: err })`. Catches already `debug.error` the underlying error; adding `cause` makes the chain available on the rethrown `Error` too. |
| `no-useless-assignment` | 6 | `flat-generator.ts` (5), `generator.ts` (1) | Drop dead initial empty-string writes that were always overwritten by the if/else chain immediately below. Convert to typed declarations without an initial value where every branch assigns. |
| `react-hooks/immutability` | 1 | `BatchModal.tsx` | `generatePdfForRow` was recursively self-calling for the `ENGINE_RESET_NEEDED` retry — technically TDZ-unsafe at declaration time even though it works at runtime. Refactored to a `for` loop with `continue`. Same retry semantics, no self-reference. |

## Test plan

- [x] 1137 unit tests pass
- [x] `tsc -b` clean
- [x] Lint: 33 → 22 problems (11 errors gone)
- [x] No behavior changes — equivalent error messages, equivalent retry semantics