### PR TITLE
fix(latex): render § (and other symbols) instead of failing the PDF compile

### DIFF
--- a/src/services/latex/escaper.ts
+++ b/src/services/latex/escaper.ts
@@ -1,4 +1,75 @@
 /**
+ * Map non-ASCII symbols to LaTeX commands that render with the FONTS WE BUNDLE.
+ *
+ * Why this exists: the offline SwiftLaTeX engine ships a curated 85-file font
+ * set (Computer Modern + Times + Courier). `textcomp` is loaded, which routes
+ * symbols like `§` (U+00A7) to the TS1 ("text companion") encoding. But the TS1
+ * Computer Modern metrics (`tcrm*.tfm`) are NOT in the bundle, so a single `§`
+ * — e.g. a routine "5 U.S.C. § 552a" citation — makes pdfTeX abort with
+ * `Font TS1/cmr/m/n/12=tcrm1200 ... Metric (TFM) file not found` and produces
+ * NO PDF at all. (On the deployed site the engine would try to fetch the
+ * missing metric and 404; on air-gap it fails outright.)
+ *
+ * Each mapping below targets a glyph in a font we DO ship:
+ *   - `\S \P \dag \ddag` fall back to `\mathsection` etc. in `cmsy` (bundled).
+ *   - `\ensuremath{...}` symbols (°, ×, ÷, ±, µ, •, ·) come from cmsy/cmmi.
+ *   - `\textcircled{c}` composes a circle + letter from the base font.
+ *   - Smart quotes / dashes / ellipsis map to their classic ASCII-LaTeX forms.
+ *
+ * Anything NOT mapped here that is also non-ASCII and not a letter/combining
+ * mark is dropped by the fail-safe in `applyLatexSymbolFallback` — better to
+ * lose one exotic glyph than to fatal the whole compile. Letters (incl.
+ * accented: é, ü, ñ …) are preserved; inputenc composes them from the base
+ * font. Extend SYMBOL_REPLACEMENTS as new symbols are reported.
+ *
+ * NOTE: this is for the PDF (SwiftLaTeX) path only. The DOCX/pandoc path
+ * (flat-generator.ts) handles Unicode natively and must NOT use this.
+ */
+const SYMBOL_REPLACEMENTS: Array<[RegExp, string]> = [
+  [/§/g, '\\S{}'],            // § section sign
+  [/¶/g, '\\P{}'],            // ¶ pilcrow
+  [/†/g, '\\dag{}'],          // † dagger
+  [/‡/g, '\\ddag{}'],         // ‡ double dagger
+  [/©/g, '\\textcircled{c}'], // © copyright
+  [/®/g, '\\textcircled{r}'], // ® registered
+  [/™/g, '\\textsuperscript{TM}'], // ™ trademark
+  [/°/g, '\\ensuremath{^\\circ}'], // ° degree
+  [/±/g, '\\ensuremath{\\pm}'],    // ± plus-minus
+  [/×/g, '\\ensuremath{\\times}'], // × multiplication
+  [/÷/g, '\\ensuremath{\\div}'],   // ÷ division
+  [/µ/g, '\\ensuremath{\\mu}'],    // µ micro
+  [/•/g, '\\ensuremath{\\bullet}'], // • bullet
+  [/·/g, '\\ensuremath{\\cdot}'],  // · middle dot
+  [/…/g, '\\ldots{}'],        // … ellipsis
+  [/–/g, '--'],               // – en dash
+  [/—/g, '---'],              // — em dash
+  [/‘/g, '`'],                // ' left single quote
+  [/’/g, "'"],                // ' right single quote / apostrophe
+  [/“/g, '``'],               // " left double quote
+  [/”/g, "''"],               // " right double quote
+];
+
+/**
+ * Apply the bundled-font symbol map, then a fail-safe that strips any remaining
+ * non-ASCII that is not a letter or combining mark — so an unmapped symbol can
+ * never hard-fail the compile. Must run AFTER the special-char escaping phase
+ * (the replacements introduce `\` and `{}` that must not be re-escaped).
+ */
+function applyLatexSymbolFallback(text: string): string {
+  let out = text;
+  for (const [re, rep] of SYMBOL_REPLACEMENTS) {
+    out = out.replace(re, rep);
+  }
+  // Fail-safe: drop unmapped non-ASCII symbols/punctuation. ASCII (incl.
+  // whitespace and the newlines body text relies on) is kept via \p{ASCII};
+  // letters (\p{L}) and marks (\p{M}) are kept so accented names still render
+  // via inputenc. Only stray non-ASCII *symbols* (emoji, exotic glyphs) are
+  // removed — they have no bundled font and a raw one would fatal the compile.
+  out = out.replace(/[^\p{ASCII}\p{L}\p{M}]/gu, '');
+  return out;
+}
+
+/**
  * Escape special LaTeX characters (with placeholder support)
  */
 export function escapeLatex(str: string | undefined | null): string {
@@ -38,6 +109,11 @@ export function escapeLatex(str: string | undefined | null): string {
     .replace(/ZZZDOLLARZZZ/g, '{\\char36}')
     .replace(/ZZZTILDEZZZ/g, '\\textasciitilde{}')
     .replace(/ZZZCARETZZZ/g, '\\textasciicircum{}');
+
+  // Phase 5: map non-ASCII symbols (§, ¶, ©, °, …) to bundled-font LaTeX so a
+  // single such character can't fatal the offline compile. Runs after escaping
+  // because it introduces `\` and `{}` that must not be re-escaped.
+  result = applyLatexSymbolFallback(result);
 
   // Restore placeholders with highlighted LaTeX rendering
   // Escape underscores in the placeholder name for LaTeX text mode
@@ -282,6 +358,12 @@ export function processBodyText(text: string): string {
 
   // Note: Don't escape _ or * as they're used for formatting
   // The rich text conversion will handle them
+
+  // Map non-ASCII symbols (§, ¶, ©, °, …) to bundled-font LaTeX so a single
+  // such character in a paragraph can't fatal the offline compile. Runs after
+  // escaping (it introduces `\` and `{}`) but before the rich-text marker
+  // conversion, which only touches `*` / `_` markers.
+  result = applyLatexSymbolFallback(result);
 
   // Convert newlines to LaTeX line breaks so input line breaks appear in PDF
   result = result.replace(/\n/g, '\\\\\n');

--- a/tests/fuzz/semantic.fuzz.test.ts
+++ b/tests/fuzz/semantic.fuzz.test.ts
@@ -147,9 +147,19 @@ describe('escaper — semantic fuzz', () => {
     );
   });
 
-  it('formatSubjectForLatex output is non-empty for non-empty input', () => {
+  it('formatSubjectForLatex output is non-empty for input with renderable content', () => {
+    // Precondition refined to require at least one RENDERABLE character (ASCII
+    // printable or a Unicode letter/mark). The escaper intentionally drops
+    // unmapped non-ASCII *symbols* (emoji, exotic glyphs) because the offline
+    // SwiftLaTeX font set can't render them and a raw one would fatal the whole
+    // compile (see tests/regressions/latex-section-sign-tcrm-missing.test.ts).
+    // So a subject made ENTIRELY of such symbols (e.g. "👨‍👩‍👧‍👦") legitimately
+    // sanitizes to empty — that is the safe outcome, not a bug. The real
+    // invariant is: any subject containing renderable content yields non-empty
+    // LaTeX.
+    const hasRenderable = (s: string) => /[\x21-\x7E]/.test(s) || /\p{L}|\p{M}/u.test(s);
     fc.assert(
-      fc.property(adversarialString.filter((s) => s.trim().length > 0), (s) => {
+      fc.property(adversarialString.filter((s) => s.trim().length > 0 && hasRenderable(s)), (s) => {
         const out = formatSubjectForLatex(s);
         expect(out.length).toBeGreaterThan(0);
       }),

--- a/tests/regressions/latex-section-sign-tcrm-missing.test.ts
+++ b/tests/regressions/latex-section-sign-tcrm-missing.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression: a section sign `§` (U+00A7) in any user field made the offline
+ * PDF compile abort with no output.
+ *
+ * Reported failure (e.g. a routine "5 U.S.C. § 552a Privacy Act of 1972"
+ * citation):
+ *
+ *   LaTeX Font Warning: Font shape `TS1/ptm/m/n' undefined,
+ *                       using `TS1/cmr/m/n' instead for symbol `textsection'
+ *   ! Font TS1/cmr/m/n/12=tcrm1200 at 12.0pt not loadable:
+ *                       Metric (TFM) file not found.
+ *   ! ==> Fatal error occurred, no output PDF file produced!
+ *
+ * Root cause: `textcomp` is loaded in the bundle, so `§` routes to the TS1
+ * ("text companion") encoding as `\textsection`. The TS1 Computer Modern
+ * metrics (`tcrm*.tfm`) are NOT in the curated 85-file offline font set the
+ * SwiftLaTeX engine ships, so pdfTeX can't load `tcrm1200.tfm` and aborts the
+ * whole document. The (`cmsy`-backed) `\S` command IS available offline.
+ *
+ * Fix: the PDF-path escaper (`escapeLatex` / `processBodyText` in
+ * services/latex/escaper.ts) maps `§` → `\S{}` (and a set of other common
+ * non-ASCII symbols → bundled-font LaTeX), with a fail-safe that drops any
+ * unmapped non-ASCII symbol so a stray glyph can never fatal the compile.
+ * Letters (incl. accented) are preserved.
+ *
+ * This is a unit-level regression because the integration compile matrix uses
+ * a full `xelatex` install — which HAS `tcrm1200.tfm` — and therefore cannot
+ * reproduce a bundled-font-set gap. We pin the escaper output instead: the
+ * generated LaTeX must never route these symbols through `\textsection` (the
+ * TS1 path that needs the missing metric).
+ */
+import { describe, it, expect } from 'vitest';
+import { escapeLatex, processBodyText, formatSubjectForLatex } from '@/services/latex/escaper';
+
+describe('section sign / TS1 symbol regression (tcrm1200.tfm not in offline bundle)', () => {
+  it('maps § to \\S{} (the exact reported citation) and never emits \\textsection', () => {
+    const out = escapeLatex('5 U.S.C. § 552a Privacy Act of 1972');
+    expect(out).toContain('\\S{}');
+    expect(out).not.toContain('\\textsection');
+    // The surrounding text must survive intact.
+    expect(out).toContain('5 U.S.C.');
+    expect(out).toContain('552a Privacy Act of 1972');
+  });
+
+  it('handles repeated and body-text § the same way (processBodyText path)', () => {
+    const out = processBodyText('See §§ 1 and 2, and ¶ 3.');
+    expect(out).not.toContain('\\textsection');
+    expect(out).not.toContain('\\textparagraph');
+    expect((out.match(/\\S\{\}/g) || []).length).toBe(2);
+    expect(out).toContain('\\P{}');
+  });
+
+  it('routes § in the subject line through the same safe mapping', () => {
+    const out = formatSubjectForLatex('REQUEST UNDER 5 U.S.C. § 552');
+    expect(out).toContain('\\S{}');
+    expect(out).not.toContain('\\textsection');
+  });
+
+  it('maps the other common textcomp/TS1 symbols to bundled-font commands', () => {
+    // Each of these would otherwise route to a TS1 symbol needing an un-bundled
+    // tc*.tfm metric. Assert none of the TS1 \text* command names appear.
+    const out = escapeLatex('Acme© Corp™ Beta® 98.6° ± 0.5° 3×4 6÷2 5µm • · …');
+    for (const ts1 of [
+      '\\textsection',
+      '\\textparagraph',
+      '\\textcopyright',
+      '\\texttrademark',
+      '\\textregistered',
+      '\\textdegree',
+      '\\textbullet',
+    ]) {
+      expect(out, `should not emit ${ts1}`).not.toContain(ts1);
+    }
+    // Spot-check a couple of the safe forms are present.
+    expect(out).toContain('\\textcircled{c}'); // ©
+    expect(out).toContain('\\ensuremath{^\\circ}'); // °
+  });
+
+  it('preserves letters including accented names (composed via inputenc)', () => {
+    const out = escapeLatex('From: Col Müller-García, José Ñoño');
+    expect(out).toContain('Müller-García');
+    expect(out).toContain('José');
+    expect(out).toContain('Ñoño');
+  });
+
+  it('fail-safe: an unmapped non-ASCII symbol is dropped, not fatal', () => {
+    // Emoji / exotic glyphs have no bundled font; dropping them keeps the
+    // compile alive instead of aborting the whole document.
+    const out = escapeLatex('Status: done 😀 ✅ 🎯 — ship it');
+    // No raw non-ASCII symbol survives (would risk a missing-glyph fatal)...
+    expect(out).not.toMatch(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u);
+    // ...but the surrounding ASCII text and the em dash mapping are intact.
+    expect(out).toContain('Status: done');
+    expect(out).toContain('ship it');
+    expect(out).toContain('---'); // em dash → ---
+  });
+
+  it('smart quotes / dashes / ellipsis map to classic ASCII-LaTeX forms', () => {
+    const out = escapeLatex('He said “hello” to ‘all’ — wait… really–truly');
+    expect(out).toContain('``hello\'\'');
+    expect(out).toContain('`all\'');
+    expect(out).toContain('---'); // em dash
+    expect(out).toContain('--');  // en dash
+    expect(out).toContain('\\ldots{}');
+  });
+
+  it('does not double-escape: the introduced backslashes survive intact', () => {
+    // The symbol map runs AFTER the \-escaping phase, so its own backslashes
+    // must NOT have been turned into \textbackslash{}.
+    const out = escapeLatex('§');
+    expect(out).toBe('\\S{}');
+    expect(out).not.toContain('textbackslash');
+  });
+});


### PR DESCRIPTION
## The bug

A user's document failed to generate a PDF, repeatedly, with this error:

```
! Font TS1/cmr/m/n/12=tcrm1200 at 12.0pt not loadable: Metric (TFM) file not found.
! ==> Fatal error occurred, no output PDF file produced!
l.12 ...5 U.S.C. ^^c2^^a7 552a Privacy Act of 1972}
```

**In plain terms:** they typed a section sign **`§`** — a routine "5 U.S.C. § 552a, Privacy Act of 1972" citation. That one character was enough to abort the *entire* PDF compile and produce nothing.

## Why it happened

- `textcomp` (loaded in our LaTeX bundle) routes `§` to the **TS1** font encoding as `\textsection`.
- TS1 needs the Computer Modern metric **`tcrm1200.tfm`**, which is **not** in the offline SwiftLaTeX font set we ship (85 fonts: Computer Modern + Times + Courier, no TS1 metrics).
- pdfTeX can't load the missing metric → fatal → no PDF.

Any document with `§`, `¶`, `©`, `°`, `†`, etc. hit the same wall. `§` is especially common because every U.S. Code / CFR citation uses it.

## The fix

The PDF-path escaper now maps these symbols to LaTeX commands that render with **fonts we already bundle**:

| Char | → | Renders from |
|--|--|--|
| `§` | `\S{}` | `cmsy` (bundled) via `\mathsection` |
| `¶` | `\P{}` | `cmsy` |
| `†` `‡` | `\dag{}` `\ddag{}` | `cmsy` |
| `©` `®` | `\textcircled{c/r}` | base font |
| `™` | `\textsuperscript{TM}` | base font |
| `°` `±` `×` `÷` `µ` `•` `·` | `\ensuremath{…}` | cmsy/cmmi |
| smart quotes, en/em dashes, `…` | classic ASCII-LaTeX | — |

The `§` glyph still renders — it just comes from a font we ship instead of the one we don't.

**Fail-safe:** any *unmapped* non-ASCII symbol (emoji, exotic glyphs) is dropped rather than passed through raw, so a single stray character can never again take down the whole compile. Letters — including accented names (Müller, García) — are preserved.

Scope: PDF (SwiftLaTeX) path only. The DOCX/pandoc path handles Unicode natively and is untouched.

## Test plan

- [x] New regression `tests/regressions/latex-section-sign-tcrm-missing.test.ts` pins the exact "5 U.S.C. § 552a" citation → `\S{}`, asserts no `\textsection` is ever emitted, covers the other symbols, accented-letter preservation, and the emoji fail-safe.
- [x] Refined one fuzz precondition (an all-symbol subject now legitimately sanitizes to empty — the safe outcome).
- [x] 1145 unit tests pass; lint + typecheck clean.

Note: the integration compile matrix uses a full `xelatex` (which *has* `tcrm1200.tfm`), so it structurally cannot reproduce a bundled-font-set gap — hence the unit-level regression.