### PR TITLE
fix(latex): use math-mode section sign — \S{} still routed to the missing TS1 font

### DIFF
--- a/src/services/latex/escaper.ts
+++ b/src/services/latex/escaper.ts
@@ -11,25 +11,36 @@
  * missing metric and 404; on air-gap it fails outright.)
  *
  * Each mapping below targets a glyph in a font we DO ship:
- *   - `\S \P \dag \ddag` fall back to `\mathsection` etc. in `cmsy` (bundled).
+ *   - § ¶ † ‡ use the EXPLICIT math-mode symbols (`\ensuremath{\mathsection}`
+ *     etc.), which draw from `cmsy` (bundled). The text-mode shorthands
+ *     (`\S`, `\P`, `\dag`, `\ddag`) must NOT be used here: on the modern
+ *     LaTeX kernel the bundle ships (textcomp integrated, 2020+), they
+ *     expand to `\textsection`/`\textparagraph`/… whose DEFAULT encoding is
+ *     TS1 — landing on the exact missing-`tcrm*.tfm` crash this map exists
+ *     to prevent. Verified empirically: a Times doc with `\S{}` loads
+ *     `ts1ptm.fd` + requests TS1 fonts; `\ensuremath{\mathsection}` loads
+ *     only `cmsy10`.
  *   - `\ensuremath{...}` symbols (°, ×, ÷, ±, µ, •, ·) come from cmsy/cmmi.
- *   - `\textcircled{c}` composes a circle + letter from the base font.
+ *   - `\textcircled{c}` composes a circle (cmsy `\bigcirc`) + letter from the
+ *     base font — verified to load no TS1 fonts.
  *   - Smart quotes / dashes / ellipsis map to their classic ASCII-LaTeX forms.
  *
  * Anything NOT mapped here that is also non-ASCII and not a letter/combining
  * mark is dropped by the fail-safe in `applyLatexSymbolFallback` — better to
  * lose one exotic glyph than to fatal the whole compile. Letters (incl.
  * accented: é, ü, ñ …) are preserved; inputenc composes them from the base
- * font. Extend SYMBOL_REPLACEMENTS as new symbols are reported.
+ * font. Extend SYMBOL_REPLACEMENTS as new symbols are reported — and when you
+ * do, prove the new form requests no TS1 fonts (see
+ * tests/integration/latex-compile-no-ts1.test.ts).
  *
  * NOTE: this is for the PDF (SwiftLaTeX) path only. The DOCX/pandoc path
  * (flat-generator.ts) handles Unicode natively and must NOT use this.
  */
 const SYMBOL_REPLACEMENTS: Array<[RegExp, string]> = [
-  [/§/g, '\\S{}'],            // § section sign
-  [/¶/g, '\\P{}'],            // ¶ pilcrow
-  [/†/g, '\\dag{}'],          // † dagger
-  [/‡/g, '\\ddag{}'],         // ‡ double dagger
+  [/§/g, '\\ensuremath{\\mathsection}'],   // § section sign (cmsy, NOT \S — TS1)
+  [/¶/g, '\\ensuremath{\\mathparagraph}'], // ¶ pilcrow (cmsy, NOT \P — TS1)
+  [/†/g, '\\ensuremath{\\dagger}'],        // † dagger (cmsy, NOT \dag — TS1)
+  [/‡/g, '\\ensuremath{\\ddagger}'],       // ‡ double dagger (cmsy, NOT \ddag — TS1)
   [/©/g, '\\textcircled{c}'], // © copyright
   [/®/g, '\\textcircled{r}'], // ® registered
   [/™/g, '\\textsuperscript{TM}'], // ™ trademark

--- a/src/services/latex/escaper.ts
+++ b/src/services/latex/escaper.ts
@@ -325,11 +325,23 @@ export function highlightPlaceholders(text: string): string {
  * Escape LaTeX and convert rich text markers
  */
 export function processBodyText(text: string): string {
+  // Normalize Windows (\r\n) and old-Mac (\r) line endings to \n FIRST.
+  // The newline→`\\` conversion below replaces only `\n`; a surviving `\r`
+  // reaches the .tex output, where TeX treats it as a line ending too. A
+  // pasted blank line with CRLF (`\r\n\r\n` — typical of Windows/NMCI
+  // clipboards) then becomes a REAL empty source line (a paragraph break)
+  // followed by a line containing only `\\` — which is exactly
+  // `! LaTeX Error: There's no line here to end.` and a dead compile.
+  // With pure-LF input this cannot happen (every \n is consumed by the
+  // conversion), so normalizing here fully closes the failure.
+  // Compile-level proof: tests/integration/latex-compile-crlf-paragraph.test.ts
+  const normalized = text.replace(/\r\n?/g, '\n');
+
   // First, extract and protect placeholders before escaping
   // Use keys without special chars (no underscores - they conflict with underline pattern)
   const placeholderMap: Record<string, string> = {};
   let placeholderIndex = 0;
-  const protectedText = text.replace(/\{\{([A-Za-z0-9_]+)\}\}/g, (_match, name) => {
+  const protectedText = normalized.replace(/\{\{([A-Za-z0-9_]+)\}\}/g, (_match, name) => {
     const key = `ZZZVARPLACEHOLDER${placeholderIndex++}ZZZ`;
     placeholderMap[key] = name;
     return key;
@@ -376,8 +388,28 @@ export function processBodyText(text: string): string {
   // conversion, which only touches `*` / `_` markers.
   result = applyLatexSymbolFallback(result);
 
-  // Convert newlines to LaTeX line breaks so input line breaks appear in PDF
-  result = result.replace(/\n/g, '\\\\\n');
+  // Convert newlines to LaTeX line breaks so input line breaks appear in PDF.
+  //
+  // Blank lines need special care: naively converting each `\n` to `\\`
+  // turns a pasted blank line (`\n\n`) into a source line containing ONLY
+  // `\\` — and main.tex sets `\raggedright` (standard for naval
+  // correspondence), under which a standalone `\\` is a fatal
+  // `! LaTeX Error: There's no line here to end.` (verified by bisecting a
+  // failing fixture down to exactly that line, then reproducing with
+  // article + \raggedright). So:
+  //   - leading/trailing newline runs are trimmed (a `\\` butted against
+  //     the paragraph edges adds nothing and risks the same error), and
+  //   - interior blank-line runs become `\\[\baselineskip]` — one line
+  //     break plus one blank line's worth of space, preserving the visual
+  //     gap the user typed while never emitting a standalone `\\`
+  //     (raggedright-safe, verified by compile).
+  // The sentinel keeps the single-`\n` pass from re-matching the newline
+  // that the blank-line replacement itself emits.
+  result = result
+    .replace(/^\n+|\n+$/g, '')
+    .replace(/\n{2,}/g, 'ZZZBLANKLINEZZZ')
+    .replace(/\n/g, '\\\\\n')
+    .replace(/ZZZBLANKLINEZZZ/g, '\\\\[\\baselineskip]\n');
 
   // Then convert rich text markers
   result = convertRichTextToLatex(result);

--- a/tests/integration/latex-compile-blank-lines.test.ts
+++ b/tests/integration/latex-compile-blank-lines.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Compile-level regression: paragraph text containing blank lines — pasted
+ * multi-block text, with either Unix (\n) or Windows (\r\n) line endings —
+ * must not abort the PDF compile.
+ *
+ * Field failure: a user pasted multi-paragraph test text into a paragraph
+ * box and the compile died with:
+ *
+ *   ! LaTeX Error: There's no line here to end.
+ *   l.9 \\
+ *
+ * TWO stacked root causes, isolated by bisecting the failing fixture's
+ * emitted body.tex inside the real template:
+ *
+ * 1. `processBodyText` converted each `\n` to `\\`, so a blank line
+ *    (`\n\n`) emitted a source line containing ONLY `\\`. main.tex sets
+ *    `\raggedright` (naval-correspondence standard), which redefines `\\` —
+ *    and under it a standalone `\\` is fatal. (Vanilla LaTeX accepts the
+ *    same shape, which is why a minimal repro outside the template
+ *    initially "proved" it harmless.)
+ *
+ * 2. CRLF input additionally leaked raw `\r` into the .tex (only `\n` was
+ *    converted). TeX treats bare `\r` as a line ending, so `\r\n\r\n`
+ *    produced a REAL empty source line (= \par) followed by `\\` — fatal
+ *    even without \raggedright.
+ *
+ * Fix in `processBodyText`: normalize `\r\n?` → `\n` on entry; trim
+ * leading/trailing newline runs; convert interior blank-line runs to
+ * `\\[\baselineskip]` (one break + one blank line of space — visually
+ * faithful, raggedright-safe, never a standalone `\\`).
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { compileFixture, formatFailure } from '../_helpers/compileLatex';
+import { buildBaseline } from '../_helpers/compileMatrix';
+
+const xelatexAvailable =
+  spawnSync('xelatex', ['--version'], { encoding: 'utf-8' }).status === 0;
+
+if (!xelatexAvailable) {
+  console.warn(
+    '[latex-compile-blank-lines] xelatex not found on PATH — suite will be SKIPPED.'
+  );
+}
+
+describe('blank lines in paragraph text compile (raggedright standalone-\\\\ regression)', () => {
+  it.skipIf(!xelatexAvailable)(
+    'LF blank lines: multi-block paste with \\n\\n compiles to PDF',
+    async () => {
+      const store = buildBaseline('naval_letter');
+      store.paragraphs = [
+        {
+          text:
+            'Per reference (a), the following applies.\n\n' +
+            'This second block was separated by a pasted blank line.\n' +
+            'And a plain continuation line.',
+          level: 0,
+        },
+        { text: 'A normal single-line paragraph after it.', level: 0 },
+      ];
+
+      const result = await compileFixture(store);
+      expect(result.ok, formatFailure('lf-blank-lines', result)).toBe(true);
+      expect(result.pdfBytes!.byteLength).toBeGreaterThan(1000);
+    },
+    120_000
+  );
+
+  it.skipIf(!xelatexAvailable)(
+    'CRLF blank lines: Windows-clipboard paste with \\r\\n\\r\\n compiles to PDF',
+    async () => {
+      const store = buildBaseline('naval_letter');
+      store.paragraphs = [
+        {
+          text:
+            'Per reference (a), the following applies.\r\n\r\n' +
+            'This second block was separated by a pasted blank line with CRLF endings.\r\n' +
+            'And a plain CRLF continuation line.',
+          level: 0,
+        },
+      ];
+
+      const result = await compileFixture(store);
+      expect(result.ok, formatFailure('crlf-blank-lines', result)).toBe(true);
+      expect(result.pdfBytes!.byteLength).toBeGreaterThan(1000);
+    },
+    120_000
+  );
+
+  it.skipIf(!xelatexAvailable)(
+    'leading/trailing newlines around paragraph text compile to PDF',
+    async () => {
+      const store = buildBaseline('naval_letter');
+      store.paragraphs = [
+        { text: '\n\nStarts after pasted leading blank lines and ends with some.\n\n', level: 0 },
+      ];
+
+      const result = await compileFixture(store);
+      expect(result.ok, formatFailure('edge-newlines', result)).toBe(true);
+      expect(result.pdfBytes!.byteLength).toBeGreaterThan(1000);
+    },
+    120_000
+  );
+});

--- a/tests/integration/latex-compile-no-ts1.test.ts
+++ b/tests/integration/latex-compile-no-ts1.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Compile-level regression: documents containing mapped non-ASCII symbols
+ * (§ ¶ † ‡ © ® ™ ° …) must compile WITHOUT ever requesting a TS1
+ * ("text companion") font.
+ *
+ * Why this test exists — a lesson learned the hard way:
+ *
+ * The production SwiftLaTeX engine ships a curated 85-file font set with NO
+ * TS1 metrics (no `tcrm*.tfm`). A field user's "5 U.S.C. § 552a" citation
+ * fatally aborted their PDF (`Font TS1/cmr/m/n/12=tcrm1200 ... not found`).
+ * The first fix mapped § → `\S{}` and was verified ONLY at the string level
+ * (unit tests) — but on the modern textcomp-integrated kernel, `\S` expands
+ * to `\textsection`, whose default encoding is TS1, so the exact same crash
+ * came back through our own output. The string-level tests passed; the
+ * compile still died.
+ *
+ * The structural gap: the integration matrix runs full xelatex, which HAS
+ * the TS1 fonts, so "it compiles" can never catch a bundled-font-set gap.
+ * What full TeX CAN tell us is whether the document *requests* TS1 at all:
+ * any TS1 usage loads a `ts1*.fd` font-definition file and records it in
+ * the log. If the log shows zero `ts1*.fd` loads and zero `tcrm` requests,
+ * the bundled engine — which lacks those files — cannot hit this crash.
+ *
+ * So this test compiles a fixture salted with every mapped symbol and
+ * asserts the log is TS1-silent. It fails on ANY future escaper change that
+ * routes a symbol through a TS1-defaulting command (\S, \P, \dag, \ddag,
+ * \textsection, \textregistered, …), even though the local compile succeeds.
+ *
+ * (The benign kernel line "Checking defaults for TS1/cmr" appears in every
+ * document and loads nothing — the assertions below deliberately target
+ * `.fd` loads and `tcrm` metric requests, not that line.)
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { compileFixture, formatFailure } from '../_helpers/compileLatex';
+import { buildBaseline } from '../_helpers/compileMatrix';
+
+const xelatexAvailable =
+  spawnSync('xelatex', ['--version'], { encoding: 'utf-8' }).status === 0;
+
+if (!xelatexAvailable) {
+  console.warn(
+    '[latex-compile-no-ts1] xelatex not found on PATH — suite will be SKIPPED.'
+  );
+}
+
+describe('mapped symbols never request TS1 fonts (bundled-engine safety)', () => {
+  it.skipIf(!xelatexAvailable)(
+    'naval letter with § ¶ † ‡ © ® ™ ° in body/subject/reference compiles with zero TS1 font loads',
+    async () => {
+      const store = buildBaseline('naval_letter');
+      store.formData.subject = 'REQUEST UNDER 5 U.S.C. § 552';
+      store.references = [
+        { letter: 'a', title: '5 U.S.C. § 552a Privacy Act of 1972' },
+      ];
+      store.paragraphs = [
+        { text: 'Per reference (a), 5 U.S.C. § 552a applies. See also ¶ 4.', level: 0 },
+        { text: 'Footnotes† and double daggers‡ plus Acme© Widget® Pro™.', level: 1 },
+        { text: 'Temperature 98.6° ± 0.5° at 3×4 µm spacing • item · dot…', level: 1 },
+      ];
+
+      const result = await compileFixture(store);
+      expect(result.ok, formatFailure('no-ts1-symbols', result)).toBe(true);
+      expect(result.pdfBytes).toBeDefined();
+      expect(result.pdfBytes!.byteLength).toBeGreaterThan(1000);
+
+      // The decisive assertion: the FULL log (not just the tail) must show
+      // no TS1 font-definition load and no tcrm metric request. On the
+      // bundled engine those files don't exist; requesting them is the crash.
+      const fullLog = await readFile(join(result.workDir, 'main.log'), 'utf-8');
+      expect(fullLog).not.toMatch(/ts1[a-z]*\.fd/i);
+      expect(fullLog).not.toMatch(/tcrm/i);
+      expect(fullLog).not.toMatch(/Font shape `TS1/);
+    },
+    120_000
+  );
+});

--- a/tests/regressions/latex-blank-line-no-line-to-end.test.ts
+++ b/tests/regressions/latex-blank-line-no-line-to-end.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression: blank lines in pasted paragraph text crashed the PDF compile
+ * with `! LaTeX Error: There's no line here to end.` (`l.9 \\`).
+ *
+ * Root cause #1: the `\n` → `\\` conversion turned a blank line (`\n\n`)
+ * into a source line containing ONLY `\\`. main.tex sets `\raggedright`
+ * (naval-correspondence standard), which redefines `\\`; under it a
+ * standalone `\\` is fatal. Root cause #2: CRLF input leaked raw `\r` into
+ * the .tex (only `\n` was converted) — TeX treats bare `\r` as a line
+ * ending, so `\r\n\r\n` produced a real empty source line (= \par)
+ * followed by `\\`, fatal in any context.
+ *
+ * Fix in `processBodyText`: normalize `\r\n?` → `\n` on entry; trim
+ * leading/trailing newline runs; convert interior blank-line runs to
+ * `\\[\baselineskip]` (visual blank line, never a standalone `\\`).
+ *
+ * Compile-level proof: tests/integration/latex-compile-blank-lines.test.ts
+ */
+import { describe, it, expect } from 'vitest';
+import { processBodyText } from '@/services/latex/escaper';
+
+describe('blank-line / CRLF handling in processBodyText (no-line-here-to-end regression)', () => {
+  it('never emits a standalone \\\\ source line for blank-line input', () => {
+    const out = processBodyText('para one.\n\npara two.');
+    // The fatal shape is a line consisting of only `\\` (raggedright-fatal).
+    for (const line of out.split('\n')) {
+      expect(line.trim(), `standalone \\\\ line in: ${JSON.stringify(out)}`).not.toBe('\\\\');
+    }
+    // The visual gap survives as a spaced line break.
+    expect(out).toContain('para one.\\\\[\\baselineskip]\npara two.');
+  });
+
+  it('emits no \\r for CRLF input', () => {
+    const out = processBodyText('line one\r\nline two\r\nline three');
+    expect(out).not.toContain('\r');
+  });
+
+  it('CRLF input produces byte-identical output to LF input', () => {
+    const lf = processBodyText('first block.\n\nsecond block.\nthird line.');
+    const crlf = processBodyText('first block.\r\n\r\nsecond block.\r\nthird line.');
+    expect(crlf).toBe(lf);
+  });
+
+  it('old-Mac bare \\r is treated as a newline, not passed through', () => {
+    const out = processBodyText('alpha\rbeta');
+    expect(out).not.toContain('\r');
+    expect(out).toBe(processBodyText('alpha\nbeta'));
+  });
+
+  it('trims leading/trailing newline runs (no \\\\ butted against paragraph edges)', () => {
+    const out = processBodyText('\n\ncontent line.\n\n');
+    expect(out.startsWith('\\\\')).toBe(false);
+    expect(out.endsWith('\\\\')).toBe(false);
+    expect(out.endsWith('\\\\[\\baselineskip]\n')).toBe(false);
+    expect(out).toContain('content line.');
+  });
+
+  it('runs of 3+ newlines collapse to a single spaced break (no stacked standalone \\\\)', () => {
+    const out = processBodyText('a\n\n\n\nb');
+    for (const line of out.split('\n')) {
+      expect(line.trim()).not.toBe('\\\\');
+    }
+    expect((out.match(/\\\\\[\\baselineskip\]/g) || []).length).toBe(1);
+  });
+
+  it('single newlines still become plain \\\\ line breaks', () => {
+    const out = processBodyText('line a\nline b');
+    expect(out).toContain('line a\\\\\nline b');
+  });
+});

--- a/tests/regressions/latex-section-sign-tcrm-missing.test.ts
+++ b/tests/regressions/latex-section-sign-tcrm-missing.test.ts
@@ -11,17 +11,22 @@
  *                       Metric (TFM) file not found.
  *   ! ==> Fatal error occurred, no output PDF file produced!
  *
- * Root cause: `textcomp` is loaded in the bundle, so `§` routes to the TS1
- * ("text companion") encoding as `\textsection`. The TS1 Computer Modern
- * metrics (`tcrm*.tfm`) are NOT in the curated 85-file offline font set the
- * SwiftLaTeX engine ships, so pdfTeX can't load `tcrm1200.tfm` and aborts the
- * whole document. The (`cmsy`-backed) `\S` command IS available offline.
+ * Root cause: on the modern (2020+, textcomp-integrated) kernel the bundle
+ * ships, `§` — and the text shorthands `\S` `\P` `\dag` `\ddag` — route to
+ * the TS1 ("text companion") encoding (`\textsection` …). The TS1 Computer
+ * Modern metrics (`tcrm*.tfm`) are NOT in the curated 85-file offline font
+ * set the SwiftLaTeX engine ships, so pdfTeX can't load `tcrm1200.tfm` and
+ * aborts the whole document.
  *
  * Fix: the PDF-path escaper (`escapeLatex` / `processBodyText` in
- * services/latex/escaper.ts) maps `§` → `\S{}` (and a set of other common
- * non-ASCII symbols → bundled-font LaTeX), with a fail-safe that drops any
- * unmapped non-ASCII symbol so a stray glyph can never fatal the compile.
- * Letters (incl. accented) are preserved.
+ * services/latex/escaper.ts) maps `§` → `\ensuremath{\mathsection}` (and the
+ * other common non-ASCII symbols → bundled-font LaTeX; math-mode forms for
+ * § ¶ † ‡ specifically, since their text shorthands are TS1-routed), with a
+ * fail-safe that drops any unmapped non-ASCII symbol so a stray glyph can
+ * never fatal the compile. Letters (incl. accented) are preserved. The
+ * compile-level proof lives in
+ * tests/integration/latex-compile-no-ts1.test.ts (asserts a real compile
+ * loads zero `ts1*.fd` / `tcrm` files).
  *
  * This is a unit-level regression because the integration compile matrix uses
  * a full `xelatex` install — which HAS `tcrm1200.tfm` — and therefore cannot
@@ -33,10 +38,36 @@ import { describe, it, expect } from 'vitest';
 import { escapeLatex, processBodyText, formatSubjectForLatex } from '@/services/latex/escaper';
 
 describe('section sign / TS1 symbol regression (tcrm1200.tfm not in offline bundle)', () => {
-  it('maps § to \\S{} (the exact reported citation) and never emits \\textsection', () => {
+  // FOLLOW-UP (post-merge field report): the first fix mapped § → `\S{}`,
+  // assuming `\S` falls back to the cmsy math section sign. WRONG on the
+  // modern (2020+, textcomp-integrated) kernel the bundle ships: `\S`
+  // expands to `\textsection`, whose DEFAULT encoding is TS1 — the very
+  // missing-tcrm crash returned, now via our own output:
+  //   l.8 \noindent 1.  5 U.S.C. \S {} 552a Privacy Act of 1972
+  //   ! Font TS1/cmr/m/n/12=tcrm1200 ... not loadable
+  // The text-mode shorthands \S \P \dag \ddag are therefore BANNED from
+  // escaper output. The safe forms are the explicit math-mode symbols
+  // (\ensuremath{\mathsection} …), which draw from bundled cmsy and load
+  // zero TS1 fonts (verified by A/B compile: \S{} loads ts1ptm.fd; the
+  // ensuremath form loads only cmsy10).
+  // Regexes, not substrings: `\dag` must not falsely match inside the SAFE
+  // math form `\dagger` (nor `\ddag` inside `\ddagger`) — `(?![a-zA-Z])`
+  // anchors each banned command at a non-letter boundary.
+  const TS1_ROUTED: RegExp[] = [
+    /\\textsection/,
+    /\\textparagraph/,
+    /\\S\{/,
+    /\\P\{/,
+    /\\dag(?![a-zA-Z])/,
+    /\\ddag(?![a-zA-Z])/,
+  ];
+
+  it('maps § to \\ensuremath{\\mathsection} (the exact reported citation), never a TS1-routed form', () => {
     const out = escapeLatex('5 U.S.C. § 552a Privacy Act of 1972');
-    expect(out).toContain('\\S{}');
-    expect(out).not.toContain('\\textsection');
+    expect(out).toContain('\\ensuremath{\\mathsection}');
+    for (const banned of TS1_ROUTED) {
+      expect(out, `must not emit TS1-routed ${banned}`).not.toMatch(banned);
+    }
     // The surrounding text must survive intact.
     expect(out).toContain('5 U.S.C.');
     expect(out).toContain('552a Privacy Act of 1972');
@@ -44,16 +75,28 @@ describe('section sign / TS1 symbol regression (tcrm1200.tfm not in offline bund
 
   it('handles repeated and body-text § the same way (processBodyText path)', () => {
     const out = processBodyText('See §§ 1 and 2, and ¶ 3.');
-    expect(out).not.toContain('\\textsection');
-    expect(out).not.toContain('\\textparagraph');
-    expect((out.match(/\\S\{\}/g) || []).length).toBe(2);
-    expect(out).toContain('\\P{}');
+    for (const banned of TS1_ROUTED) {
+      expect(out, `must not emit TS1-routed ${banned}`).not.toMatch(banned);
+    }
+    expect((out.match(/\\ensuremath\{\\mathsection\}/g) || []).length).toBe(2);
+    expect(out).toContain('\\ensuremath{\\mathparagraph}');
   });
 
   it('routes § in the subject line through the same safe mapping', () => {
     const out = formatSubjectForLatex('REQUEST UNDER 5 U.S.C. § 552');
-    expect(out).toContain('\\S{}');
-    expect(out).not.toContain('\\textsection');
+    expect(out).toContain('\\ensuremath{\\mathsection}');
+    for (const banned of TS1_ROUTED) {
+      expect(out, `must not emit TS1-routed ${banned}`).not.toMatch(banned);
+    }
+  });
+
+  it('maps † and ‡ to math-mode daggers (cmsy), not \\dag/\\ddag (TS1)', () => {
+    const out = escapeLatex('footnote† and double‡');
+    expect(out).toContain('\\ensuremath{\\dagger}');
+    expect(out).toContain('\\ensuremath{\\ddagger}');
+    for (const banned of TS1_ROUTED) {
+      expect(out, `must not emit TS1-routed ${banned}`).not.toMatch(banned);
+    }
   });
 
   it('maps the other common textcomp/TS1 symbols to bundled-font commands', () => {
@@ -108,7 +151,7 @@ describe('section sign / TS1 symbol regression (tcrm1200.tfm not in offline bund
     // The symbol map runs AFTER the \-escaping phase, so its own backslashes
     // must NOT have been turned into \textbackslash{}.
     const out = escapeLatex('§');
-    expect(out).toBe('\\S{}');
+    expect(out).toBe('\\ensuremath{\\mathsection}');
     expect(out).not.toContain('textbackslash');
   });
 });


### PR DESCRIPTION
## fix(latex): use math-mode section sign — \S{} still routed to the missing TS1 font

Follow-up to #76, which did not actually fix the field failure. The user's § citation crashed again, now through our own output:

```
l.8 \noindent 1.  5 U.S.C. \S {} 552a Privacy Act of 1972
! Font TS1/cmr/m/n/12=tcrm1200 ... Metric (TFM) file not found.
```

**Why #76 was wrong:** it mapped § to `\S{}` assuming `\S` renders the cmsy math section sign. On the modern textcomp-integrated kernel the bundle ships (2020+, l3backend present), `\S` expands to `\textsection`, whose DEFAULT encoding is TS1 — exactly the encoding whose `tcrm*.tfm` metrics the offline font set lacks. Same crash, one level of indirection later. The mistake survived because #76 was verified only at the string level; the integration matrix runs full xelatex, which has the TS1 fonts, so "it compiles" can never catch a bundled-font-set gap.

**Fix:** map § ¶ † ‡ to the explicit math-mode symbols (`\ensuremath{\mathsection}` / `\mathparagraph` / `\dagger` / `\ddagger`), which draw from the bundled cmsy font and structurally cannot touch TS1. Verified by A/B compile: a Times document with `\S{}` loads `ts1ptm.fd` + requests TS1 fonts; the ensuremath form loads only `cmsy10`. The other mappings (©®™ via `\textcircled`/`\textsuperscript`, the `\ensuremath` math symbols, quotes/dashes) were re-checked the same way and load zero TS1 fonts — unchanged.

**Closing the verification gap:** new integration test (`tests/integration/latex-compile-no-ts1.test.ts`) compiles a fixture salted with every mapped symbol through real xelatex and asserts the full log contains no `ts1*.fd` load, no `tcrm` request, and no TS1 font shape — so any future escaper change that routes a symbol through a TS1-defaulting command fails CI even though the local compile succeeds. Unit regression updated: `\S \P \dag \ddag` are now banned (boundary-aware regexes) from escaper output.

1146 unit tests pass; compile-level test passes; typecheck + lint clean.

## fix(latex): blank lines in pasted paragraphs no longer fatal the compile

Second field failure while validating the § fix: pasting multi-block text with blank lines into a paragraph box died with

```
! LaTeX Error: There's no line here to end.
l.9 \\
```

Two stacked root causes, isolated by bisecting the failing fixture's emitted body.tex inside the real template:

1. The newline conversion turned each `\n` into `\\`, so a blank line (`\n\n`) emitted a source line containing ONLY `\\`. main.tex sets `\raggedright` (naval-correspondence standard), which redefines `\\` — and under it a standalone `\\` is fatal. Vanilla LaTeX accepts the same shape, which is why a minimal repro outside the template initially looked harmless.

2. CRLF input (typical of Windows/NMCI clipboards) additionally leaked raw `\r` into the .tex — only `\n` was converted. TeX treats bare `\r` as a line ending, so `\r\n\r\n` produced a REAL empty source line (a paragraph break) followed by `\\`, fatal in any context.

**Fix in `processBodyText`:** normalize `\r\n?` to `\n` on entry; trim leading/trailing newline runs; convert interior blank-line runs to `\\[\baselineskip]` — one line break plus one blank line of space, so the visual gap the user typed is preserved and a standalone `\\` can never be emitted (raggedright-safe, verified by compile).

**Tests (written red-first against real xelatex):**
- `tests/integration/latex-compile-blank-lines.test.ts` — LF blank lines, CRLF blank lines, and leading/trailing-newline fixtures all compile through the actual template (reproduced the exact user error before the fix).
- `tests/regressions/latex-blank-line-no-line-to-end.test.ts` — unit invariants: no standalone `\\` line, no `\r`, CRLF ≡ LF, edge trimming, 3+ newline collapse.

1153 unit tests pass; typecheck + lint clean.