### PR TITLE
chore: bump version to 1.1.33 (missed in #77)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.32",
+  "version": "1.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.32",
+      "version": "1.1.33",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.32",
+  "version": "1.1.33",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Version bump that should have ridden in #77 (TS1-safe symbol mapping + blank-line/CRLF compile fixes), per the repo convention of bumping inside the substantive PR. Version-only change so the About modal and build info reflect the deployed fix.