### PR TITLE
fix(classification): banner derived from highest portion mark + PDF portion marks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.36",
+  "version": "1.1.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.36",
+      "version": "1.1.37",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.36",
+  "version": "1.1.37",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/lib/overallClassification.ts
+++ b/src/lib/overallClassification.ts
@@ -1,0 +1,62 @@
+/**
+ * Derive the overall (banner) classification from the document level and
+ * the highest per-paragraph portion marking.
+ *
+ * SECNAV M-5216.5 / DoDM 5200.01 Vol 2: the banner must reflect the highest
+ * classification of any portion in the document. Previously the banner was
+ * driven solely by the document-level `classLevel`, so a CUI document with
+ * an `(S)` paragraph rendered a CUI banner over SECRET content — an
+ * under-marked document. Both generators (PDF and DOCX) now derive the
+ * banner through this single chokepoint.
+ *
+ * `custom` is never derived over/under: free-text markings can't be ranked,
+ * so a custom document keeps its custom banner unchanged.
+ */
+import type { ClassificationLevel } from '@/lib/domainClassification';
+import type { Paragraph, PortionMarking } from '@/types/document';
+
+const LEVEL_RANK: Record<string, number> = {
+  unclassified: 0,
+  cui: 1,
+  confidential: 2,
+  secret: 3,
+  top_secret: 4,
+  top_secret_sci: 5,
+};
+
+/** Portion mark → the document-level classification it implies.
+ *  FOUO maps to CUI (FOUO was retired into the CUI program, DoDI 5200.48). */
+const PORTION_TO_LEVEL: Record<PortionMarking, ClassificationLevel> = {
+  U: 'unclassified',
+  CUI: 'cui',
+  FOUO: 'cui',
+  C: 'confidential',
+  S: 'secret',
+  TS: 'top_secret',
+};
+
+/**
+ * Returns the higher of the document-level classification and the highest
+ * portion marking present in `paragraphs`. Returns the input unchanged for
+ * `custom` (unrankable) or unknown levels.
+ */
+export function deriveOverallClassLevel(
+  classLevel: string | undefined,
+  paragraphs: Array<Pick<Paragraph, 'portionMarking'>>
+): string {
+  const docLevel = classLevel || 'unclassified';
+  if (docLevel === 'custom' || !(docLevel in LEVEL_RANK)) return docLevel;
+
+  let maxRank = LEVEL_RANK[docLevel];
+  let maxLevel = docLevel;
+  for (const para of paragraphs) {
+    if (!para.portionMarking) continue;
+    const level = PORTION_TO_LEVEL[para.portionMarking];
+    const rank = level ? LEVEL_RANK[level] : undefined;
+    if (rank !== undefined && rank > maxRank) {
+      maxRank = rank;
+      maxLevel = level;
+    }
+  }
+  return maxLevel;
+}

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -18,6 +18,7 @@ import type { DocumentData, Reference, Enclosure, Paragraph, CopyTo, Distributio
 import { DOC_TYPE_CONFIG } from '@/types/document';
 import { LAYOUT, TEXT_WIDTH_IN } from '@/services/docx/layout-config';
 import { splitAddressForLetterhead } from '@/lib/unitAddress';
+import { deriveOverallClassLevel } from '@/lib/overallClassification';
 
 interface DocumentStore {
   docType: string;
@@ -254,8 +255,10 @@ ${colorDef}
 `;
 }
 
-function buildClassificationHeaders(data: Partial<DocumentData>): string {
-  const classLevel = data.classLevel;
+function buildClassificationHeaders(data: Partial<DocumentData>, paragraphs: Paragraph[]): string {
+  // Banner = max(document level, highest portion mark) — same chokepoint as
+  // the PDF path (SECNAV M-5216.5 / DoDM 5200.01 Vol 2).
+  const classLevel = deriveOverallClassLevel(data.classLevel, paragraphs);
   if (!classLevel || classLevel === 'unclassified') return '';
 
   let marking: string;
@@ -1447,7 +1450,7 @@ export function generateFlatLatex(store: DocumentStore): string {
   let tex = '';
 
   tex += buildPreamble(data);
-  tex += buildClassificationHeaders(data);
+  tex += buildClassificationHeaders(data, store.paragraphs);
   tex += buildPageNumbering(data);
   tex += '\n\\begin{document}\n\n';
 

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -4,6 +4,7 @@ import { DOC_TYPE_CONFIG } from '@/types/document';
 import { base64ToUint8Array } from '@/lib/encoding';
 import { safeUrl } from '@/lib/url-safety';
 import { splitAddressForLetterhead } from '@/lib/unitAddress';
+import { deriveOverallClassLevel } from '@/lib/overallClassification';
 
 interface DocumentStore {
   docType: string;
@@ -672,6 +673,10 @@ export function generateBodyTex(store: DocumentStore): string {
     const para = store.paragraphs[i];
     const label = useNumberedParagraphs ? labels[i] : '';
     const headerText = para.header?.trim();
+    // Portion marking prefix, e.g. "(S) " — previously rendered only on the
+    // DOCX path; the PDF silently dropped it (DoDM 5200.01 V2 requires
+    // portion marks on the primary output too). Enum-constrained, LaTeX-safe.
+    const portionPrefix = para.portionMarking ? `(${para.portionMarking}) ` : '';
 
     if (para.level === 0) {
       // Level 0: Main paragraph with optional underlined header
@@ -680,15 +685,15 @@ export function generateBodyTex(store: DocumentStore): string {
         // Business letter: 0.5" first-line indent, no numbers
         if (headerText) {
           const formattedHeader = toTitleCase(headerText);
-          parts.push(`\\vspace{12pt}\n\\noindent\\hspace{0.5in}${underlineWords(escapeLatex(formattedHeader))}.  ${processBodyText(para.text)}\n\n`);
+          parts.push(`\\vspace{12pt}\n\\noindent\\hspace{0.5in}${underlineWords(escapeLatex(formattedHeader))}.  ${portionPrefix}${processBodyText(para.text)}\n\n`);
         } else {
-          parts.push(`\\vspace{12pt}\n\\noindent\\hspace{0.5in}${processBodyText(para.text)}\n\n`);
+          parts.push(`\\vspace{12pt}\n\\noindent\\hspace{0.5in}${portionPrefix}${processBodyText(para.text)}\n\n`);
         }
       } else if (headerText) {
         const formattedHeader = toTitleCase(headerText);
-        parts.push(`\\vspace{12pt}\n\\noindent ${label} ${underlineWords(escapeLatex(formattedHeader))}.  ${processBodyText(para.text)}\n\n`);
+        parts.push(`\\vspace{12pt}\n\\noindent ${label} ${underlineWords(escapeLatex(formattedHeader))}.  ${portionPrefix}${processBodyText(para.text)}\n\n`);
       } else {
-        parts.push(`\\vspace{12pt}\n\\noindent ${label}  ${processBodyText(para.text)}\n\n`);
+        parts.push(`\\vspace{12pt}\n\\noindent ${label}  ${portionPrefix}${processBodyText(para.text)}\n\n`);
       }
     } else {
       // Subparagraphs: Use leftskip for proper continuation line wrapping
@@ -697,9 +702,9 @@ export function generateBodyTex(store: DocumentStore): string {
 
       if (headerText) {
         const formattedHeader = toTitleCase(headerText);
-        parts.push(`\\vspace{6pt}\n{\\leftskip=${levelIndent}in\n\\noindent ${label} ${underlineWords(escapeLatex(formattedHeader))}. ${processBodyText(para.text)}\\par}\n\n`);
+        parts.push(`\\vspace{6pt}\n{\\leftskip=${levelIndent}in\n\\noindent ${label} ${underlineWords(escapeLatex(formattedHeader))}. ${portionPrefix}${processBodyText(para.text)}\\par}\n\n`);
       } else {
-        parts.push(`\\vspace{6pt}\n{\\leftskip=${levelIndent}in\n\\noindent ${label} ${processBodyText(para.text)}\\par}\n\n`);
+        parts.push(`\\vspace{6pt}\n{\\leftskip=${levelIndent}in\n\\noindent ${label} ${portionPrefix}${processBodyText(para.text)}\\par}\n\n`);
       }
     }
   }
@@ -710,11 +715,17 @@ export function generateBodyTex(store: DocumentStore): string {
 export function generateClassificationTex(store: DocumentStore): string {
   const data = store.formData;
 
-  if (data.classLevel === 'unclassified' || !data.classLevel) {
+  // Banner reflects the HIGHEST portion marking, not just the document
+  // level (SECNAV M-5216.5 / DoDM 5200.01 Vol 2). A CUI document with an
+  // (S) paragraph must render a SECRET banner. `custom` passes through
+  // unchanged (unrankable free text).
+  const overallLevel = deriveOverallClassLevel(data.classLevel, store.paragraphs);
+
+  if (overallLevel === 'unclassified') {
     return '% Unclassified - no classification markings\n';
   }
 
-  if (data.classLevel === 'cui') {
+  if (overallLevel === 'cui') {
     // \setClassification{CUI} is the canonical entry point — it sets
     // \ClassificationMarking, flips \ClassificationEnabledtrue, and
     // detects the literal "CUI" arg to flip \CUIEnabledtrue (see
@@ -737,7 +748,7 @@ export function generateClassificationTex(store: DocumentStore): string {
 
   // Handle custom classification - just output the text verbatim as banner only
   // Uses \setCustomClassification which sets banners but NOT the classified info block.
-  if (data.classLevel === 'custom') {
+  if (overallLevel === 'custom') {
     // No marking text yet → emit nothing. We MUST NOT fall through to the
     // classified branch below: that path's `\setClassification{...}` setter
     // had a `|| 'SECRET'` fallback which silently rendered fake SECRET
@@ -765,7 +776,7 @@ export function generateClassificationTex(store: DocumentStore): string {
   // Hard refusal — if the classLevel is some unrecognized value, do NOT
   // silently default to SECRET. Render the doc as unclassified rather than
   // fabricating a classification marking the user did not select.
-  const marking = classLevelMap[data.classLevel];
+  const marking = classLevelMap[overallLevel];
   if (!marking) {
     return '% Unrecognized classLevel — no classification markings rendered\n';
   }

--- a/tests/regressions/banner-derived-from-portion-marks.test.ts
+++ b/tests/regressions/banner-derived-from-portion-marks.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression: the classification banner was driven solely by the document
+ * level, so a CUI document containing an (S) paragraph rendered a CUI banner
+ * over SECRET content — an under-marked document. SECNAV M-5216.5 /
+ * DoDM 5200.01 Vol 2 require the banner to reflect the highest portion.
+ * Also: portion marks rendered in DOCX but were silently dropped from the
+ * PDF body. Both fixed via the shared deriveOverallClassLevel chokepoint.
+ */
+import { describe, it, expect } from 'vitest';
+import { deriveOverallClassLevel } from '@/lib/overallClassification';
+import { generateClassificationTex, generateBodyTex } from '@/services/latex/generator';
+import type { Paragraph } from '@/types/document';
+
+function store(classLevel: string, paragraphs: Paragraph[]) {
+  return {
+    docType: 'naval_letter',
+    formData: { classLevel } as never,
+    references: [],
+    enclosures: [],
+    paragraphs,
+    copyTos: [],
+    distributions: [],
+  };
+}
+
+describe('deriveOverallClassLevel', () => {
+  it('returns the document level when no portion outranks it', () => {
+    expect(deriveOverallClassLevel('secret', [{ text: 'x', level: 0, portionMarking: 'C' }])).toBe('secret');
+    expect(deriveOverallClassLevel('unclassified', [])).toBe('unclassified');
+  });
+
+  it('raises to the highest portion mark', () => {
+    expect(deriveOverallClassLevel('cui', [{ text: 'x', level: 0, portionMarking: 'S' }])).toBe('secret');
+    expect(deriveOverallClassLevel('unclassified', [{ text: 'x', level: 0, portionMarking: 'TS' }])).toBe('top_secret');
+    expect(deriveOverallClassLevel('confidential', [
+      { text: 'a', level: 0, portionMarking: 'U' },
+      { text: 'b', level: 1, portionMarking: 'S' },
+    ])).toBe('secret');
+  });
+
+  it('maps retired FOUO portions to CUI', () => {
+    expect(deriveOverallClassLevel('unclassified', [{ text: 'x', level: 0, portionMarking: 'FOUO' }])).toBe('cui');
+  });
+
+  it('never derives over custom (unrankable free text)', () => {
+    expect(deriveOverallClassLevel('custom', [{ text: 'x', level: 0, portionMarking: 'TS' }])).toBe('custom');
+  });
+});
+
+describe('banner derivation in generateClassificationTex (PDF path)', () => {
+  it('CUI document with an (S) paragraph renders a SECRET banner', () => {
+    const tex = generateClassificationTex(store('cui', [{ text: 'classified para', level: 0, portionMarking: 'S' }]));
+    expect(tex).toContain('\\setClassification{SECRET}');
+  });
+
+  it('unclassified document with a (TS) paragraph renders a TOP SECRET banner', () => {
+    const tex = generateClassificationTex(store('unclassified', [{ text: 'x', level: 0, portionMarking: 'TS' }]));
+    expect(tex).toContain('\\setClassification{TOP SECRET}');
+  });
+
+  it('unmarked documents are unchanged', () => {
+    const tex = generateClassificationTex(store('unclassified', [{ text: 'x', level: 0 }]));
+    expect(tex).toContain('Unclassified');
+    expect(tex).not.toContain('\\setClassification{');
+  });
+});
+
+describe('portion marks render in the PDF body (previously DOCX-only)', () => {
+  it('prefixes (S) on the marked paragraph', () => {
+    const tex = generateBodyTex(store('secret', [
+      { text: 'secret content here', level: 0, portionMarking: 'S' },
+      { text: 'unmarked content', level: 0 },
+    ]));
+    expect(tex).toContain('(S) secret content here');
+    expect(tex).not.toContain('(S) unmarked');
+  });
+
+  it('prefixes on subparagraph levels too', () => {
+    const tex = generateBodyTex(store('secret', [
+      { text: 'top', level: 0, portionMarking: 'U' },
+      { text: 'nested secret', level: 1, portionMarking: 'S' },
+    ]));
+    expect(tex).toContain('(U) top');
+    expect(tex).toContain('(S) nested secret');
+  });
+});


### PR DESCRIPTION
A CUI document with an (S) paragraph rendered a CUI banner over SECRET content (under-marking, SECNAV M-5216.5 / DoDM 5200.01 Vol 2). Portion marks also rendered in DOCX but were silently dropped from the PDF body.

- New shared `deriveOverallClassLevel` — banner = max(document level, highest portion mark); both PDF and DOCX generators use it. `custom` passes through unranked. FOUO portions map to CUI.
- PDF body now prefixes `(S)`-style portion marks at all paragraph levels, matching DOCX.
- 9 new regression tests; 1162 total pass; typecheck + lint clean.

Audit refs: critical #1 (banner derivation), C-3 (PDF portion marks).