### PR TITLE
fix(latex): fail-safe word-fusion and non-Latin compile fatals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.37",
+  "version": "1.1.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.37",
+      "version": "1.1.38",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.37",
+  "version": "1.1.38",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/services/latex/escaper.ts
+++ b/src/services/latex/escaper.ts
@@ -51,6 +51,13 @@ const SYMBOL_REPLACEMENTS: Array<[RegExp, string]> = [
   [/µ/g, '\\ensuremath{\\mu}'],    // µ micro
   [/•/g, '\\ensuremath{\\bullet}'], // • bullet
   [/·/g, '\\ensuremath{\\cdot}'],  // · middle dot
+  [/¹/g, '\\textsuperscript{1}'], // ¹ superscript one
+  [/²/g, '\\textsuperscript{2}'], // ² superscript two
+  [/³/g, '\\textsuperscript{3}'], // ³ superscript three
+  [/½/g, '1/2'],              // ½ vulgar fraction
+  [/¼/g, '1/4'],              // ¼ vulgar fraction
+  [/¾/g, '3/4'],              // ¾ vulgar fraction
+  [/€/g, 'EUR '],             // € no bundled glyph; text fallback beats deletion
   [/…/g, '\\ldots{}'],        // … ellipsis
   [/–/g, '--'],               // – en dash
   [/—/g, '---'],              // — em dash
@@ -71,12 +78,21 @@ function applyLatexSymbolFallback(text: string): string {
   for (const [re, rep] of SYMBOL_REPLACEMENTS) {
     out = out.replace(re, rep);
   }
-  // Fail-safe: drop unmapped non-ASCII symbols/punctuation. ASCII (incl.
-  // whitespace and the newlines body text relies on) is kept via \p{ASCII};
-  // letters (\p{L}) and marks (\p{M}) are kept so accented names still render
-  // via inputenc. Only stray non-ASCII *symbols* (emoji, exotic glyphs) are
-  // removed — they have no bundled font and a raw one would fatal the compile.
-  out = out.replace(/[^\p{ASCII}\p{L}\p{M}]/gu, '');
+  // Unicode separators (NBSP U+00A0, thin/figure spaces, line/para seps —
+  // ubiquitous in Word/Outlook paste) become a regular space rather than
+  // being deleted: deleting them silently fused words ("ref (a)\u{00A0}para 4"
+  // -> "ref (a)para 4").
+  out = out.replace(/[\p{Zs}\p{Zl}\p{Zp}]/gu, ' ');
+  // Fail-safe: drop any remaining character the offline font set cannot
+  // render, so a stray glyph can never fatal the compile. Kept: ASCII, and
+  // the Latin ranges the bundled fonts + the kernel's UTF-8 handling cover —
+  // Latin-1 Supplement through Latin Extended-B (U+00C0–U+024F) and Latin
+  // Extended Additional (U+1E00–U+1EFF, Vietnamese), plus combining marks.
+  // NOT kept: Greek/Cyrillic/CJK/Hangul/Arabic letters — they are \p{L} but
+  // pdfTeX throws "Unicode character ... not set up for use with LaTeX"
+  // (a fatal, no-PDF error), so the earlier letters-are-safe premise was
+  // wrong for non-Latin scripts. Stripping them keeps the compile alive.
+  out = out.replace(/[^\p{ASCII}\u00C0-\u024F\u1E00-\u1EFF\p{M}]/gu, '');
   return out;
 }
 

--- a/tests/fuzz/semantic.fuzz.test.ts
+++ b/tests/fuzz/semantic.fuzz.test.ts
@@ -157,7 +157,10 @@ describe('escaper — semantic fuzz', () => {
     // sanitizes to empty — that is the safe outcome, not a bug. The real
     // invariant is: any subject containing renderable content yields non-empty
     // LaTeX.
-    const hasRenderable = (s: string) => /[\x21-\x7E]/.test(s) || /\p{L}|\p{M}/u.test(s);
+    // Renderable = ASCII printable, or letters in the Latin ranges the
+    // bundled fonts cover (non-Latin scripts are stripped by the fail-safe
+    // because pdfTeX fatals on them — see escaper-failsafe-i18n regression).
+    const hasRenderable = (s: string) => /[\x21-\x7E]/.test(s) || /[\u00C0-\u024F\u1E00-\u1EFF]/u.test(s);
     fc.assert(
       fc.property(adversarialString.filter((s) => s.trim().length > 0 && hasRenderable(s)), (s) => {
         const out = formatSubjectForLatex(s);

--- a/tests/regressions/escaper-failsafe-i18n.test.ts
+++ b/tests/regressions/escaper-failsafe-i18n.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regressions in the symbol fail-safe (audit C-1 / C-2).
+ *
+ * C-1: the fail-safe deleted Unicode separators and numeric glyphs —
+ * NBSP (ubiquitous in Word paste) fused words ("ref (a) para 4" →
+ * "ref (a)para 4"); "100 m²" became "100 m"; "½ inch" became " inch";
+ * "€500" became "500". Separators now map to a plain space and
+ * ¹²³½¼¾€ have explicit replacements.
+ *
+ * C-2: the keep-set was all \p{L}, but non-Latin letters (Greek,
+ * Cyrillic, CJK, Hangul, Arabic) make pdfTeX fatal with "Unicode
+ * character ... not set up for use with LaTeX" — defeating the
+ * fail-safe's purpose. The keep-set is now restricted to the Latin
+ * ranges the bundled fonts cover; other scripts are stripped instead
+ * of crashing the compile.
+ */
+import { describe, it, expect } from 'vitest';
+import { escapeLatex } from '@/services/latex/escaper';
+
+describe('fail-safe separators and numerics (C-1)', () => {
+  it('NBSP becomes a space, not a deletion (no word fusion)', () => {
+    const out = escapeLatex('ref (a) para 4');
+    expect(out).toBe('ref (a) para 4');
+  });
+
+  it('thin/figure/ideographic spaces become spaces', () => {
+    expect(escapeLatex('a b c　d')).toBe('a b c d');
+  });
+
+  it('superscripts render instead of vanishing', () => {
+    const out = escapeLatex('100 m² and x³');
+    expect(out).toContain('100 m\\textsuperscript{2}');
+    expect(out).toContain('x\\textsuperscript{3}');
+  });
+
+  it('vulgar fractions render as text', () => {
+    expect(escapeLatex('½ inch and ¾ turn')).toBe('1/2 inch and 3/4 turn');
+  });
+
+  it('euro maps to EUR text rather than deletion', () => {
+    expect(escapeLatex('€500')).toBe('EUR 500');
+  });
+});
+
+describe('fail-safe non-Latin scripts (C-2)', () => {
+  it('Latin accented names still pass through', () => {
+    const out = escapeLatex('Müller-García, José Ñoño, Nguyễn');
+    expect(out).toContain('Müller-García');
+    expect(out).toContain('Nguyễn'); // Latin Extended Additional (Vietnamese)
+  });
+
+  it('Greek/Cyrillic/CJK/Hangul letters are stripped, not passed to pdfTeX', () => {
+    // These are \p{L} but the bundled fonts cannot render them — passing
+    // them through fatals the compile with "Unicode character not set up".
+    const out = escapeLatex('alpha α beta Б kanji 漢 hangul 한 end');
+    expect(out).not.toMatch(/[α-ωА-Яа-я一-鿿가-힯]/u);
+    expect(out).toContain('alpha');
+    expect(out).toContain('end');
+  });
+});


### PR DESCRIPTION
Two regressions in the #76/#77 symbol fail-safe (audit C-1/C-2):

- **C-1**: it deleted Unicode separators and numeric glyphs — NBSP (ubiquitous in Word/Outlook paste) silently fused words; `100 m²` → `100 m`; `€500` → `500`. Separators now map to a plain space; ¹²³½¼¾€ have explicit replacements.
- **C-2**: the keep-set was all `\p{L}`, but pdfTeX fatals on Greek/Cyrillic/CJK/Hangul ("Unicode character ... not set up") — a Korean surname defeated the fail-safe's whole purpose. Keep-set restricted to bundled-font Latin ranges (Latin-1 Supp → Ext-B + Ext Additional for Vietnamese); other scripts strip instead of crashing.

7 new regression tests; 1160 total pass; typecheck + lint clean.