### PR TITLE
fix(history): undo no longer destroys attached enclosure PDFs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.37",
+  "version": "1.1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.37",
+      "version": "1.1.39",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.37",
+  "version": "1.1.39",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -541,15 +541,36 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
   },
 
   // History (Undo/Redo)
-  applySnapshot: (snapshot) => set({
-    documentMode: snapshot.documentMode,
-    docType: snapshot.docType,
-    formData: snapshot.formData,
-    references: snapshot.references,
-    enclosures: snapshot.enclosures,
-    paragraphs: snapshot.paragraphs,
-    copyTos: snapshot.copyTos,
-    distributions: snapshot.distributions || [],
+  applySnapshot: (snapshot) => set((state) => {
+    // Re-graft live enclosure file bytes. History snapshots intentionally
+    // omit `file` (too large to keep 50 copies of), so a wholesale replace
+    // permanently destroyed attached PDFs on every undo/redo — the next
+    // download silently omitted those pages. Match same-index-same-title
+    // first, then any unused same-title enclosure.
+    const used = new Set<number>();
+    const enclosures = snapshot.enclosures.map((e, i) => {
+      if (e.file) return e;
+      const cur = state.enclosures;
+      const match =
+        cur[i]?.title === e.title && cur[i]?.file && !used.has(i)
+          ? i
+          : cur.findIndex((c, j) => !used.has(j) && c.title === e.title && !!c.file);
+      if (match >= 0) {
+        used.add(match);
+        return { ...e, file: cur[match].file };
+      }
+      return e;
+    });
+    return {
+      documentMode: snapshot.documentMode,
+      docType: snapshot.docType,
+      formData: snapshot.formData,
+      references: snapshot.references,
+      enclosures,
+      paragraphs: snapshot.paragraphs,
+      copyTos: snapshot.copyTos,
+      distributions: snapshot.distributions || [],
+    };
   }),
 
   getSnapshot: (): DocumentSnapshot => {

--- a/tests/regressions/undo-preserves-enclosure-files.test.ts
+++ b/tests/regressions/undo-preserves-enclosure-files.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression (audit C-9): undo permanently destroyed attached enclosure
+ * PDF bytes. History snapshots intentionally omit `file` (too large), but
+ * `applySnapshot` replaced `enclosures` wholesale — so attach → edit →
+ * Ctrl+Z dropped the bytes, redo could not recover them, and the next
+ * download silently omitted the pages. `applySnapshot` now re-grafts the
+ * live file bytes onto restored enclosures (index+title match first, then
+ * any unused title match).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDocumentStore } from '@/stores/documentStore';
+
+const FILE_A = { name: 'a.pdf', size: 3, data: new ArrayBuffer(3) };
+const FILE_B = { name: 'b.pdf', size: 5, data: new ArrayBuffer(5) };
+
+describe('applySnapshot re-grafts enclosure file bytes (C-9)', () => {
+  beforeEach(() => {
+    useDocumentStore.setState({ enclosures: [] });
+  });
+
+  it('undo keeps the attached file when the enclosure survives in the snapshot', () => {
+    const store = useDocumentStore.getState();
+    useDocumentStore.setState({
+      enclosures: [{ title: 'Roster', file: FILE_A, pageStyle: 'border' }],
+    });
+    // Snapshot as history stores it: same enclosure, file stripped.
+    store.applySnapshot({
+      documentMode: 'correspondence',
+      docType: 'naval_letter',
+      formData: {},
+      references: [],
+      enclosures: [{ title: 'Roster', pageStyle: 'border' }],
+      paragraphs: [],
+      copyTos: [],
+      distributions: [],
+    } as never);
+    expect(useDocumentStore.getState().enclosures[0].file).toBe(FILE_A);
+  });
+
+  it('matches by title when order changed; never duplicates one file onto two', () => {
+    const store = useDocumentStore.getState();
+    useDocumentStore.setState({
+      enclosures: [
+        { title: 'Roster', file: FILE_A },
+        { title: 'Report', file: FILE_B },
+      ],
+    });
+    store.applySnapshot({
+      documentMode: 'correspondence',
+      docType: 'naval_letter',
+      formData: {},
+      references: [],
+      enclosures: [{ title: 'Report' }, { title: 'Roster' }, { title: 'Roster' }],
+      paragraphs: [],
+      copyTos: [],
+      distributions: [],
+    } as never);
+    const enc = useDocumentStore.getState().enclosures;
+    expect(enc[0].file).toBe(FILE_B);
+    expect(enc[1].file).toBe(FILE_A);
+    expect(enc[2].file).toBeUndefined(); // FILE_A already used once
+  });
+
+  it('enclosures removed before the snapshot stay file-less (no resurrection)', () => {
+    const store = useDocumentStore.getState();
+    useDocumentStore.setState({ enclosures: [{ title: 'Other', file: FILE_A }] });
+    store.applySnapshot({
+      documentMode: 'correspondence',
+      docType: 'naval_letter',
+      formData: {},
+      references: [],
+      enclosures: [{ title: 'Unrelated' }],
+      paragraphs: [],
+      copyTos: [],
+      distributions: [],
+    } as never);
+    expect(useDocumentStore.getState().enclosures[0].file).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Audit C-9: history snapshots intentionally omit enclosure `file` bytes, but `applySnapshot` replaced `enclosures` wholesale — so attach → edit → Ctrl+Z permanently dropped the PDF bytes; redo couldn't recover them and the next download silently omitted the pages.

`applySnapshot` now re-grafts the live file bytes onto restored enclosures: same-index-same-title match first, then any unused same-title match; each file attaches at most once; removed enclosures don't resurrect.

3 new regression tests; 1156 total pass; typecheck + lint clean.