### PR TITLE
test(latex): make no-TS1 compile assertion portable across TeX Live versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.34",
+  "version": "1.1.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.34",
+      "version": "1.1.35",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.34",
+  "version": "1.1.35",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tests/integration/latex-compile-no-ts1.test.ts
+++ b/tests/integration/latex-compile-no-ts1.test.ts
@@ -69,10 +69,25 @@ describe('mapped symbols never request TS1 fonts (bundled-engine safety)', () =>
       // The decisive assertion: the FULL log (not just the tail) must show
       // no TS1 font-definition load and no tcrm metric request. On the
       // bundled engine those files don't exist; requesting them is the crash.
+      // Environment note: older TeX Live kernels (e.g. CI's apt install)
+      // route some symbols through TS1 and load ts1*.fd even though the
+      // modern kernel (local + the production bundle) does not — so a
+      // blanket "no ts1*.fd" assertion is not portable. The portable,
+      // failure-mode-accurate assertions are: no tcrm metric request and
+      // no TS1 font-shape substitution (what actually crashes the bundled
+      // engine), plus a source-level ban on the TS1-defaulting commands.
       const fullLog = await readFile(join(result.workDir, 'main.log'), 'utf-8');
-      expect(fullLog).not.toMatch(/ts1[a-z]*\.fd/i);
       expect(fullLog).not.toMatch(/tcrm/i);
       expect(fullLog).not.toMatch(/Font shape `TS1/);
+
+      // Source-level ban (environment-independent): the generated TeX must
+      // never contain the text-mode shorthands that default to TS1.
+      const body = await readFile(join(result.workDir, 'body.tex'), 'utf-8');
+      const refs = await readFile(join(result.workDir, 'references.tex'), 'utf-8');
+      for (const banned of [/\\textsection/, /\\S\{/, /\\P\{/, /\\dag(?![a-zA-Z])/, /\\ddag(?![a-zA-Z])/]) {
+        expect(body, `banned TS1 command in body.tex: ${banned}`).not.toMatch(banned);
+        expect(refs, `banned TS1 command in references.tex: ${banned}`).not.toMatch(banned);
+      }
     },
     120_000
   );


### PR DESCRIPTION
The compile-matrix job fails on PRs #79/#80 (and would on any branch) because the no-TS1 test's blanket `ts1*.fd` assertion is environment-dependent: CI's older TeX Live loads it for symbols the modern kernel (local + production bundle) doesn't route through TS1. Not a regression from those PRs — 773/774 integration tests pass on both.

Replaced with portable, failure-mode-accurate checks: no `tcrm` metric request, no TS1 font-shape substitution, plus a source-level ban on the TS1-defaulting commands in the generated TeX (environment-independent teeth).

Merge this first; #79/#80/#81 clear their matrix failures on rebase/re-run. The remaining `npm audit` failure on all PRs is the known pre-existing allowlist issue (advisory 1118732).