### PR TITLE
fix(batch): column-mapping dropdown no longer crashes the app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.38",
+  "version": "1.1.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.38",
+      "version": "1.1.41",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.38",
+  "version": "1.1.41",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -91,6 +91,11 @@ interface BatchModalProps {
 // Max retries for ENGINE_RESET_NEEDED
 const MAX_RETRIES = 2;
 
+// Sentinel for the column-mapping "skip this column" choice. Radix Select v2
+// throws on <SelectItem value=""> (empty string is reserved for clearing),
+// which crashed the whole app the moment the mapping dropdown opened.
+const SKIP_COLUMN = '__skip__';
+
 // Copy text to clipboard
 function copyToClipboard(text: string) {
   navigator.clipboard.writeText(text);
@@ -1020,14 +1025,14 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
                             </span>
                             <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
                             <Select
-                              value={columnMappings[idx] || ''}
-                              onValueChange={(v) => updateColumnMapping(idx, v)}
+                              value={columnMappings[idx] || SKIP_COLUMN}
+                              onValueChange={(v) => updateColumnMapping(idx, v === SKIP_COLUMN ? '' : v)}
                             >
                               <SelectTrigger className="h-8 flex-1">
                                 <SelectValue placeholder="Select variable..." />
                               </SelectTrigger>
                               <SelectContent>
-                                <SelectItem value="">— Skip —</SelectItem>
+                                <SelectItem value={SKIP_COLUMN}>— Skip —</SelectItem>
                                 {detectedPlaceholders.map((p) => (
                                   <SelectItem key={p} value={p}>{`{{${p}}}`}</SelectItem>
                                 ))}


### PR DESCRIPTION
Audit COV-1 (high). Radix Select v2 unconditionally throws on `<SelectItem value="">`; the batch paste column-mapping UI used exactly that for its Skip option, so opening any mapping dropdown crashed the whole app to the ErrorBoundary. Skip now uses a `__skip__` sentinel translated back to an empty mapping in `onValueChange`.

1153 tests pass; typecheck + lint clean.