### PR TITLE
fix(docx): escape content ampersands in tabular cells

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.40",
+  "version": "1.1.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.40",
+      "version": "1.1.42",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.40",
+  "version": "1.1.42",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -56,7 +56,11 @@ function escapeFlat(str: string | undefined | null): string {
     .replace(/ZZZCARETZZZ/g, '\\textasciicircum{}');
 }
 
-/** Escape for use inside tabular cells (& must not be escaped since it's the column separator) */
+/** Escape for use inside tabular cells. User CONTENT ampersands must be
+ * escaped (\&) — the old "& is the column separator" rationale applied to
+ * the table SYNTAX our code emits, not to cell text. Unescaped, a unit name
+ * like "H&S Battalion" became a phantom alignment tab that corrupted the
+ * DOCX table (the PDF path always escaped it). */
 function escapeTabular(str: string | undefined | null): string {
   if (!str) return '';
   // ORDER MATTERS: Use placeholders for replacements that introduce { }
@@ -65,6 +69,7 @@ function escapeTabular(str: string | undefined | null): string {
   // (first replace) escapes all `\` from input before subsequent replaces add their own.
   return str
     .replace(/\\/g, 'ZZZTEXTBACKSLASHZZZ')
+    .replace(/&/g, '\\&')
     .replace(/%/g, '\\%')
     .replace(/#/g, '\\#')
     .replace(/_/g, '\\_')

--- a/tests/regressions/escapetabular-ampersand.test.ts
+++ b/tests/regressions/escapetabular-ampersand.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Regression (audit C-4): escapeTabular did not escape `&` — the comment
+ * ("& is the column separator") misapplied to cell CONTENT. A unit name
+ * like "H&S Battalion" became a phantom alignment tab that corrupted the
+ * DOCX table layout. The PDF path always escaped `&`; same input produced
+ * a broken DOCX. Content ampersands are now escaped to \&.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateFlatLatex } from '@/services/latex/flat-generator';
+
+describe('escapeTabular escapes content ampersands (C-4)', () => {
+  it('H&S-style unit names emit \\& in tabular cells, never a bare &', () => {
+    const tex = generateFlatLatex({
+      docType: 'naval_letter',
+      formData: {
+        unitLine1: 'H&S Battalion',
+        from: 'Commanding Officer, H&S Battalion',
+        to: 'CG, II MEF',
+        subject: 'TEST',
+      } as never,
+      references: [],
+      enclosures: [],
+      paragraphs: [{ text: 'body', level: 0 }],
+      copyTos: [],
+      distributions: [],
+    });
+    expect(tex).toContain('H\\&S Battalion');
+    // No bare content ampersand from the input survives. (Table syntax `&`
+    // emitted by the generator itself is always ` & ` separated.)
+    expect(tex).not.toMatch(/H&S/);
+  });
+});


### PR DESCRIPTION
Audit C-4 (high). `escapeTabular` left user `&` unescaped — the comment's rationale (column separator) applies to the table syntax the generator emits, not to cell content. A unit name like "H&S Battalion" became a phantom alignment tab corrupting the DOCX table; the PDF path already escaped it. Now escaped to `\&` after the backslash sentinel.

1 new regression test; 1154 total pass; typecheck + lint clean.