### PR TITLE
fix(session): restore prompt no longer races the autosave

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.40",
+  "version": "1.1.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.40",
+      "version": "1.1.43",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.40",
+  "version": "1.1.43",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/modals/RestoreSessionModal.tsx
+++ b/src/components/modals/RestoreSessionModal.tsx
@@ -18,6 +18,8 @@ import {
 import { Button } from '@/components/ui/button';
 import {
   hasSavedSession,
+  suspendSessionSaves,
+  resumeSessionSaves,
   getSavedSession,
   restoreSession,
   clearSavedSession,
@@ -85,6 +87,9 @@ export function RestoreSessionModal() {
           referenceCount: session.references?.length || 0,
           docType: session.docType,
         });
+        // Freeze session autosave while the prompt is up so mount-time
+        // store writes can't overwrite the payload before the user decides.
+        suspendSessionSaves();
         setOpen(true);
         // Mark that we've shown the modal in this session
         sessionStorage.setItem(RESTORE_SHOWN_KEY, 'true');
@@ -94,11 +99,13 @@ export function RestoreSessionModal() {
 
   const handleRestore = () => {
     restoreSession();
+    resumeSessionSaves();
     setOpen(false);
   };
 
   const handleStartFresh = () => {
     clearSavedSession();
+    resumeSessionSaves();
     setOpen(false);
   };
 

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -572,6 +572,20 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
 let saveTimeout: ReturnType<typeof setTimeout> | null = null;
 let sessionSaveTimeout: ReturnType<typeof setTimeout> | null = null;
 
+// While the session-restore prompt is on screen, mount-time store writes
+// (profile letterhead sync, defaults) would autosave over the very session
+// the user is about to restore — restoreSession() re-reads localStorage at
+// click time, so a user who took >2s to read the prompt restored the
+// freshly-overwritten default document and lost their work. The restore
+// modal suspends session saves while the decision is pending.
+let sessionSavesSuspended = false;
+export function suspendSessionSaves(): void {
+  sessionSavesSuspended = true;
+}
+export function resumeSessionSaves(): void {
+  sessionSavesSuspended = false;
+}
+
 useDocumentStore.subscribe((state: DocumentState) => {
   // Debounce snapshot saving
   if (saveTimeout) {
@@ -597,14 +611,18 @@ useDocumentStore.subscribe((state: DocumentState) => {
     }
   }, TIMING.HISTORY_SNAPSHOT_DEBOUNCE);
 
-  // Also persist to localStorage for session restore (debounced more)
+  // Also persist to localStorage for session restore (debounced more).
+  // Skipped entirely while suspended (restore prompt is on screen) — see
+  // suspendSessionSaves below for the race this prevents.
   if (sessionSaveTimeout) {
     clearTimeout(sessionSaveTimeout);
   }
 
-  sessionSaveTimeout = setTimeout(() => {
-    saveSessionToStorage(state);
-  }, 2000); // 2 second debounce for localStorage
+  if (!sessionSavesSuspended) {
+    sessionSaveTimeout = setTimeout(() => {
+      if (!sessionSavesSuspended) saveSessionToStorage(state);
+    }, 2000); // 2 second debounce for localStorage
+  }
 });
 
 /**

--- a/tests/regressions/restore-race-session-overwrite.test.ts
+++ b/tests/regressions/restore-race-session-overwrite.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression (audit C-10): mount-time store writes (profile letterhead
+ * sync, defaults) triggered the 2s-debounced session autosave, which
+ * overwrote the saved session BEFORE the user clicked Restore —
+ * restoreSession() re-reads localStorage at click time, so anyone who
+ * took >2s to read the prompt restored the freshly-overwritten default
+ * document. suspendSessionSaves()/resumeSessionSaves() freeze the
+ * session autosave while the restore prompt is pending.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  useDocumentStore,
+  suspendSessionSaves,
+  resumeSessionSaves,
+} from '@/stores/documentStore';
+
+const KEY = 'dondocs-document-session';
+
+describe('restore race: session saves suspended while prompt pending (C-10)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resumeSessionSaves();
+    vi.useFakeTimers();
+  });
+
+  it('store mutations while suspended do not overwrite the saved session', () => {
+    localStorage.setItem(KEY, JSON.stringify({ marker: 'users-saved-work' }));
+    suspendSessionSaves();
+    // Simulate the mount-time profile-sync write the audit traced.
+    useDocumentStore.setState({ formData: { subject: 'fresh default' } as never });
+    vi.advanceTimersByTime(5000); // well past the 2s debounce
+    expect(localStorage.getItem(KEY)).toContain('users-saved-work');
+    resumeSessionSaves();
+    vi.useRealTimers();
+  });
+
+  it('after resume, autosave works again', () => {
+    suspendSessionSaves();
+    resumeSessionSaves();
+    useDocumentStore.setState({ formData: { subject: 'post-decision edit' } as never });
+    vi.advanceTimersByTime(5000);
+    // Payload is compressed ('gz:' prefix) — assert the save happened,
+    // not its raw content.
+    const saved = localStorage.getItem(KEY);
+    expect(saved).toBeTruthy();
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
Audit C-10 (high). Mount-time store writes triggered the 2s-debounced session autosave, overwriting the saved session before the user clicked Restore — `restoreSession()` re-reads localStorage at click time, so taking >2s to read the prompt meant restoring the freshly-overwritten default document.

New `suspendSessionSaves()`/`resumeSessionSaves()` freeze the session autosave while the prompt is up; resumed on Restore or Start Fresh. 2 new regression tests (suspended mutations don't overwrite; saves resume after the decision).

1156 total pass; typecheck + lint clean.