### PR TITLE
fix(signature): CAC field clamped to the basic document's pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.42",
+  "version": "1.1.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.42",
+      "version": "1.1.44",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.42",
+  "version": "1.1.44",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -388,10 +388,12 @@ function App() {
         // When disabled (default), these are deferred to the download/export path
         // for better responsiveness on slower machines.
         if (fullQualityPreview) {
+          let lastBasicPageIndex: number | undefined;
           if (generatedEnclosures.length > 0 || (includeHyperlinks && referenceUrls.length > 0)) {
             const classification = getClassificationInfo(currentStore.formData.classLevel);
             const mergeResult = await mergeEnclosures(pdfBytes, generatedEnclosures, classification, includeHyperlinks, referenceUrls);
             pdfBytes = mergeResult.pdfBytes;
+            lastBasicPageIndex = mergeResult.basicPageCount !== undefined ? mergeResult.basicPageCount - 1 : undefined;
           }
 
           if (currentStore.formData.signatureType === 'digital') {
@@ -399,10 +401,10 @@ function App() {
             const isDualSignature = config?.uiMode === 'moa' || config?.compliance?.dualSignature;
             if (isDualSignature) {
               const sigConfig = getDualSignatoryConfig(currentStore.formData, config?.uiMode);
-              pdfBytes = await addDualSignatureFields(new Uint8Array(pdfBytes), sigConfig);
+              pdfBytes = await addDualSignatureFields(new Uint8Array(pdfBytes), { ...sigConfig, lastBasicPageIndex });
             } else {
               const sigConfig = getSignatoryConfig(currentStore.formData);
-              pdfBytes = await addSignatureField(new Uint8Array(pdfBytes), sigConfig);
+              pdfBytes = await addSignatureField(new Uint8Array(pdfBytes), { ...sigConfig, lastBasicPageIndex });
             }
           }
         }
@@ -622,11 +624,13 @@ function App() {
 
     if (pdfBytes) {
       // Merge enclosures and/or create hyperlinks (handles both PDF and text-only enclosures, and reference URLs)
+      let lastBasicPageIndex: number | undefined;
       if (generatedEnclosures.length > 0 || (includeHyperlinks && referenceUrls.length > 0)) {
         onProgress?.({ kind: 'pdf-merging-enclosures' });
         const classification = getClassificationInfo(currentStore.formData.classLevel);
         const mergeResult = await mergeEnclosures(pdfBytes, generatedEnclosures, classification, includeHyperlinks, referenceUrls);
         pdfBytes = mergeResult.pdfBytes;
+        lastBasicPageIndex = mergeResult.basicPageCount !== undefined ? mergeResult.basicPageCount - 1 : undefined;
 
         // Track enclosure errors for user notification (download context)
         if (mergeResult.hasErrors) {
@@ -642,10 +646,10 @@ function App() {
         const isDualSignature = config?.uiMode === 'moa' || config?.compliance?.dualSignature;
         if (isDualSignature) {
           const sigConfig = getDualSignatoryConfig(currentStore.formData, config?.uiMode);
-          pdfBytes = await addDualSignatureFields(new Uint8Array(pdfBytes), sigConfig);
+          pdfBytes = await addDualSignatureFields(new Uint8Array(pdfBytes), { ...sigConfig, lastBasicPageIndex });
         } else {
           const sigConfig = getSignatoryConfig(currentStore.formData);
-          pdfBytes = await addSignatureField(new Uint8Array(pdfBytes), sigConfig);
+          pdfBytes = await addSignatureField(new Uint8Array(pdfBytes), { ...sigConfig, lastBasicPageIndex });
         }
       }
 
@@ -828,11 +832,13 @@ function App() {
     let pdfBytes = await compile(files);
 
     if (pdfBytes) {
+      let lastBasicPageIndex: number | undefined;
       if (enclosures.length > 0 || (includeHyperlinks && referenceUrls.length > 0)) {
         onProgress?.({ kind: 'pdf-merging-enclosures' });
         const classification = getClassificationInfo(currentStore.formData.classLevel);
         const mergeResult = await mergeEnclosures(pdfBytes, enclosures, classification, includeHyperlinks, referenceUrls);
         pdfBytes = mergeResult.pdfBytes;
+        lastBasicPageIndex = mergeResult.basicPageCount !== undefined ? mergeResult.basicPageCount - 1 : undefined;
 
         // Track enclosure errors for user notification (PII download context)
         if (mergeResult.hasErrors) {
@@ -848,10 +854,10 @@ function App() {
         const isDualSignature = config?.uiMode === 'moa' || config?.compliance?.dualSignature;
         if (isDualSignature) {
           const sigConfig = getDualSignatoryConfig(currentStore.formData, config?.uiMode);
-          pdfBytes = await addDualSignatureFields(new Uint8Array(pdfBytes), sigConfig);
+          pdfBytes = await addDualSignatureFields(new Uint8Array(pdfBytes), { ...sigConfig, lastBasicPageIndex });
         } else {
           const sigConfig = getSignatoryConfig(currentStore.formData);
-          pdfBytes = await addSignatureField(new Uint8Array(pdfBytes), sigConfig);
+          pdfBytes = await addSignatureField(new Uint8Array(pdfBytes), { ...sigConfig, lastBasicPageIndex });
         }
       }
 

--- a/src/services/pdf/addSignatureField.ts
+++ b/src/services/pdf/addSignatureField.ts
@@ -12,6 +12,10 @@ export interface SignatureFieldConfig {
   height?: number;
   /** Signatory name to search for (for text-based positioning) */
   signatoryName?: string;
+  /** Last page index of the BASIC document (0-based). When enclosures were
+   *  merged before signing, the signature must not land on enclosure pages —
+   *  search and fallback are clamped to this page (C-7). */
+  lastBasicPageIndex?: number;
 }
 
 /**
@@ -333,10 +337,17 @@ function calculateFallbackPosition(
 function findSignatoryPosition(
   pdfDoc: PDFDocument,
   signatoryName: string | undefined,
-  signatureType: 'single' | 'junior' | 'senior' = 'single'
+  signatureType: 'single' | 'junior' | 'senior' = 'single',
+  lastBasicPageIndex?: number
 ): { pageIndex: number; x: number; y: number } {
   const pages = pdfDoc.getPages();
-  const lastPageIndex = pages.length - 1;
+  // Clamp to the basic document's page range so the CAC field never lands
+  // on a merged enclosure page (e.g. over someone else's signature in an
+  // endorsement package).
+  const lastPageIndex = Math.min(
+    lastBasicPageIndex ?? pages.length - 1,
+    pages.length - 1
+  );
   const lastPage = pages[lastPageIndex];
 
   // Try text-based search if signatory name provided
@@ -408,7 +419,7 @@ export async function addSignatureField(
   } = config;
 
   // Find position (text-based or calculated fallback)
-  const position = findSignatoryPosition(pdfDoc, signatoryName, 'single');
+  const position = findSignatoryPosition(pdfDoc, signatoryName, 'single', config.lastBasicPageIndex);
 
   console.log(`[addSignatureField] Using position: page ${position.pageIndex + 1}, x=${position.x}, y=${position.y}`);
 
@@ -486,8 +497,8 @@ export async function addDualSignatureFields(
   } = config;
 
   // Find positions
-  const juniorPosition = findSignatoryPosition(pdfDoc, juniorSignatoryName, 'junior');
-  const seniorPosition = findSignatoryPosition(pdfDoc, seniorSignatoryName, 'senior');
+  const juniorPosition = findSignatoryPosition(pdfDoc, juniorSignatoryName, 'junior', config.lastBasicPageIndex);
+  const seniorPosition = findSignatoryPosition(pdfDoc, seniorSignatoryName, 'senior', config.lastBasicPageIndex);
 
   // Align both signatures to the same Y coordinate (use the average)
   // This ensures both signature fields appear at the same height

--- a/src/services/pdf/mergeEnclosures.ts
+++ b/src/services/pdf/mergeEnclosures.ts
@@ -24,6 +24,10 @@ export interface MergeResult {
   pdfBytes: Uint8Array;
   errors: EnclosureError[];
   hasErrors: boolean;
+  /** Page count of the basic document BEFORE enclosures were appended.
+   *  Lets the signature-field placer stay off enclosure pages (C-7).
+   *  Undefined when nothing was merged (whole doc = basic doc). */
+  basicPageCount?: number;
 }
 
 export interface ReferenceUrlData {
@@ -1193,7 +1197,7 @@ export async function mergeEnclosures(
     debug.warn('MergeEnclosures', `Completed with ${errors.length} enclosure error(s):`, errors);
   }
 
-  return { pdfBytes, errors, hasErrors: errors.length > 0 };
+  return { pdfBytes, errors, hasErrors: errors.length > 0, basicPageCount: mainPageCount };
 }
 
 /**


### PR DESCRIPTION
Audit C-7 (high). The signature placer ran after `mergeEnclosures` and searched from the merged document's last page backwards (falling back to the last page) — in endorsement packages the CAC field landed on an enclosure page, over someone else's signature.

`mergeEnclosures` now returns `basicPageCount`; all three call sites thread `lastBasicPageIndex` into the signature configs, and `findSignatoryPosition` clamps both the text search and the coordinate fallback to the basic document's page range (no merge → unchanged behavior).

1153 tests pass; typecheck + lint clean.