### PR TITLE
fix(deploy): real 404s for missing assets on Cloudflare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.42",
+  "version": "1.1.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.42",
+      "version": "1.1.45",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.42",
+  "version": "1.1.45",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,4 +3,11 @@ compatibility_date = "2025-04-01"
 
 [assets]
 directory = "./dist"
-not_found_handling = "single-page-application"
+# Real 404s for missing assets (DEP-1). The previous
+# "single-page-application" setting served 200+index.html for EVERY missing
+# path — including missing TeX/font/engine files, which poisoned the
+# engine's caches with HTML bytes (the pk-font path has no HTML sniff).
+# The app is a single page at "/" with hash-based share links, so SPA
+# deep-link rewriting is unnecessary; this matches the Caddy deployment,
+# which already returns real 404s.
+not_found_handling = "none"


### PR DESCRIPTION
Audit DEP-1 (med-high). `not_found_handling = "single-page-application"` served 200+index.html for every missing path — including missing TeX/font/engine assets, which fed HTML bytes into the engine's caches (the pk-font path has no HTML sniff; ENG-4). The Caddy deployment already returns real 404s, so identical failures behaved differently per target.

The app is a single page at `/` with hash-based share links — no deep links to rewrite — so `none` is safe and restores parity. Verify after deploy: a missing `/lib/texlive/...` URL returns 404, and `/` still serves the app.