### PR TITLE
test(ci): compile matrix uses pdflatex to match production pdfTeX

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,6 +246,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             texlive-xetex \
+            texlive-latex-base \
             texlive-latex-extra \
             texlive-fonts-recommended \
             pandoc

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.35",
+  "version": "1.1.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.35",
+      "version": "1.1.36",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.35",
+  "version": "1.1.36",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/tests/_helpers/compileLatex.ts
+++ b/tests/_helpers/compileLatex.ts
@@ -13,11 +13,13 @@
  * runs a fixture matrix through this and asserts every combination
  * compiles.
  *
- * Engine choice: xelatex (not pdflatex). SwiftLaTeX in production is
- * a XeTeX fork, so xelatex is the closest local engine. A bug that
- * compiles in xelatex but not in SwiftLaTeX would still be a SwiftLaTeX
- * quirk worth knowing about — but the inverse (compiles in SwiftLaTeX,
- * fails in xelatex) is uncommon and would still be a bug worth fixing.
+ * Engine choice: pdflatex. The production engine is the SwiftLaTeX
+ * *pdfTeX* build (public/lib/swiftlatexpdftex.wasm + PdfTeXEngine.js),
+ * NOT XeTeX — so pdflatex is the closest local engine. This matters:
+ * the harness previously used xelatex, which loads TS1/Unicode fonts
+ * pdfTeX lacks, so it green-lit documents that fataled in production
+ * (the § / tcrm1200 bug, twice). pdflatex shares pdfTeX's 8-bit font
+ * model and inputenc behavior, catching that class locally and in CI.
  *
  * Templates: read directly from `tex/main.tex` and `tex/templates/*.tex`
  * — these are the canonical source. The `public/lib/latex-templates.js`
@@ -118,14 +120,14 @@ function tail(log: string, n: number): string {
  * never rejects, even on timeout. The caller decides what counts as
  * a failure based on `exitCode`.
  */
-function runXelatex(cwd: string, mainFile: string): Promise<{
+function runPdflatex(cwd: string, mainFile: string): Promise<{
   exitCode: number | null;
   log: string;
 }> {
   return new Promise((resolve) => {
     let log = '';
     const proc = spawn(
-      'xelatex',
+      'pdflatex',
       [
         '-interaction=nonstopmode',
         '-halt-on-error',
@@ -149,7 +151,7 @@ function runXelatex(cwd: string, mainFile: string): Promise<{
 }
 
 /**
- * Compile a fixture with xelatex. Single-pass — we don't need
+ * Compile a fixture with pdflatex. Single-pass — we don't need
  * `\pageref{LastPage}` resolution for compile-error detection. If a
  * future test wants accurate page counts, run xelatex twice.
  */
@@ -192,7 +194,7 @@ export async function compileFixture(store: TestStore): Promise<CompileResult> {
   // No-op for now; if individual fixtures need stubs, the matrix can
   // override them.
 
-  const { exitCode, log } = await runXelatex(workDir, 'main.tex');
+  const { exitCode, log } = await runPdflatex(workDir, 'main.tex');
   const ok = exitCode === 0;
   const errors = parseLatexErrors(log);
   const logTail = tail(log, 60);

--- a/tests/integration/differential.test.ts
+++ b/tests/integration/differential.test.ts
@@ -41,12 +41,12 @@ import { applyFlags, buildBaseline, type DocType } from '../_helpers/compileMatr
 import { PDFParse } from 'pdf-parse';
 import mammoth from 'mammoth';
 
-const xelatexAvailable =
-  spawnSync('xelatex', ['--version'], { encoding: 'utf-8' }).status === 0;
+const pdflatexAvailable =
+  spawnSync('pdflatex', ['--version'], { encoding: 'utf-8' }).status === 0;
 const pandocAvailable =
   spawnSync('pandoc', ['--version'], { encoding: 'utf-8' }).status === 0;
 
-const toolchainAvailable = xelatexAvailable && pandocAvailable;
+const toolchainAvailable = pdflatexAvailable && pandocAvailable;
 
 if (!toolchainAvailable) {
   console.warn(

--- a/tests/integration/latex-compile-blank-lines.test.ts
+++ b/tests/integration/latex-compile-blank-lines.test.ts
@@ -34,17 +34,17 @@ import { spawnSync } from 'node:child_process';
 import { compileFixture, formatFailure } from '../_helpers/compileLatex';
 import { buildBaseline } from '../_helpers/compileMatrix';
 
-const xelatexAvailable =
-  spawnSync('xelatex', ['--version'], { encoding: 'utf-8' }).status === 0;
+const pdflatexAvailable =
+  spawnSync('pdflatex', ['--version'], { encoding: 'utf-8' }).status === 0;
 
-if (!xelatexAvailable) {
+if (!pdflatexAvailable) {
   console.warn(
     '[latex-compile-blank-lines] xelatex not found on PATH — suite will be SKIPPED.'
   );
 }
 
 describe('blank lines in paragraph text compile (raggedright standalone-\\\\ regression)', () => {
-  it.skipIf(!xelatexAvailable)(
+  it.skipIf(!pdflatexAvailable)(
     'LF blank lines: multi-block paste with \\n\\n compiles to PDF',
     async () => {
       const store = buildBaseline('naval_letter');
@@ -66,7 +66,7 @@ describe('blank lines in paragraph text compile (raggedright standalone-\\\\ reg
     120_000
   );
 
-  it.skipIf(!xelatexAvailable)(
+  it.skipIf(!pdflatexAvailable)(
     'CRLF blank lines: Windows-clipboard paste with \\r\\n\\r\\n compiles to PDF',
     async () => {
       const store = buildBaseline('naval_letter');
@@ -87,7 +87,7 @@ describe('blank lines in paragraph text compile (raggedright standalone-\\\\ reg
     120_000
   );
 
-  it.skipIf(!xelatexAvailable)(
+  it.skipIf(!pdflatexAvailable)(
     'leading/trailing newlines around paragraph text compile to PDF',
     async () => {
       const store = buildBaseline('naval_letter');

--- a/tests/integration/latex-compile-no-ts1.test.ts
+++ b/tests/integration/latex-compile-no-ts1.test.ts
@@ -37,17 +37,17 @@ import { join } from 'node:path';
 import { compileFixture, formatFailure } from '../_helpers/compileLatex';
 import { buildBaseline } from '../_helpers/compileMatrix';
 
-const xelatexAvailable =
-  spawnSync('xelatex', ['--version'], { encoding: 'utf-8' }).status === 0;
+const pdflatexAvailable =
+  spawnSync('pdflatex', ['--version'], { encoding: 'utf-8' }).status === 0;
 
-if (!xelatexAvailable) {
+if (!pdflatexAvailable) {
   console.warn(
     '[latex-compile-no-ts1] xelatex not found on PATH — suite will be SKIPPED.'
   );
 }
 
 describe('mapped symbols never request TS1 fonts (bundled-engine safety)', () => {
-  it.skipIf(!xelatexAvailable)(
+  it.skipIf(!pdflatexAvailable)(
     'naval letter with § ¶ † ‡ © ® ™ ° in body/subject/reference compiles with zero TS1 font loads',
     async () => {
       const store = buildBaseline('naval_letter');

--- a/tests/integration/latex-compile.test.ts
+++ b/tests/integration/latex-compile.test.ts
@@ -1,10 +1,10 @@
 /**
  * End-to-end LaTeX compile matrix.
  *
- * Runs `xelatex` on every fixture in `pairwiseMatrix()` — a covering
+ * Runs `pdflatex` (matching the production pdfTeX engine) on every fixture in `pairwiseMatrix()` — a covering
  * array (IPOG-style) over 18 per-doc-type dimensions, hitting every
  * 2-way (dim_a=val_x, dim_b=val_y) interaction across all 20 doc
- * types. A fixture passes iff xelatex exits 0 and produces a non-empty
+ * types. A fixture passes iff pdflatex exits 0 and produces a non-empty
  * PDF. This is the gap the rest of the test suite can't close: the
  * unit / property / fuzz tests assert on generator *output strings*,
  * but only this test proves those strings are valid LaTeX.
@@ -13,9 +13,9 @@
  * so the default `npm test` stays fast. Triggered via
  * `npm run test:integration` locally or the `compile-matrix` job in CI.
  *
- * Requires: `xelatex` on PATH. CI installs it via apt; macOS dev needs
+ * Requires: `pdflatex` on PATH. CI installs it via apt; macOS dev needs
  * MacTeX or BasicTeX. Tests are skipped (with a console warning) if
- * xelatex is unavailable, so a fresh checkout doesn't false-fail.
+ * pdflatex is unavailable, so a fresh checkout doesn't false-fail.
  */
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
@@ -25,16 +25,16 @@ import { pairwiseMatrix } from '../_helpers/compileMatrix';
 // Synchronous toolchain check at module load. Done at top level (not in
 // `beforeAll`) so the result is available BEFORE `describe.each` runs,
 // letting us use `it.skipIf(...)` and report tests as truly SKIPPED
-// (not falsely PASSED) when xelatex is missing. The previous pattern
+// (not falsely PASSED) when pdflatex is missing. The previous pattern
 // used `if (!available) return;` inside the test body, which made
 // vitest report 760 passing tests on a runner with no TeX Live —
 // silently green CI on machines without a working compile path.
-const xelatexAvailable =
-  spawnSync('xelatex', ['--version'], { encoding: 'utf-8' }).status === 0;
+const pdflatexAvailable =
+  spawnSync('pdflatex', ['--version'], { encoding: 'utf-8' }).status === 0;
 
-if (!xelatexAvailable) {
+if (!pdflatexAvailable) {
   console.warn(
-    '[latex-compile] xelatex not found on PATH — every fixture below will be SKIPPED.\n' +
+    '[latex-compile] pdflatex not found on PATH — every fixture below will be SKIPPED.\n' +
     'Install MacTeX (macOS) or `apt install texlive-xetex` (Linux) to run this suite.'
   );
 }
@@ -43,7 +43,7 @@ describe('LaTeX compile matrix', () => {
   const fixtures = pairwiseMatrix();
 
   describe.each(fixtures)('$name', ({ name, store }) => {
-    it.skipIf(!xelatexAvailable)('compiles to PDF without xelatex error', async () => {
+    it.skipIf(!pdflatexAvailable)('compiles to PDF without error', async () => {
       const result = await compileFixture(store);
 
       if (!result.ok) {


### PR DESCRIPTION
Audit T-1 (high). The compile harness used `xelatex`, but the production engine is the SwiftLaTeX **pdfTeX** build (`swiftlatexpdftex.wasm` / `PdfTeXEngine.js`), not XeTeX — the harness comment claiming a 'XeTeX fork' was wrong. xelatex carries TS1/Unicode fonts pdfTeX lacks, so it compiled documents that fataled in production. That gap is exactly why the §/tcrm1200 crash was invisible to CI **twice**.

Switched `runPdflatex` and every `pdflatexAvailable` skip gate to pdflatex (shares pdfTeX's 8-bit font model + inputenc behavior); added `texlive-latex-base` to the matrix job's apt install.

Verified: full integration matrix re-run locally under pdflatex — **774/774 pass**, including the no-TS1 test now running against the production-accurate engine. typecheck + lint clean.