### PR TITLE
fix(recovery): ErrorBoundary targets the auto-saved session key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.46",
+  "version": "1.1.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.46",
+      "version": "1.1.50",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.49",
+  "version": "1.1.50",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { debug } from '@/lib/debug';
 import { STORAGE_KEYS } from '@/lib/constants';
+import { getSavedSession } from '@/stores/documentStore';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -89,7 +90,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   handleCopySession = async (): Promise<void> => {
     try {
-      const data = localStorage.getItem(STORAGE_KEYS.DOCUMENT);
+      // The auto-saved session (the one that rehydrates on load, and the
+      // thing the user is most likely trying to rescue) is stored COMPRESSED
+      // under DOCUMENT_SESSION. Decompress it to readable JSON; fall back to
+      // the manual Save/Load draft under DOCUMENT.
+      const session = getSavedSession();
+      const data = session
+        ? JSON.stringify(session, null, 2)
+        : localStorage.getItem(STORAGE_KEYS.DOCUMENT);
       if (!data) {
         this.setState({ copyStatus: 'empty' });
         this.scheduleCopyStatusReset();
@@ -119,6 +127,11 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       return;
     }
     try {
+      // Clear BOTH the auto-saved session (rehydrated on load) and the
+      // manual draft. Previously only DOCUMENT was cleared, so a crash
+      // caused by the auto-saved session re-loaded the same bad state and
+      // crashed again — an infinite loop with no escape.
+      localStorage.removeItem(STORAGE_KEYS.DOCUMENT_SESSION);
       localStorage.removeItem(STORAGE_KEYS.DOCUMENT);
     } catch (err) {
       debug.error('Boundary', 'Failed to clear session before reload', err);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -203,6 +203,11 @@ export const STORAGE_KEYS = {
   // buttons) and read by ErrorBoundary.tsx (Copy saved draft / Reset and
   // reload buttons). Keep these in sync via this single source of truth.
   DOCUMENT: 'dondocs-document',
+  // Auto-saved session (written by documentStore's debounced autosave,
+  // read on load by the restore prompt). This is the key that actually
+  // rehydrates at startup — so it's the one ErrorBoundary must clear to
+  // break a crash-on-rehydrate loop.
+  DOCUMENT_SESSION: 'dondocs-document-session',
 } as const;
 
 /**

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -5,12 +5,12 @@ import { DOC_TYPE_CONFIG } from '@/types/document';
 import { useHistoryStore } from './historyStore';
 import type { DocumentSnapshot } from './historyStore';
 import { debug } from '@/lib/debug';
-import { TIMING } from '@/lib/constants';
+import { TIMING, STORAGE_KEYS} from '@/lib/constants';
 import { compressedParse, compressedStringify } from '@/lib/compressedStorage';
 import { canonicalizeUnitAddress } from '@/lib/unitAddress';
 
 // Session persistence keys
-const SESSION_STORAGE_KEY = 'dondocs-document-session';
+const SESSION_STORAGE_KEY = STORAGE_KEYS.DOCUMENT_SESSION;
 const SESSION_TIMESTAMP_KEY = 'dondocs-session-timestamp';
 const SESSION_MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
 

--- a/tests/regressions/errorboundary-session-key.test.ts
+++ b/tests/regressions/errorboundary-session-key.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression (audit critical #6): the ErrorBoundary's recovery operated on
+ * the wrong localStorage key. Its UI says "auto-saved draft", but it
+ * read/cleared STORAGE_KEYS.DOCUMENT (the manual Save/Load key) while the
+ * thing that rehydrates at startup — and can crash-loop the app — is the
+ * auto-saved session under DOCUMENT_SESSION. So "Copy saved draft" copied
+ * nothing, and "Reset and reload" left the crashing session in place →
+ * infinite crash loop. Recovery now targets the auto-saved session.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { STORAGE_KEYS } from '@/lib/constants';
+import { useDocumentStore, getSavedSession } from '@/stores/documentStore';
+
+describe('ErrorBoundary recovery key (critical #6)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('the recovery keys are distinct and both defined', () => {
+    expect(STORAGE_KEYS.DOCUMENT).toBe('dondocs-document');
+    expect(STORAGE_KEYS.DOCUMENT_SESSION).toBe('dondocs-document-session');
+    expect(STORAGE_KEYS.DOCUMENT).not.toBe(STORAGE_KEYS.DOCUMENT_SESSION);
+  });
+
+  it('the auto-saved session lands under DOCUMENT_SESSION, not DOCUMENT', () => {
+    vi.useFakeTimers();
+    useDocumentStore.setState({ formData: { subject: 'RECOVERY MARKER' } as never });
+    vi.advanceTimersByTime(3000); // past the 2s autosave debounce
+    vi.useRealTimers();
+
+    // What ErrorBoundary now reads (DOCUMENT_SESSION via getSavedSession) —
+    // populated. The old key it used to read (DOCUMENT) — empty.
+    expect(localStorage.getItem(STORAGE_KEYS.DOCUMENT_SESSION)).toBeTruthy();
+    expect(localStorage.getItem(STORAGE_KEYS.DOCUMENT)).toBeNull();
+    expect(getSavedSession()?.formData?.subject).toBe('RECOVERY MARKER');
+  });
+});


### PR DESCRIPTION
Audit critical #6. The crash-recovery UI says 'auto-saved draft' but read/cleared `STORAGE_KEYS.DOCUMENT` (the manual Save/Load key). The session that actually rehydrates at startup — and can crash-loop the app — lives under the separate `dondocs-document-session` key. Result: 'Copy saved draft' copied nothing; 'Reset and reload' left the crashing session in place and looped on every reload.

- Added `DOCUMENT_SESSION` to `STORAGE_KEYS` as the single source of truth; `documentStore` now references it.
- 'Copy saved draft' reads the decompressed auto-saved session (falls back to the manual draft).
- 'Reset and reload' clears both keys, breaking the loop.

2 new regression tests; 1155 total pass; typecheck + lint clean.