### PR TITLE
fix(privacy): bug-report flow no longer exfiltrates document content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.51",
+  "version": "1.1.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.51",
+      "version": "1.1.52",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.51",
+  "version": "1.1.52",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -26,6 +26,7 @@ import { uint8ArrayToBase64, base64ToUint8Array, arrayBufferToUint8Array } from 
 import { STORAGE_KEYS } from '@/lib/constants';
 import { canonicalizeUnitAddress } from '@/lib/unitAddress';
 import { useLogStore } from '@/stores/logStore';
+import { safeReportUrl, BUG_REPORT_PRIVACY_NOTICE, BUG_REPORT_LOG_PROMPT } from '@/lib/bugReport';
 
 interface HeaderProps {
   onDownloadPdf?: () => void;
@@ -53,43 +54,6 @@ const GITHUB_REPO_URL = 'https://github.com/marinecoders/dondocs';
 const GITHUB_NEW_ISSUE_URL = 'https://github.com/marinecoders/dondocs/issues/new';
 const STORAGE_KEY = STORAGE_KEYS.DOCUMENT;
 
-// GitHub URLs over ~8 KB start to fail in some browsers; cap the prefilled
-// log payload so the link always works. Users can still copy full logs from
-// Help → View Logs if they need the rest.
-const GH_ISSUE_LOG_MAX = 4000;
-// How many recent log entries to auto-include. We filter to errors + warnings
-// first — if there aren't enough, we fall back to the tail of all levels so
-// non-error bugs (UI glitches, etc.) still get useful context.
-const RECENT_LOG_COUNT = 40;
-
-/**
- * Grab recent logs from the LogStore for auto-inclusion in a bug report.
- * Prioritizes errors/warnings (what devs actually care about), falls back to
- * the tail of all levels if there aren't enough signal-level entries.
- * Returns null if logging isn't available or the store is empty.
- */
-function collectRecentLogs(): string | null {
-  const logs = useLogStore.getState().logs;
-  if (logs.length === 0) return null;
-
-  // Prefer error + warn; if we don't have at least a handful, include the
-  // tail of everything so there's still something to look at.
-  const signalLogs = logs.filter((l) => l.level === 'error' || l.level === 'warn');
-  const picked = signalLogs.length >= 5
-    ? signalLogs.slice(-RECENT_LOG_COUNT)
-    : logs.slice(-RECENT_LOG_COUNT);
-
-  const formatted = picked
-    .map((l) => `[${l.timestamp.toISOString()}] [${l.level.toUpperCase()}] ${l.message}`)
-    .join('\n');
-
-  if (formatted.length > GH_ISSUE_LOG_MAX) {
-    const truncated = formatted.slice(-GH_ISSUE_LOG_MAX);
-    return `… [older entries truncated — ${formatted.length - GH_ISSUE_LOG_MAX} more chars in Help → View Logs]\n${truncated}`;
-  }
-  return formatted;
-}
-
 /**
  * Build a prefilled "New issue" URL for the Help-menu bug report button.
  *
@@ -105,9 +69,10 @@ function collectRecentLogs(): string | null {
  * other rather than overlap.
  */
 function buildBugReportUrl(): string {
-  const recentLogs = collectRecentLogs();
 
   const body = [
+    BUG_REPORT_PRIVACY_NOTICE,
+    '',
     '<!--',
     'Thanks for reporting a bug! Not every section below is required — fill',
     'in what you can and delete anything that does not apply. The more',
@@ -131,16 +96,11 @@ function buildBugReportUrl(): string {
     '## Screenshots',
     '<!-- paste images here if relevant -->',
     '',
-    '## Logs',
-    recentLogs
-      ? '<!-- auto-captured from the in-app log store. Full logs available via Help → View Logs. -->\n```\n' +
-        recentLogs +
-        '\n```'
-      : '<!-- no recent errors were captured. If this bug produced one, open Help → View Logs, copy what you see, and paste below. -->\n```\n\n```',
+    BUG_REPORT_LOG_PROMPT,
     '',
     '## Environment',
     `- User agent: ${typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown'}`,
-    `- URL: ${typeof window !== 'undefined' ? window.location.href : 'unknown'}`,
+    `- URL: ${safeReportUrl()}`,
     `- Reported: ${new Date().toISOString()}`,
   ].join('\n');
 

--- a/src/components/modals/CompileErrorModal.tsx
+++ b/src/components/modals/CompileErrorModal.tsx
@@ -25,10 +25,9 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { useLogStore } from '@/stores/logStore';
+import { safeReportUrl, BUG_REPORT_PRIVACY_NOTICE, BUG_REPORT_LOG_PROMPT } from '@/lib/bugReport';
 
 const GITHUB_NEW_ISSUE_URL = 'https://github.com/marinecoders/dondocs/issues/new';
-// Keep the prefilled URL under the ~8 KB threshold that breaks some browsers.
-const GH_ISSUE_LOG_MAX = 6000;
 
 interface CompileErrorModalProps {
   open: boolean;
@@ -39,18 +38,13 @@ interface CompileErrorModalProps {
   onClose: () => void;
 }
 
-function buildIssueUrl(args: { error: string; compileLog?: string | null }): string {
-  const log = args.compileLog ?? undefined;
-  const truncated = log && log.length > GH_ISSUE_LOG_MAX
-    ? log.slice(0, GH_ISSUE_LOG_MAX) +
-      `\n\n… [log truncated — ${log.length - GH_ISSUE_LOG_MAX} more chars, paste the full log from the "Copy logs" button]`
-    : log;
-
+function buildIssueUrl(args: { error: string }): string {
   const body = [
+    BUG_REPORT_PRIVACY_NOTICE,
+    '',
     '<!--',
-    'Thanks for reporting this! The log below was captured automatically — you',
-    'only need to fill in what you were editing when it broke. Reporting bugs',
-    'is the fastest way to get them fixed; we triage every report.',
+    'Thanks for reporting this! Fill in what you were editing when it broke.',
+    'Reporting bugs is the fastest way to get them fixed; we triage every report.',
     '-->',
     '',
     '## What happened',
@@ -62,12 +56,11 @@ function buildIssueUrl(args: { error: string; compileLog?: string | null }): str
     '## What I was editing',
     '<!-- short description of what LaTeX / fields you were changing when this happened -->',
     '',
-    '## Log output',
-    truncated ? '```\n' + truncated + '\n```' : '(no log available)',
+    BUG_REPORT_LOG_PROMPT,
     '',
     '## Environment',
     `- User agent: ${typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown'}`,
-    `- URL: ${typeof window !== 'undefined' ? window.location.href : 'unknown'}`,
+    `- URL: ${safeReportUrl()}`,
     `- Reported: ${new Date().toISOString()}`,
   ].join('\n');
 
@@ -98,7 +91,7 @@ export function CompileErrorModal({ open, error, compileLog, onClose }: CompileE
 
   const handleReport = () => {
     if (!error) return;
-    const url = buildIssueUrl({ error, compileLog });
+    const url = buildIssueUrl({ error });
     window.open(url, '_blank', 'noopener,noreferrer');
   };
 
@@ -159,8 +152,8 @@ export function CompileErrorModal({ open, error, compileLog, onClose }: CompileE
           <p className="text-xs text-muted-foreground break-words">
             If this looks like a bug (not just a typo in your document), reporting
             it on GitHub is the fastest way to get it fixed — we triage every
-            report.
-            {compileLog ? ' The log is included in the prefilled issue.' : ''}
+            report. Use “Copy logs” and paste the log into the issue after
+            reviewing it — reports go to public GitHub, so don’t include CUI.
           </p>
 
           <DialogFooter className="flex-col-reverse sm:flex-row sm:justify-end gap-2">

--- a/src/components/modals/DownloadProgressModal.tsx
+++ b/src/components/modals/DownloadProgressModal.tsx
@@ -29,11 +29,9 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import type { DownloadProgressPhase } from './downloadProgressTypes';
+import { safeReportUrl, BUG_REPORT_PRIVACY_NOTICE, BUG_REPORT_LOG_PROMPT } from '@/lib/bugReport';
 
 const GITHUB_NEW_ISSUE_URL = 'https://github.com/marinecoders/dondocs/issues/new';
-// GitHub URLs over ~8 KB start to fail in some browsers; cap the pasted log
-// so the prefill link always works. Users hit "Copy logs" for the full text.
-const GH_ISSUE_LOG_MAX = 6000;
 
 interface DownloadProgressModalProps {
   /**
@@ -58,21 +56,17 @@ interface DownloadProgressModalProps {
 }
 
 /**
- * Build a prefilled "New issue" URL for the current error. Logs are
- * capped at GH_ISSUE_LOG_MAX chars so the URL stays under browser
- * length limits; the full log is still available via Copy logs.
+ * Build a prefilled "New issue" URL for the current error. Document
+ * content (logs, URL hash/share payload) is deliberately NOT embedded —
+ * the user pastes a reviewed log via "Copy logs". See lib/bugReport.ts.
  */
-function buildIssueUrl(args: { target: 'pdf' | 'docx'; title: string; message: string; compileLog?: string }): string {
-  const truncated = args.compileLog && args.compileLog.length > GH_ISSUE_LOG_MAX
-    ? args.compileLog.slice(0, GH_ISSUE_LOG_MAX) +
-      `\n\n… [log truncated — ${args.compileLog.length - GH_ISSUE_LOG_MAX} more chars, paste the full log from the "Copy logs" button]`
-    : args.compileLog;
-
+function buildIssueUrl(args: { target: 'pdf' | 'docx'; title: string; message: string }): string {
   const body = [
+    BUG_REPORT_PRIVACY_NOTICE,
+    '',
     '<!--',
-    'Thanks for reporting this! The log below was captured automatically — you',
-    'only need to fill in what happened and how to reproduce it. Reporting bugs',
-    'is the fastest way to get them fixed; we triage every report.',
+    'Thanks for reporting this! Fill in what happened and how to reproduce it.',
+    'Reporting bugs is the fastest way to get them fixed; we triage every report.',
     '-->',
     '',
     '## What happened',
@@ -84,12 +78,11 @@ function buildIssueUrl(args: { target: 'pdf' | 'docx'; title: string; message: s
     '## Steps to reproduce',
     '<!-- describe what you were doing when this happened -->',
     '',
-    '## Log output',
-    truncated ? '```\n' + truncated + '\n```' : '(no log available)',
+    BUG_REPORT_LOG_PROMPT,
     '',
     '## Environment',
     `- User agent: ${typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown'}`,
-    `- URL: ${typeof window !== 'undefined' ? window.location.href : 'unknown'}`,
+    `- URL: ${safeReportUrl()}`,
     `- Reported: ${new Date().toISOString()}`,
   ].join('\n');
 
@@ -228,7 +221,6 @@ export function DownloadProgressModal({ phase, onClose, onRetry }: DownloadProgr
       target: phase.target,
       title: phase.title,
       message: phase.message,
-      compileLog: phase.compileLog,
     });
     window.open(url, '_blank', 'noopener,noreferrer');
   };
@@ -359,7 +351,7 @@ export function DownloadProgressModal({ phase, onClose, onRetry }: DownloadProgr
                 <p className="text-xs text-muted-foreground break-words">
                   Reporting this on GitHub is the fastest way to get it fixed —
                   we triage every report.
-                  {phase.compileLog ? ' The log is included in the prefilled issue.' : ''}
+                  {phase.compileLog ? ' Use “Copy logs” and paste it into the issue after reviewing — reports are public, no CUI.' : ''}
                 </p>
               )}
 

--- a/src/lib/bugReport.ts
+++ b/src/lib/bugReport.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared helpers for the "Report a bug" flows.
+ *
+ * These flows open a prefilled GitHub issue (a public, commercial, non-.mil
+ * service). dondocs advertises "no data ever leaves your browser", so the
+ * bug-report URL must NOT carry document content off-device:
+ *   - The full URL (`window.location.href`) includes the `#s=<ciphertext>`
+ *     share payload when the app was opened from a share link — so we strip
+ *     the hash AND query and report only origin+pathname.
+ *   - Compile logs and in-app logs contain verbatim document body text, so
+ *     they are no longer auto-embedded; the user is asked to paste what they
+ *     have reviewed, with a visible warning that the report is public.
+ */
+
+/** A reportable page location with no hash (share payload) and no query. */
+export function safeReportUrl(): string {
+  if (typeof window === 'undefined') return 'unknown';
+  return `${window.location.origin}${window.location.pathname}`;
+}
+
+/** One-line warning placed at the top of every prefilled issue body. */
+export const BUG_REPORT_PRIVACY_NOTICE =
+  '> ⚠️ This issue is filed on **public GitHub**. Do not paste CUI, FOUO, ' +
+  'or any document content. Logs may contain your letter text — review ' +
+  'before pasting.';
+
+/** Markdown block instructing the user to paste logs manually (never auto-embedded). */
+export const BUG_REPORT_LOG_PROMPT =
+  '## Logs\n' +
+  '<!-- Use the "Copy logs" button in the app, REVIEW the text for sensitive ' +
+  'content, then paste it between the fences below. Leave empty if none. -->\n' +
+  '```\n\n```';

--- a/tests/regressions/bug-report-no-exfiltration.test.ts
+++ b/tests/regressions/bug-report-no-exfiltration.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression (audit critical #4): the "Report a bug" flows embedded
+ * document content into a public GitHub issue URL — the compile log
+ * (verbatim letter text), in-app logs, and the full window.location.href
+ * (which carries the #s=<ciphertext> share payload). That contradicts the
+ * "no data ever leaves your browser" promise. Reports now carry only
+ * origin+pathname (no hash/query) and never auto-embed logs.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { safeReportUrl, BUG_REPORT_PRIVACY_NOTICE, BUG_REPORT_LOG_PROMPT } from '@/lib/bugReport';
+
+describe('bug report URL sanitization (critical #4)', () => {
+  const realHref = Object.getOwnPropertyDescriptor(window, 'location');
+
+  beforeEach(() => {
+    // Simulate the app opened from a share link.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        origin: 'https://dondocs.example',
+        pathname: '/app/',
+        search: '?ref=email',
+        hash: '#s=ENCRYPTED_DOCUMENT_PAYLOAD',
+        href: 'https://dondocs.example/app/?ref=email#s=ENCRYPTED_DOCUMENT_PAYLOAD',
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (realHref) Object.defineProperty(window, 'location', realHref);
+  });
+
+  it('safeReportUrl strips the hash (share payload) and query', () => {
+    const url = safeReportUrl();
+    expect(url).toBe('https://dondocs.example/app/');
+    expect(url).not.toContain('ENCRYPTED_DOCUMENT_PAYLOAD');
+    expect(url).not.toContain('#');
+    expect(url).not.toContain('?');
+  });
+
+  it('the log prompt asks the user to paste, never auto-embeds content', () => {
+    expect(BUG_REPORT_LOG_PROMPT).toContain('Copy logs');
+    expect(BUG_REPORT_LOG_PROMPT).not.toContain('ENCRYPTED');
+    // It is an empty fenced block, not pre-populated content.
+    expect(BUG_REPORT_LOG_PROMPT).toContain('```\n\n```');
+  });
+
+  it('the privacy notice warns about public GitHub + CUI', () => {
+    expect(BUG_REPORT_PRIVACY_NOTICE.toLowerCase()).toContain('public');
+    expect(BUG_REPORT_PRIVACY_NOTICE).toContain('CUI');
+  });
+});


### PR DESCRIPTION
Audit critical #4. The three 'Report a bug' builders (Header, CompileErrorModal, DownloadProgressModal) embedded document content into a **public GitHub** issue URL:
- the **compile log** — verbatim letter body text;
- the **in-app logs**;
- `window.location.href` — which carries the `#s=<ciphertext>` **share payload** when the app was opened from a share link.

That directly contradicts the app's 'no data ever leaves your browser' claim.

- New `src/lib/bugReport.ts` with `safeReportUrl()` (origin+pathname only — no hash, no query), a one-line privacy notice, and a manual log-paste prompt.
- All three builders use it: logs are no longer auto-embedded; the user pastes a reviewed log via the existing 'Copy logs' button; the URL can no longer carry the share payload.
- UI copy updated to say reports are public and must not contain CUI.

3 new regression tests (hash/query stripped, no auto-embed, notice present); 1156 total pass; typecheck + lint clean.