### PR TITLE
ci: allowlist pdfjs-dist advisory 1118732

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,7 +179,10 @@ jobs:
         run: |
           # Comma-separated GHSA / npm advisory IDs we accept (with reason).
           # Add new entries as a separate PR with the reason inline.
-          export KNOWN_ADVISORIES="1104044"   # @react-pdf-viewer transitive — no upstream fix
+          # Both advisories are pdfjs-dist transitive via @react-pdf-viewer (dormant
+          # upstream, no fix). Tracked for the react-pdf migration that removes
+          # @react-pdf-viewer entirely; until then they are knowingly accepted.
+          export KNOWN_ADVISORIES="1104044,1118732"   # @react-pdf-viewer → pdfjs-dist
           npm audit --json > audit.json || true
           UNKNOWN=$(python3 <<'PY'
           import json, os

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.33",
+  "version": "1.1.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.33",
+      "version": "1.1.34",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.33",
+  "version": "1.1.34",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
The `npm audit (high+)` gate fails on **every** open branch because advisory **1118732** (PDF.js arbitrary-JS-execution, via `pdfjs-dist` → `@react-pdf-viewer`, dormant upstream) isn't in `KNOWN_ADVISORIES` — only the older `1104044` is. Both are the same dependency with no upstream fix, tracked for the react-pdf migration that drops `@react-pdf-viewer`.

Adds `1118732` to the allowlist with the reason inline. Verified locally: zero unknown high/critical advisories remain, so the gate passes on a clean branch. **Merge this first** — it greens the audit gate across all the other open PRs.