### PR TITLE
test: add React component tests for recovery, classification, and share paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "web-react",
-  "version": "1.1.49",
+  "version": "1.1.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.49",
+      "version": "1.1.50",
+      "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -55,6 +56,10 @@
         "@stryker-mutator/typescript-checker": "^9.6.1",
         "@stryker-mutator/vitest-runner": "^9.6.1",
         "@tailwindcss/vite": "^4.3.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.10.4",
         "@types/pako": "^2.0.4",
         "@types/react": "^19.2.5",
@@ -79,6 +84,13 @@
         "vitest": "^4.1.5",
         "workbox-window": "^7.0.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@apideck/better-ajv-errors": {
       "version": "0.3.7",
@@ -5531,6 +5543,95 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tiptap/core": {
       "version": "3.23.1",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.23.1.tgz",
@@ -5999,6 +6100,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -6597,11 +6705,23 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/aproba": {
@@ -6664,6 +6784,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -7203,6 +7333,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -7415,6 +7552,13 @@
       "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/duck": {
       "version": "0.1.12",
@@ -8745,6 +8889,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -9844,6 +9998,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -9964,6 +10128,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -10612,6 +10786,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -10857,6 +11046,13 @@
         "react": "^19.2.6"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-pdf": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-10.4.1.tgz",
@@ -10980,6 +11176,20 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -11827,6 +12037,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.49",
+  "version": "1.1.50",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -67,6 +67,10 @@
     "@stryker-mutator/typescript-checker": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
     "@tailwindcss/vite": "^4.3.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.10.4",
     "@types/pako": "^2.0.4",
     "@types/react": "^19.2.5",

--- a/tests/_helpers/setup.ts
+++ b/tests/_helpers/setup.ts
@@ -7,6 +7,16 @@
  * the same code services both the vitest runner (this file) AND the
  * cartesian CLI runner (`tests/cartesian/_globals.ts`).
  */
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
 import { installStorageShim } from './storageShim';
 
 installStorageShim();
+
+// Unmount any component-test trees and reset jsdom between tests so React
+// component tests (tests/component/**) don't leak DOM into one another.
+// Pure-function tests render nothing, so cleanup() is a no-op for them.
+afterEach(() => {
+  cleanup();
+});

--- a/tests/component/ClassificationSection.test.tsx
+++ b/tests/component/ClassificationSection.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Component tests for <ClassificationSection> (classification path).
+ *
+ * Classification marking is the highest-consequence domain in the app
+ * (audit #1). These tests lock in that the picker surfaces the right
+ * marking-specific fields for the selected level — the classified warning
+ * + classified config for a classified level, the CUI config for CUI, and
+ * neither for an unclassified document.
+ *
+ * Domain restriction + async config are mocked to a permissive, settled
+ * state so the conditional rendering is driven purely by the selected
+ * level (not by the test host's hostname or a config-load race).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ClassificationSection } from '@/components/editor/ClassificationSection';
+import { useDocumentStore } from '@/stores/documentStore';
+
+const ALL_LEVELS = ['unclassified', 'cui', 'confidential', 'secret', 'top_secret', 'top_secret_sci'];
+
+vi.mock('@/lib/domainClassification', () => ({
+  getDomainClassificationRestriction: () => ({ allowedLevels: ALL_LEVELS }),
+  getDomainRestrictionMessage: () => 'All levels permitted (test).',
+}));
+vi.mock('@/config/classification', () => ({
+  getClassificationConfig: () => Promise.resolve(null),
+}));
+
+function setLevel(level: string) {
+  useDocumentStore.getState().setField('classLevel', level);
+}
+
+beforeEach(() => {
+  setLevel('unclassified');
+});
+
+describe('ClassificationSection', () => {
+  it('reflects the selected classified level in the section header', () => {
+    setLevel('secret');
+    render(<ClassificationSection />);
+    // The header label is visible without expanding the accordion.
+    expect(screen.getByText('(SECRET)')).toBeInTheDocument();
+  });
+
+  it('shows the classified warning + classified config when a classified level is selected', async () => {
+    const user = userEvent.setup();
+    setLevel('secret');
+    render(<ClassificationSection />);
+
+    await user.click(screen.getByText('Classification')); // expand accordion
+
+    expect(await screen.findByText('Classified Document Warning')).toBeInTheDocument();
+    expect(screen.getByText('Classified Configuration')).toBeInTheDocument();
+    expect(screen.getByLabelText('Classified By')).toBeInTheDocument();
+    // CUI-only config must NOT be present for a classified (non-CUI) level.
+    expect(screen.queryByText('CUI Configuration')).not.toBeInTheDocument();
+  });
+
+  it('shows CUI configuration (and no classified warning) for CUI', async () => {
+    const user = userEvent.setup();
+    setLevel('cui');
+    render(<ClassificationSection />);
+
+    await user.click(screen.getByText('Classification'));
+
+    expect(await screen.findByText('CUI Configuration')).toBeInTheDocument();
+    expect(screen.queryByText('Classified Document Warning')).not.toBeInTheDocument();
+  });
+
+  it('shows neither classified nor CUI config for an unclassified document', async () => {
+    const user = userEvent.setup();
+    setLevel('unclassified');
+    render(<ClassificationSection />);
+
+    await user.click(screen.getByText('Classification'));
+
+    // Domain-restriction info always renders; marking-specific blocks do not.
+    expect(await screen.findByText('Domain Restrictions')).toBeInTheDocument();
+    expect(screen.queryByText('Classified Document Warning')).not.toBeInTheDocument();
+    expect(screen.queryByText('CUI Configuration')).not.toBeInTheDocument();
+  });
+});

--- a/tests/component/ErrorBoundary.test.tsx
+++ b/tests/component/ErrorBoundary.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Component tests for the top-level <ErrorBoundary> (recovery path).
+ *
+ * The recovery UI is itself untested by the rest of the suite, yet it is
+ * the last line of defense against a white-screen crash. These tests lock
+ * in the behaviour that matters during a real crash:
+ *   - children render normally when nothing throws;
+ *   - a render-phase throw is caught and the fallback is shown;
+ *   - "Copy saved draft" reflects copied / empty / failed states;
+ *   - "Reset and reload" clears BOTH session keys (the regression that
+ *     used to clear the wrong key and infinite-crash-loop — audit #6).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { STORAGE_KEYS } from '@/lib/constants';
+
+// Control what the boundary believes is in the auto-saved session.
+const getSavedSession = vi.fn();
+vi.mock('@/stores/documentStore', () => ({
+  getSavedSession: () => getSavedSession(),
+}));
+
+function Bomb(): never {
+  throw new Error('KaBoom');
+}
+
+// React prints the caught error to console.error; silence it so the test
+// output stays readable (the boundary's own behaviour is what we assert).
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  getSavedSession.mockReset();
+  localStorage.clear();
+});
+
+describe('ErrorBoundary', () => {
+  it('renders children when nothing throws', () => {
+    render(
+      <ErrorBoundary>
+        <p>all good</p>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText('all good')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('catches a render-phase throw and shows the recovery UI', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    );
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Something went wrong');
+    // The original error name + message are surfaced to the user.
+    expect(alert).toHaveTextContent('Error:');
+    expect(alert).toHaveTextContent('KaBoom');
+  });
+
+  it('"Copy saved draft" copies the decompressed session and confirms', async () => {
+    const user = userEvent.setup();
+    getSavedSession.mockReturnValue({ docType: 'naval_letter', paragraphs: [] });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    );
+    await user.click(screen.getByRole('button', { name: /copy auto-saved session/i }));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0][0]).toContain('naval_letter');
+    expect(await screen.findByText('Copied ✓')).toBeInTheDocument();
+  });
+
+  it('"Copy saved draft" reports "No saved draft" when nothing is stored', async () => {
+    const user = userEvent.setup();
+    getSavedSession.mockReturnValue(null); // no compressed session
+    // and no manual DOCUMENT draft either
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    );
+    await user.click(screen.getByRole('button', { name: /copy auto-saved session/i }));
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(await screen.findByText('No saved draft')).toBeInTheDocument();
+  });
+
+  it('"Copy saved draft" reports failure when the clipboard rejects', async () => {
+    const user = userEvent.setup();
+    getSavedSession.mockReturnValue({ docType: 'naval_letter' });
+    const writeText = vi.fn().mockRejectedValue(new Error('insecure context'));
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    );
+    await user.click(screen.getByRole('button', { name: /copy auto-saved session/i }));
+
+    expect(await screen.findByText('Copy failed')).toBeInTheDocument();
+  });
+
+  it('"Reset and reload" clears BOTH session keys after confirmation (audit #6)', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(STORAGE_KEYS.DOCUMENT_SESSION, 'compressed-session');
+    localStorage.setItem(STORAGE_KEYS.DOCUMENT, 'manual-draft');
+    window.confirm = vi.fn().mockReturnValue(true);
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload },
+      writable: true,
+      configurable: true,
+    });
+
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    );
+    await user.click(screen.getByRole('button', { name: /erase saved draft and reload/i }));
+
+    expect(localStorage.getItem(STORAGE_KEYS.DOCUMENT_SESSION)).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEYS.DOCUMENT)).toBeNull();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('"Reset and reload" is a no-op when the user cancels the confirm', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(STORAGE_KEYS.DOCUMENT_SESSION, 'compressed-session');
+    window.confirm = vi.fn().mockReturnValue(false);
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, reload },
+      writable: true,
+      configurable: true,
+    });
+
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    );
+    await user.click(screen.getByRole('button', { name: /erase saved draft and reload/i }));
+
+    expect(localStorage.getItem(STORAGE_KEYS.DOCUMENT_SESSION)).toBe('compressed-session');
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('toggles the stack-trace details on demand', async () => {
+    const user = userEvent.setup();
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    );
+    expect(screen.queryByText('Stack trace')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /show details/i }));
+    expect(screen.getByText('Stack trace')).toBeInTheDocument();
+  });
+});

--- a/tests/component/RestoreSessionModal.test.tsx
+++ b/tests/component/RestoreSessionModal.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Component tests for <RestoreSessionModal> (recovery path).
+ *
+ * Covers the prompt that decides the fate of a returning user's unsaved
+ * work, including the suspend/resume guard that stops mount-time autosaves
+ * from clobbering the saved session before the user chooses (audit #10
+ * restore-race; the fix shipped in fix/restore-race).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RestoreSessionModal } from '@/components/modals/RestoreSessionModal';
+import * as store from '@/stores/documentStore';
+import { getDeviceInfo } from '@/utils/device';
+import { SW_AUTO_RESTORE_KEY } from '@/hooks/useServiceWorker';
+
+vi.mock('@/stores/documentStore', () => ({
+  hasSavedSession: vi.fn(),
+  suspendSessionSaves: vi.fn(),
+  resumeSessionSaves: vi.fn(),
+  getSavedSession: vi.fn(),
+  restoreSession: vi.fn(),
+  clearSavedSession: vi.fn(),
+  getSessionAge: vi.fn(() => '2 hours ago'),
+}));
+vi.mock('@/utils/device', () => ({
+  getDeviceInfo: vi.fn(() => ({ isInAppBrowser: false })),
+}));
+vi.mock('@/hooks/useServiceWorker', () => ({
+  SW_AUTO_RESTORE_KEY: 'dondocs-sw-auto-restore',
+}));
+
+const SESSION = {
+  docType: 'naval_letter',
+  formData: { subject: 'PROMOTION RECOMMENDATION' },
+  paragraphs: [{ text: 'a' }, { text: 'b' }],
+  references: [{ letter: 'a', title: 'ref' }],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  sessionStorage.clear();
+  vi.mocked(getDeviceInfo).mockReturnValue({ isInAppBrowser: false } as ReturnType<typeof getDeviceInfo>);
+  vi.mocked(store.getSessionAge).mockReturnValue('2 hours ago');
+});
+
+describe('RestoreSessionModal', () => {
+  it('stays closed when there is no saved session', () => {
+    vi.mocked(store.hasSavedSession).mockReturnValue(false);
+    render(<RestoreSessionModal />);
+    expect(screen.queryByText('Restore Previous Session?')).not.toBeInTheDocument();
+    expect(store.suspendSessionSaves).not.toHaveBeenCalled();
+  });
+
+  it('opens, suspends autosave, and previews the saved session', async () => {
+    vi.mocked(store.hasSavedSession).mockReturnValue(true);
+    vi.mocked(store.getSavedSession).mockReturnValue(SESSION as ReturnType<typeof store.getSavedSession>);
+
+    render(<RestoreSessionModal />);
+
+    expect(await screen.findByText('Restore Previous Session?')).toBeInTheDocument();
+    // Autosave is frozen while the prompt is up (the restore-race guard).
+    expect(store.suspendSessionSaves).toHaveBeenCalledTimes(1);
+    // Preview is seeded from the saved session.
+    expect(screen.getByText('Naval Letter')).toBeInTheDocument();
+    expect(screen.getByText(/PROMOTION RECOMMENDATION/)).toBeInTheDocument();
+    expect(screen.getByText('2 paragraphs')).toBeInTheDocument();
+    expect(screen.getByText('1 reference')).toBeInTheDocument();
+  });
+
+  it('"Restore Session" restores and resumes autosave', async () => {
+    const user = userEvent.setup();
+    vi.mocked(store.hasSavedSession).mockReturnValue(true);
+    vi.mocked(store.getSavedSession).mockReturnValue(SESSION as ReturnType<typeof store.getSavedSession>);
+
+    render(<RestoreSessionModal />);
+    await screen.findByText('Restore Previous Session?');
+    await user.click(screen.getByRole('button', { name: /restore session/i }));
+
+    expect(store.restoreSession).toHaveBeenCalledTimes(1);
+    expect(store.resumeSessionSaves).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(screen.queryByText('Restore Previous Session?')).not.toBeInTheDocument()
+    );
+  });
+
+  it('"Start Fresh" clears the session and resumes autosave', async () => {
+    const user = userEvent.setup();
+    vi.mocked(store.hasSavedSession).mockReturnValue(true);
+    vi.mocked(store.getSavedSession).mockReturnValue(SESSION as ReturnType<typeof store.getSavedSession>);
+
+    render(<RestoreSessionModal />);
+    await screen.findByText('Restore Previous Session?');
+    await user.click(screen.getByRole('button', { name: /start fresh/i }));
+
+    expect(store.clearSavedSession).toHaveBeenCalledTimes(1);
+    expect(store.resumeSessionSaves).toHaveBeenCalledTimes(1);
+    expect(store.restoreSession).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt inside an in-app browser', () => {
+    vi.mocked(getDeviceInfo).mockReturnValue({ isInAppBrowser: true } as ReturnType<typeof getDeviceInfo>);
+    vi.mocked(store.hasSavedSession).mockReturnValue(true);
+    vi.mocked(store.getSavedSession).mockReturnValue(SESSION as ReturnType<typeof store.getSavedSession>);
+
+    render(<RestoreSessionModal />);
+    expect(screen.queryByText('Restore Previous Session?')).not.toBeInTheDocument();
+    expect(store.suspendSessionSaves).not.toHaveBeenCalled();
+  });
+
+  it('auto-restores silently (no prompt) after a service-worker update', () => {
+    localStorage.setItem(SW_AUTO_RESTORE_KEY, 'true');
+    vi.mocked(store.hasSavedSession).mockReturnValue(true);
+    vi.mocked(store.getSavedSession).mockReturnValue(SESSION as ReturnType<typeof store.getSavedSession>);
+
+    render(<RestoreSessionModal />);
+
+    expect(store.restoreSession).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Restore Previous Session?')).not.toBeInTheDocument();
+    // The one-shot flag is consumed so it can't re-fire next mount.
+    expect(localStorage.getItem(SW_AUTO_RESTORE_KEY)).toBeNull();
+  });
+});

--- a/tests/component/ShareModal.test.tsx
+++ b/tests/component/ShareModal.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Component tests for <ShareModal> (share path).
+ *
+ * The encrypt-and-share / paste-and-import round trip is the user-facing
+ * surface of the client-side crypto. shareCrypto's primitives are unit
+ * tested separately; here we lock in that the modal wires them correctly:
+ * generating a link encrypts the session and copies it, and importing
+ * decrypts the payload and loads it (surfacing a friendly error on a bad
+ * password rather than throwing).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ShareModal } from '@/components/modals/ShareModal';
+import {
+  encryptSharePayload,
+  decryptSharePayload,
+  buildShareUrl,
+} from '@/lib/shareCrypto';
+import {
+  getSerializedSessionForShare,
+  loadSharedSession,
+} from '@/stores/documentStore';
+
+vi.mock('@/lib/shareCrypto', () => ({
+  encryptSharePayload: vi.fn(),
+  decryptSharePayload: vi.fn(),
+  buildShareUrl: vi.fn((p: string) => `https://dondocs.app/#s=${p}`),
+  parseShareUrl: vi.fn((s: string) => (s.includes('#s=') ? s.split('#s=')[1] : null)),
+}));
+vi.mock('@/stores/documentStore', () => ({
+  getSerializedSessionForShare: vi.fn(() => ({ docType: 'naval_letter' })),
+  loadSharedSession: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// userEvent.setup() installs its own clipboard stub, so any spy must be
+// assigned AFTER it to win — this helper returns the writeText spy.
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+  return writeText;
+}
+
+describe('ShareModal — share mode', () => {
+  it('encrypts the session, builds a link, and copies it to the clipboard', async () => {
+    const user = userEvent.setup();
+    const writeText = stubClipboard();
+    vi.mocked(encryptSharePayload).mockResolvedValue('ENCRYPTED');
+
+    render(<ShareModal open mode="share" onOpenChange={vi.fn()} />);
+
+    await user.type(screen.getByLabelText('Password for this link'), 'hunter2');
+    await user.click(screen.getByRole('button', { name: /generate link/i }));
+
+    expect(encryptSharePayload).toHaveBeenCalledWith({ docType: 'naval_letter' }, 'hunter2');
+    expect(buildShareUrl).toHaveBeenCalledWith('ENCRYPTED');
+    expect(writeText).toHaveBeenCalledWith('https://dondocs.app/#s=ENCRYPTED');
+    expect(getSerializedSessionForShare).toHaveBeenCalledTimes(1);
+    // The generated link is surfaced for the user to copy/share.
+    expect(await screen.findByDisplayValue('https://dondocs.app/#s=ENCRYPTED')).toBeInTheDocument();
+  });
+
+  it('disables Generate link until a password is entered', () => {
+    render(<ShareModal open mode="share" onOpenChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /generate link/i })).toBeDisabled();
+  });
+});
+
+describe('ShareModal — import mode', () => {
+  it('decrypts the payload, loads the session, and closes', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onImportComplete = vi.fn();
+    vi.mocked(decryptSharePayload).mockResolvedValue({ docType: 'naval_letter' });
+
+    render(
+      <ShareModal
+        open
+        mode="import"
+        initialPayload="PAYLOAD"
+        onOpenChange={onOpenChange}
+        onImportComplete={onImportComplete}
+      />
+    );
+
+    await user.type(screen.getByLabelText('Password'), 'hunter2');
+    await user.click(screen.getByRole('button', { name: /open document/i }));
+
+    expect(decryptSharePayload).toHaveBeenCalledWith('PAYLOAD', 'hunter2');
+    expect(loadSharedSession).toHaveBeenCalledWith({ docType: 'naval_letter' });
+    expect(onImportComplete).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('surfaces a friendly error on a bad password instead of throwing', async () => {
+    const user = userEvent.setup();
+    vi.mocked(decryptSharePayload).mockRejectedValue(new Error('decryption failed'));
+
+    render(<ShareModal open mode="import" initialPayload="PAYLOAD" onOpenChange={vi.fn()} />);
+
+    await user.type(screen.getByLabelText('Password'), 'wrongpass');
+    await user.click(screen.getByRole('button', { name: /open document/i }));
+
+    expect(await screen.findByText('decryption failed')).toBeInTheDocument();
+    expect(loadSharedSession).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -56,17 +56,18 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       // Whole-source thresholds. Set just below the current numbers
-      // (Statements 9.31%, Branches 8.03%, Functions 7.15%, Lines 9.63%
-      // as of the property/fuzz/integration test layer landing) so a
-      // future PR can't accidentally drop coverage by removing tests
-      // — even one test file going missing fails the gate. Bump these
-      // upward as the suite grows. Margins are deliberately tight
-      // (~0.1%) so coverage drift trips the alarm early.
+      // (Statements 15.62%, Branches 14.48%, Functions 13.26%,
+      // Lines 16.09% as of the first React component-test layer landing
+      // — tests/component/**) so a future PR can't accidentally drop
+      // coverage by removing tests — even one test file going missing
+      // fails the gate. Bump these upward as the suite grows. Margins
+      // are deliberately tight (~0.1%) so coverage drift trips the alarm
+      // early.
       thresholds: {
-        statements: 9.2,
-        branches: 7.9,
-        functions: 7.1,
-        lines: 9.5,
+        statements: 15.5,
+        branches: 14.4,
+        functions: 13.2,
+        lines: 16.0,
       },
       // Report on the whole src/ surface, not just imported files. That
       // way the threshold reflects the actual proportion of the codebase


### PR DESCRIPTION
## What

Establishes the first **React component-test layer** for the app and uses it to cover the highest-consequence UI paths called out in the audit (critical #10 — *"Zero React component tests despite 1137 unit + 770 integration tests"*).

Adds `@testing-library/react` + `@testing-library/jest-dom` (React 19 compatible) wired into the existing happy-dom vitest setup, with `cleanup()` between tests.

## Coverage added (22 tests, `tests/component/`)

**Recovery**
- `ErrorBoundary` — renders children normally; catches a render-phase throw and shows the recovery UI; *Copy saved draft* reflects copied / empty / failed; **Reset and reload clears BOTH session keys** (locks in the critical #6 fix); cancel is a no-op; details toggle.
- `RestoreSessionModal` — opens + previews a saved session and **suspends autosave** while the prompt is up (the restore-race guard); Restore vs Start Fresh; in-app-browser suppression; silent service-worker auto-restore.

**Classification**
- `ClassificationSection` — the correct marking-specific fields surface for the selected level (classified warning + classified config; CUI config; neither for unclassified).

**Share**
- `ShareModal` — generate-link encrypts the session, builds the URL, and copies it; import decrypts the payload and loads the session; a bad password surfaces a friendly error instead of throwing.

## Notes
- Coverage rose from ~9% to ~16%; thresholds in `vitest.config.ts` bumped to match the new floor so the drift-guard stays tight.
- Full suite (1202 tests), typecheck, eslint, coverage gate, and production build all pass locally.
- `npm audit` high+ gate unaffected — the new dev deps introduce no new unallowlisted advisories.