### PR TITLE
feat(tour): guided product tour and new-user onboarding

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
+    <!-- Preload the welcome-letter artwork so it paints with the text instead
+         of popping in a beat later (shown the moment a new user lands; the
+         seal also serves as the app background watermark). -->
+    <link rel="preload" as="image" href="/attachments/marine-coders-banner.webp" type="image/webp" />
+    <link rel="preload" as="image" href="/attachments/marine-coders-logo.svg" type="image/svg+xml" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Free SECNAV M-5216.5 correspondence & form generator for Navy/USMC. 20 document types — naval letters, memoranda, endorsements, NAVMC forms. PDF/DOCX export, 100% browser-based, works offline." />
     <meta property="og:title" content="DonDocs - Naval Correspondence & Form Generator" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.51",
+  "version": "1.1.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.51",
+      "version": "1.1.52",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.51",
+  "version": "1.1.52",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { FindReplaceModal } from '@/components/modals/FindReplaceModal';
 import { TemplateLoaderModal } from '@/components/modals/TemplateLoaderModal';
 import { DocumentGuideModal } from '@/components/modals/DocumentGuideModal';
 import { WelcomeModal } from '@/components/modals/WelcomeModal';
+import { TourOverlay } from '@/components/tour/TourOverlay';
 import { PIIWarningModal } from '@/components/modals/PIIWarningModal';
 import { LogViewerModal } from '@/components/modals/LogViewerModal';
 import { EnclosureErrorModal } from '@/components/modals/EnclosureErrorModal';
@@ -1454,6 +1455,7 @@ ${texFiles['body.tex'] || '% No body content'}
       <TemplateLoaderModal />
       <DocumentGuideModal />
       <WelcomeModal />
+      <TourOverlay />
       <PIIWarningModal
         detectionResult={piiDetectionResult}
         onCancel={handleCancelPIIDownload}

--- a/src/components/editor/DocumentTypeSelector.tsx
+++ b/src/components/editor/DocumentTypeSelector.tsx
@@ -51,7 +51,7 @@ export function DocumentTypeSelector() {
   return (
     <div className="space-y-density-4">
       {/* Category Tabs - Correspondence vs Forms (at the top) */}
-      <div className="space-y-2 border border-border rounded-lg bg-card/60 backdrop-blur-sm px-3 py-3 shadow-sm">
+      <div data-tour="category" className="space-y-2 border border-border rounded-lg bg-card/60 backdrop-blur-sm px-3 py-3 shadow-sm">
         <Label>Category</Label>
         <Tabs value={documentCategory} onValueChange={(v) => setDocumentCategory(v as DocumentCategory)}>
           <TabsList className="grid w-full grid-cols-2">
@@ -106,7 +106,7 @@ export function DocumentTypeSelector() {
       {isCorrespondence && (
       <div className="space-y-density-4 border border-border rounded-lg bg-card/60 backdrop-blur-sm px-3 py-3 shadow-sm">
         {/* Document Type Selector */}
-        <div className="space-y-2">
+        <div data-tour="doctype" className="space-y-2">
           <Label>Document Type</Label>
           <Select value={docType} onValueChange={(v) => setDocType(v)}>
             <SelectTrigger>

--- a/src/components/editor/DocumentTypeSelector.tsx
+++ b/src/components/editor/DocumentTypeSelector.tsx
@@ -135,6 +135,7 @@ export function DocumentTypeSelector() {
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
+                      data-tour="templates"
                       variant="ghost"
                       size="sm"
                       // Tinting the bg with --primary (USMC red at 10% opacity)

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -632,7 +632,7 @@ export function Header({
           {/* Save/Load dropdown - always visible but compact on smaller screens */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" className="h-8 px-2 lg:px-3">
+              <Button data-tour="save" variant="outline" size="sm" className="h-8 px-2 lg:px-3">
                 <Save className="h-4 w-4 lg:mr-2" />
                 <span className="hidden lg:inline">Save</span>
               </Button>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -26,6 +26,7 @@ import { uint8ArrayToBase64, base64ToUint8Array, arrayBufferToUint8Array } from 
 import { STORAGE_KEYS } from '@/lib/constants';
 import { canonicalizeUnitAddress } from '@/lib/unitAddress';
 import { useLogStore } from '@/stores/logStore';
+import { useTourStore } from '@/stores/tourStore';
 import { safeReportUrl, BUG_REPORT_PRIVACY_NOTICE, BUG_REPORT_LOG_PROMPT } from '@/lib/bugReport';
 
 interface HeaderProps {
@@ -678,7 +679,7 @@ export function Header({
           {/* Download dropdown - always visible but compact on smaller screens */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" className="h-8 px-2 lg:px-3">
+              <Button data-tour="download" variant="outline" size="sm" className="h-8 px-2 lg:px-3">
                 <Download className="h-4 w-4 lg:mr-2" />
                 <span className="hidden lg:inline">Download</span>
               </Button>
@@ -767,11 +768,16 @@ export function Header({
           {/* Help dropdown - hidden below xl */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" aria-label="Help & Info" title="Help & Info" className="h-8 w-8 hidden xl:flex">
+              <Button data-tour="help" variant="ghost" size="icon" aria-label="Help & Info" title="Help & Info" className="h-8 w-8 hidden xl:flex">
                 <HelpCircle className="h-4 w-4" aria-hidden="true" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-72">
+              <DropdownMenuItem onClick={() => useTourStore.getState().start()}>
+                <Compass className="h-4 w-4 mr-2" />
+                Take the Tour
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => setNistModalOpen(true)}>
                 <Shield className="h-4 w-4 mr-2" />
                 NIST 800-171 Compliance
@@ -825,7 +831,7 @@ export function Header({
           {/* Appearance dropdown - hidden below xl */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" aria-label="Appearance settings" title="Appearance" className="h-8 w-8 sm:h-9 sm:w-9 hidden xl:flex">
+              <Button data-tour="appearance" variant="ghost" size="icon" aria-label="Appearance settings" title="Appearance" className="h-8 w-8 sm:h-9 sm:w-9 hidden xl:flex">
                 <Settings className="h-4 w-4" aria-hidden="true" />
               </Button>
             </DropdownMenuTrigger>
@@ -921,6 +927,10 @@ export function Header({
               <DropdownMenuSeparator />
               {/* Help section */}
               <div className="px-2 py-1 text-xs text-muted-foreground font-medium">Help</div>
+              <DropdownMenuItem onClick={() => useTourStore.getState().start()}>
+                <Compass className="h-4 w-4 mr-2" />
+                Take the Tour
+              </DropdownMenuItem>
               <DropdownMenuItem onClick={() => setNistModalOpen(true)}>
                 <Shield className="h-4 w-4 mr-2" />
                 NIST 800-171

--- a/src/components/modals/WelcomeModal.tsx
+++ b/src/components/modals/WelcomeModal.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { useTourStore, hasCompletedTour } from '@/stores/tourStore';
+import { useUIStore } from '@/stores/uiStore';
 // Signature face for the letter's "Marine Coders" sign-off. Self-hosted via
 // @fontsource (bundled, served same-origin), so it stays air-gap safe: no
 // web-font CDN. Damion is a bold connected script that reads as signed.
@@ -71,6 +72,10 @@ export function WelcomeModal() {
     if (!stored || stored !== WELCOME_CONTENT_VERSION) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setOpen(true);
+      // New users land with the live preview open so they immediately see the
+      // document take shape. This only runs for the welcome cohort (no saved
+      // session), so returning users keep their own preview preference.
+      useUIStore.getState().setPreviewVisible(true);
     }
   }, []);
 
@@ -109,6 +114,8 @@ export function WelcomeModal() {
                 src={BANNER_SRC}
                 alt="Marine Coders"
                 className="mx-auto"
+                decoding="sync"
+                fetchPriority="high"
                 style={{ height: '46px', filter: 'brightness(0)' }}
               />
               <div style={{ borderTop: `1px solid ${INK}`, marginTop: '12px' }} />
@@ -171,6 +178,8 @@ export function WelcomeModal() {
                 src={SEAL_SRC}
                 alt=""
                 aria-hidden="true"
+                decoding="sync"
+                fetchPriority="high"
                 style={{ height: '52px', filter: 'brightness(0)', opacity: 0.9 }}
               />
             </div>

--- a/src/components/modals/WelcomeModal.tsx
+++ b/src/components/modals/WelcomeModal.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
+import { useTourStore, hasCompletedTour } from '@/stores/tourStore';
 // Signature face for the letter's "Marine Coders" sign-off. Self-hosted via
 // @fontsource (bundled, served same-origin), so it stays air-gap safe: no
 // web-font CDN. Damion is a bold connected script that reads as signed.
@@ -78,6 +79,12 @@ export function WelcomeModal() {
       localStorage.setItem(WELCOME_STORAGE_KEY, WELCOME_CONTENT_VERSION);
     }
     setOpen(false);
+    // First-run: flow straight into the guided tour the first time, once the
+    // welcome dialog's close animation finishes. Returning users have a saved
+    // session and never see the welcome, so this only fires for new users.
+    if (!hasCompletedTour()) {
+      setTimeout(() => useTourStore.getState().start(), 350);
+    }
   };
 
   return (

--- a/src/components/tour/TourOverlay.tsx
+++ b/src/components/tour/TourOverlay.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTourStore } from '@/stores/tourStore';
+import { TOUR_STEPS } from '@/components/tour/tourSteps';
+import { Button } from '@/components/ui/button';
+
+interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+const CARD_W = 304;
+const CARD_H_EST = 188; // generous estimate for placement math only
+const GAP = 12; // space between target and card
+const PAD = 6; // spotlight padding around the target
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
+/**
+ * Guided-tour overlay. Dims the page, spotlights the current step's target
+ * (a box-shadow cutout), and anchors a coachmark beside it. Drives entirely
+ * from `useTourStore`; renders nothing when the tour is inactive.
+ *
+ * The highlighted element is shown but not interactive — the tour is a
+ * walkthrough, not a task, so navigation is via the card and the keyboard
+ * (Esc to exit, arrows to move). If a step's target is missing or hidden,
+ * the card centers and the spotlight is skipped, so the tour never breaks.
+ */
+export function TourOverlay() {
+  const active = useTourStore((s) => s.active);
+  const stepIndex = useTourStore((s) => s.stepIndex);
+  const next = useTourStore((s) => s.next);
+  const prev = useTourStore((s) => s.prev);
+  const end = useTourStore((s) => s.end);
+
+  const [rect, setRect] = useState<Rect | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const step = TOUR_STEPS[stepIndex];
+  const isLast = stepIndex === TOUR_STEPS.length - 1;
+
+  // Locate + track the target rect for the current step.
+  useEffect(() => {
+    if (!active || !step) return;
+    const reduce = prefersReducedMotion();
+    const el = step.target
+      ? document.querySelector<HTMLElement>(step.target)
+      : null;
+
+    if (!el) {
+      // Legitimate "sync React state with the DOM" measurement; the target is
+      // absent (hidden at this breakpoint) so we fall back to a centered card.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setRect(null);
+      return;
+    }
+
+    el.scrollIntoView({ block: 'center', inline: 'nearest', behavior: reduce ? 'auto' : 'smooth' });
+
+    const update = () => {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) {
+        setRect(null); // hidden (e.g. collapsed at this breakpoint)
+      } else {
+        setRect({ top: r.top, left: r.left, width: r.width, height: r.height });
+      }
+    };
+
+    update();
+    // Recompute after the smooth scroll settles.
+    const settle = window.setTimeout(update, reduce ? 0 : 280);
+    window.addEventListener('scroll', update, true);
+    window.addEventListener('resize', update);
+    return () => {
+      window.clearTimeout(settle);
+      window.removeEventListener('scroll', update, true);
+      window.removeEventListener('resize', update);
+    };
+  }, [active, stepIndex, step]);
+
+  // Keyboard controls + initial focus.
+  useEffect(() => {
+    if (!active) return;
+    cardRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') end();
+      else if (e.key === 'ArrowRight') next();
+      else if (e.key === 'ArrowLeft') prev();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [active, stepIndex, next, prev, end]);
+
+  if (!active || !step) return null;
+
+  // Position the coachmark: below the target if it fits, otherwise above;
+  // clamped to the viewport. Centered when there is no target.
+  let cardStyle: React.CSSProperties;
+  if (rect) {
+    const below = rect.top + rect.height + PAD + GAP;
+    const fitsBelow = below + CARD_H_EST < window.innerHeight;
+    const top = fitsBelow ? below : Math.max(GAP, rect.top - PAD - GAP - CARD_H_EST);
+    const left = Math.min(
+      Math.max(GAP, rect.left + rect.width / 2 - CARD_W / 2),
+      window.innerWidth - CARD_W - GAP
+    );
+    cardStyle = { top, left, width: CARD_W };
+  } else {
+    cardStyle = { top: '50%', left: '50%', transform: 'translate(-50%, -50%)', width: CARD_W };
+  }
+
+  return (
+    <div role="dialog" aria-modal="true" aria-label="Product tour">
+      {/* Click-catcher: blocks interaction with the page beneath the tour. */}
+      <div className="fixed inset-0 z-[60]" />
+
+      {/* The dim + spotlight. With a target, a transparent box punches a hole
+          via its huge spread shadow; without one, a plain full-screen dim. */}
+      {rect ? (
+        <div
+          className="fixed z-[61] pointer-events-none rounded-lg ring-2 ring-primary transition-all duration-200"
+          style={{
+            top: rect.top - PAD,
+            left: rect.left - PAD,
+            width: rect.width + PAD * 2,
+            height: rect.height + PAD * 2,
+            boxShadow: '0 0 0 9999px rgba(0,0,0,0.62)',
+          }}
+        />
+      ) : (
+        <div className="fixed inset-0 z-[61] pointer-events-none bg-black/60" />
+      )}
+
+      {/* Coachmark */}
+      <div
+        ref={cardRef}
+        tabIndex={-1}
+        className="fixed z-[62] rounded-xl border bg-popover text-popover-foreground p-4 shadow-elevated outline-none"
+        style={cardStyle}
+      >
+        <div className="text-xs text-muted-foreground mb-1">
+          {stepIndex + 1} of {TOUR_STEPS.length}
+        </div>
+        <h3 className="text-sm font-semibold mb-1">{step.title}</h3>
+        <p className="text-[13px] text-muted-foreground leading-relaxed mb-3">{step.body}</p>
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={end}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Skip tour
+          </button>
+          <div className="flex gap-2">
+            {stepIndex > 0 && (
+              <Button variant="outline" size="sm" onClick={prev}>
+                Back
+              </Button>
+            )}
+            <Button size="sm" onClick={next}>
+              {isLast ? 'Done' : 'Next'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/tour/TourOverlay.tsx
+++ b/src/components/tour/TourOverlay.tsx
@@ -84,6 +84,11 @@ export function TourOverlay() {
   // Keyboard controls + initial focus.
   useEffect(() => {
     if (!active) return;
+    // The welcome dialog can leave pointer-events:none stuck on <body>; clear
+    // it here (after render, so it wins over Radix's layout effects).
+    if (document.body.style.pointerEvents === 'none') {
+      document.body.style.pointerEvents = '';
+    }
     cardRef.current?.focus();
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') end();
@@ -114,8 +119,9 @@ export function TourOverlay() {
 
   return (
     <div role="dialog" aria-modal="true" aria-label="Product tour">
-      {/* Click-catcher: blocks interaction with the page beneath the tour. */}
-      <div className="fixed inset-0 z-[60]" />
+      {/* Click-catcher: blocks interaction with the page beneath the tour.
+          Explicit pointer-events so it works even if <body> is locked. */}
+      <div className="fixed inset-0 z-[60] pointer-events-auto" />
 
       {/* The dim + spotlight. With a target, a transparent box punches a hole
           via its huge spread shadow; without one, a plain full-screen dim. */}
@@ -138,7 +144,7 @@ export function TourOverlay() {
       <div
         ref={cardRef}
         tabIndex={-1}
-        className="fixed z-[62] rounded-xl border bg-popover text-popover-foreground p-4 shadow-elevated outline-none"
+        className="fixed z-[62] pointer-events-auto rounded-xl border bg-popover text-popover-foreground p-4 shadow-elevated outline-none"
         style={cardStyle}
       >
         <div className="text-xs text-muted-foreground mb-1">

--- a/src/components/tour/tourSteps.ts
+++ b/src/components/tour/tourSteps.ts
@@ -1,0 +1,43 @@
+/**
+ * Steps for the guided product tour.
+ *
+ * Each step spotlights a real element (found by its `data-tour` attribute)
+ * and explains it in a coachmark. Keep the set short — a tour earns its
+ * keep by getting out of the way, not by narrating every control. If a
+ * step's target is not on screen (e.g. hidden at a narrow breakpoint) the
+ * overlay falls back to a centered card, so the tour never breaks.
+ */
+export interface TourStep {
+  /** CSS selector for the element to spotlight. Omit for a centered card. */
+  target?: string;
+  title: string;
+  body: string;
+}
+
+export const TOUR_STEPS: TourStep[] = [
+  {
+    target: '[data-tour="category"]',
+    title: 'Start here',
+    body: 'Choose what you are writing: Department of the Navy correspondence, or a service form.',
+  },
+  {
+    target: '[data-tour="doctype"]',
+    title: 'Pick the format',
+    body: 'Each document type is set up to match its governing instruction, so the layout is correct from the first keystroke.',
+  },
+  {
+    target: '[data-tour="download"]',
+    title: 'Export when ready',
+    body: 'Generate a print-ready PDF or a Word file. Everything compiles in your browser; nothing leaves your device.',
+  },
+  {
+    target: '[data-tour="appearance"]',
+    title: 'Make it yours',
+    body: 'Switch between light and dark mode and adjust the spacing here.',
+  },
+  {
+    target: '[data-tour="help"]',
+    title: 'Help lives here',
+    body: 'Guides, keyboard shortcuts, bug reports, and feature ideas are all in this menu, and you can replay this tour from here anytime.',
+  },
+];

--- a/src/components/tour/tourSteps.ts
+++ b/src/components/tour/tourSteps.ts
@@ -26,9 +26,19 @@ export const TOUR_STEPS: TourStep[] = [
     body: 'Each document type is set up to match its governing instruction, so the layout is correct from the first keystroke.',
   },
   {
+    target: '[data-tour="templates"]',
+    title: 'Or start from a template',
+    body: 'Load a ready-made document for common formats instead of starting from a blank page.',
+  },
+  {
     target: '[data-tour="download"]',
     title: 'Export when ready',
     body: 'Generate a print-ready PDF or a Word file. Everything compiles in your browser; nothing leaves your device.',
+  },
+  {
+    target: '[data-tour="save"]',
+    title: 'Save your work',
+    body: 'Your draft autosaves to this browser. Save keeps a named copy you can reload later or share.',
   },
   {
     target: '[data-tour="appearance"]',

--- a/src/stores/tourStore.ts
+++ b/src/stores/tourStore.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand';
+import { TOUR_STEPS } from '@/components/tour/tourSteps';
+
+const TOUR_STORAGE_KEY = 'dondocs-tour-completed';
+// Version of the TOUR CONTENT (not the app). Bump when the steps change
+// meaningfully so the first-run tour replays once for returning users.
+const TOUR_VERSION = '1';
+
+interface TourState {
+  active: boolean;
+  stepIndex: number;
+  /** Open the tour from the first step (used by replays and first-run). */
+  start: () => void;
+  next: () => void;
+  prev: () => void;
+  /** Close the tour and mark it seen so first-run does not nag again. */
+  end: () => void;
+}
+
+export const useTourStore = create<TourState>((set, get) => ({
+  active: false,
+  stepIndex: 0,
+  start: () => set({ active: true, stepIndex: 0 }),
+  next: () => {
+    const { stepIndex } = get();
+    if (stepIndex >= TOUR_STEPS.length - 1) {
+      get().end();
+      return;
+    }
+    set({ stepIndex: stepIndex + 1 });
+  },
+  prev: () => set((s) => ({ stepIndex: Math.max(0, s.stepIndex - 1) })),
+  end: () => {
+    // Mark seen whether the user finished or skipped — first-run is one-time;
+    // explicit replays via start() ignore this flag.
+    try {
+      localStorage.setItem(TOUR_STORAGE_KEY, TOUR_VERSION);
+    } catch {
+      /* storage unavailable — nothing to persist */
+    }
+    set({ active: false, stepIndex: 0 });
+  },
+}));
+
+/** True once the user has seen the current tour version (first-run guard). */
+export function hasCompletedTour(): boolean {
+  try {
+    return localStorage.getItem(TOUR_STORAGE_KEY) === TOUR_VERSION;
+  } catch {
+    return true; // if we cannot read storage, don't auto-start
+  }
+}

--- a/src/stores/tourStore.ts
+++ b/src/stores/tourStore.ts
@@ -17,10 +17,26 @@ interface TourState {
   end: () => void;
 }
 
+// A closing Radix dialog (e.g. the welcome modal) can leave
+// `pointer-events: none` stuck on <body>, which would make the tour — and
+// the whole app — unclickable. Clear it whenever the tour opens or closes.
+function clearBodyPointerLock(): void {
+  try {
+    if (document.body.style.pointerEvents === 'none') {
+      document.body.style.pointerEvents = '';
+    }
+  } catch {
+    /* no DOM */
+  }
+}
+
 export const useTourStore = create<TourState>((set, get) => ({
   active: false,
   stepIndex: 0,
-  start: () => set({ active: true, stepIndex: 0 }),
+  start: () => {
+    clearBodyPointerLock();
+    set({ active: true, stepIndex: 0 });
+  },
   next: () => {
     const { stepIndex } = get();
     if (stepIndex >= TOUR_STEPS.length - 1) {
@@ -38,6 +54,7 @@ export const useTourStore = create<TourState>((set, get) => ({
     } catch {
       /* storage unavailable — nothing to persist */
     }
+    clearBodyPointerLock();
     set({ active: false, stepIndex: 0 });
   },
 }));


### PR DESCRIPTION
## Summary

- Adds a guided spotlight tour: it dims the page, highlights each control, and explains it. Seven steps (category, document type, templates, download, save, appearance, help), driven by a small store with a box-shadow spotlight and a positioned coachmark. No new dependency.
- "Take the Tour" lives in the desktop and mobile Help menus so it can be replayed anytime, and it runs once on first visit after the welcome letter, gated by a versioned flag.
- Targets carry data-tour attributes; a missing or hidden target falls back to a centered card so the tour never breaks. Accessible: Esc to exit, arrow-key navigation, focus into the coachmark, and it respects prefers-reduced-motion.
- New users land with the live PDF preview open so they immediately see the document take shape; returning users keep their own preference.
- Preloads the welcome banner and seal and decodes them synchronously so they paint with the letter text instead of a beat later.
- Clears a pointer-events lock that a closing dialog can leave on the body, so the tour stays clickable after the welcome closes.

Version 1.1.52. Verified: typecheck, full test suite (1202), and CI all green.