### PR TITLE
feat(ui): guide Features tab, clearer Save menu, lighter watermark

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.52",
+  "version": "1.1.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.52",
+      "version": "1.1.53",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.52",
+  "version": "1.1.53",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1364,7 +1364,7 @@ ${texFiles['body.tex'] || '% No body content'}
         <img
           src={marineCodersLogo}
           alt=""
-          className="w-full max-w-[90vw] sm:max-w-[1200px] opacity-[0.08] sm:opacity-[0.07] dark:opacity-[0.12] dark:sm:opacity-[0.10] invert dark:invert-0"
+          className="w-full max-w-[90vw] sm:max-w-[1200px] opacity-[0.04] sm:opacity-[0.035] dark:opacity-[0.12] dark:sm:opacity-[0.10] invert dark:invert-0"
           aria-hidden="true"
         />
       </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,11 +1,12 @@
 import { useState, useCallback, useRef, useEffect, type ChangeEvent } from 'react';
-import { Moon, Sun, Download, FileText, RefreshCw, Bug, Save, RotateCcw, Shield, HelpCircle, Info, Layers, Search, Keyboard, Menu, FileDown, FileUp, ScrollText, SlidersHorizontal, Minimize2, Maximize2, Check, Settings, Undo2, Redo2, Eraser, Compass, PanelRight, PanelRightClose, Link2, FileInput, X, Zap, Loader2, Lightbulb } from 'lucide-react';
+import { Moon, Sun, Download, FileText, RefreshCw, Bug, Save, RotateCcw, Shield, HelpCircle, Info, Layers, Search, Keyboard, Menu, FileDown, FileUp, ScrollText, SlidersHorizontal, Minimize2, Maximize2, Check, Settings, Undo2, Redo2, Eraser, Compass, PanelRight, PanelRightClose, Link2, FileInput, X, Zap, Loader2, Lightbulb, FolderOpen } from 'lucide-react';
 import { GithubIcon } from '@/components/icons/GithubIcon';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
@@ -637,41 +638,44 @@ export function Header({
                 <span className="hidden lg:inline">Save</span>
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
+            <DropdownMenuContent align="end" className="w-60">
+              <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">Draft (this browser)</DropdownMenuLabel>
               <DropdownMenuItem onClick={handleSaveProgress}>
                 <Save className="h-4 w-4 mr-2" />
-                Save Progress
+                Save draft
               </DropdownMenuItem>
               <DropdownMenuItem onClick={handleLoadProgress}>
-                <Download className="h-4 w-4 mr-2" />
-                Load Saved
+                <FolderOpen className="h-4 w-4 mr-2" />
+                Open saved draft
               </DropdownMenuItem>
               <DropdownMenuSeparator />
+              <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">Share</DropdownMenuLabel>
               <DropdownMenuItem onClick={() => setShareModal('share')}>
                 <Link2 className="h-4 w-4 mr-2" />
-                Share link…
+                Create share link…
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => setShareModal('import')}>
                 <FileInput className="h-4 w-4 mr-2" />
-                Import from link
+                Open from share link
               </DropdownMenuItem>
               <DropdownMenuSeparator />
+              <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">Backup file (.json)</DropdownMenuLabel>
               <DropdownMenuItem onClick={handleExportDraft}>
                 <FileDown className="h-4 w-4 mr-2" />
-                Export Draft to File
+                Export to file
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => fileInputRef.current?.click()}>
                 <FileUp className="h-4 w-4 mr-2" />
-                Import Draft from File
+                Import from file
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => setShowClearFieldsDialog(true)} className="text-orange-600 dark:text-orange-400">
                 <Eraser className="h-4 w-4 mr-2" />
-                Clear Fields (Keep Letterhead)
+                Clear fields (keep letterhead)
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => setShowResetDialog(true)} variant="destructive">
                 <RotateCcw className="h-4 w-4 mr-2" />
-                Reset All Fields
+                Reset all fields
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { HelpCircle, ChevronDown, ChevronRight, FileText, CheckCircle2, Lightbulb, BookOpen, Sparkles, ArrowRight, RotateCcw, Search, Eye, Check } from 'lucide-react';
+import { HelpCircle, ChevronDown, ChevronRight, FileText, CheckCircle2, Lightbulb, BookOpen, Sparkles, ArrowRight, RotateCcw, Search, Eye, Check, Zap, Layers, Users, FolderOpen, Paperclip, PenLine, Link2, Shield, type LucideIcon } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -745,11 +745,58 @@ function ExamplesTab({ onClose }: { onClose: () => void }) {
   );
 }
 
+// The power features that are easy to miss. Shown in the guide's "Features"
+// tab so people discover what DonDocs can do beyond drafting a single letter.
+const POWER_FEATURES: { icon: LucideIcon; title: string; where: string; body: string }[] = [
+  {
+    icon: Layers,
+    title: 'Batch generation',
+    where: 'Toolbar → Batch',
+    body: 'Generate many documents at once. Put {{NAME}} (or any label) in a field, paste a list of values, and DonDocs produces one finished document per row. Ideal for award citations, promotion letters, or anything repeated across people.',
+  },
+  {
+    icon: Users,
+    title: 'Profiles',
+    where: 'Top-left selector',
+    body: 'Save your unit letterhead and sender details as a reusable profile so you never retype them. Switch profiles to draft for a different command.',
+  },
+  {
+    icon: FolderOpen,
+    title: 'Templates',
+    where: 'Next to document type',
+    body: 'Start from a ready-made document for common formats instead of a blank page.',
+  },
+  {
+    icon: Paperclip,
+    title: 'Enclosures',
+    where: 'Enclosures section',
+    body: 'Attach PDF enclosures. They are listed on the letter and merged into the final PDF automatically.',
+  },
+  {
+    icon: PenLine,
+    title: 'Signature',
+    where: 'Signature section',
+    body: 'Add a signature block, an optional signature image, or a digital signature field on the exported PDF.',
+  },
+  {
+    icon: Link2,
+    title: 'Encrypted share link',
+    where: 'Save → Create share link',
+    body: 'Send a document as a password-protected link. Nothing is stored on a server; the recipient needs both the link and the password you set.',
+  },
+  {
+    icon: Shield,
+    title: 'Classification & portion marks',
+    where: 'Classification section',
+    body: 'Set the document classification and per-paragraph portion marks. The banner is derived from the highest marking in the document.',
+  },
+];
+
 export function DocumentGuideModal() {
   // Individual selectors — modal only re-renders on its own flag changing.
   const documentGuideOpen = useUIStore((s) => s.documentGuideOpen);
   const setDocumentGuideOpen = useUIStore((s) => s.setDocumentGuideOpen);
-  const [activeTab, setActiveTab] = useState<'finder' | 'browse' | 'examples'>('finder');
+  const [activeTab, setActiveTab] = useState<'finder' | 'browse' | 'examples' | 'features'>('finder');
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [expandedGuide, setExpandedGuide] = useState<string | null>(null);
@@ -845,12 +892,49 @@ export function DocumentGuideModal() {
               <span className="hidden sm:inline">Examples</span>
               <span className="sm:hidden">Examples</span>
             </button>
+            <button
+              onClick={() => setActiveTab('features')}
+              className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                activeTab === 'features'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              <Zap className="h-4 w-4" />
+              <span className="hidden sm:inline">Features</span>
+              <span className="sm:hidden">More</span>
+            </button>
           </div>
         </div>
 
         {activeTab === 'finder' && (
           <div className="flex-1 min-h-0 overflow-y-auto">
             <DocumentFinder onSelectGuide={handleSelectFromFinder} />
+          </div>
+        )}
+
+        {activeTab === 'features' && (
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            <div className="p-6 space-y-3">
+              <p className="text-sm text-muted-foreground">
+                DonDocs does more than draft a single letter. Here is what each feature does and where to find it.
+              </p>
+              {POWER_FEATURES.map((f) => {
+                const Icon = f.icon;
+                return (
+                  <div key={f.title} className="flex items-start gap-3 rounded-lg border bg-card/50 p-3">
+                    <Icon className="h-5 w-5 text-primary shrink-0 mt-0.5" />
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <h4 className="font-medium text-sm">{f.title}</h4>
+                        <span className="text-[11px] text-muted-foreground bg-muted rounded px-1.5 py-0.5">{f.where}</span>
+                      </div>
+                      <p className="text-sm text-muted-foreground mt-0.5">{f.body}</p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
           </div>
         )}
 

--- a/src/index.css
+++ b/src/index.css
@@ -3,52 +3,10 @@
 
 @custom-variant dark (&:is(.dark *));
 
-@layer base {
-  :root {
-    --background: 220 14% 10%;
-    --foreground: 210 40% 98%;
-    --card: 220 10% 14%;
-    --card-foreground: 210 40% 98%;
-    --popover: 220 10% 14%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 210 100% 50%;
-    --primary-foreground: 220 14% 10%;
-    --secondary: 220 10% 16%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 220 10% 16%;
-    --muted-foreground: 215 15% 75%;
-    --accent: 220 10% 16%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 220 10% 20%;
-    --input: 220 10% 20%;
-    --ring: 210 100% 50%;
-    --radius: 0.5rem;
-  }
-
-  .light {
-    --background: 0 0% 100%;
-    --foreground: 222 47% 11%;
-    --card: 0 0% 100%;
-    --card-foreground: 222 47% 11%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222 47% 11%;
-    --primary: 210 100% 50%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 210 40% 96%;
-    --secondary-foreground: 222 47% 11%;
-    --muted: 210 40% 96%;
-    --muted-foreground: 215 25% 35%;
-    --accent: 210 40% 96%;
-    --accent-foreground: 222 47% 11%;
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 0 0% 100%;
-    --border: 214 32% 91%;
-    --input: 214 32% 91%;
-    --ring: 210 100% 50%;
-  }
-}
+/* Theme tokens live in the unlayered `:root` (light) and `.dark` blocks
+   further down, in oklch. The legacy HSL `:root`/`.light` token block that
+   used to sit here was dead: the unlayered rules always win, and the app
+   only ever toggles the `dark` class, never `light`. */
 
 @layer base {
   * {


### PR DESCRIPTION
Three small UI improvements bundled together.

## Document Guide — new Features tab
The guide already helped people pick a document type, but never explained the power features. Added a **Features** tab that lists what's easy to miss, each with a one-line "where to find it" pointer:

- **Batch generation** — drop `{{NAME}}` in a field, paste a list, get one document per row
- **Profiles** — save unit letterhead and sender details for reuse
- **Templates** — start from a ready-made document
- **Enclosures** — attach PDFs that merge into the final output
- **Signature** — signature block, image, or digital field
- **Encrypted share link** — password-protected, nothing stored server-side
- **Classification & portion marks** — per-paragraph marks; banner derived from the highest

## Save menu cleanup
The Save dropdown crammed eight items with no grouping. Split into labeled sections — **Draft (this browser)** / **Share** / **Backup file (.json)** — with plainer item names, and swapped the misleading download icon on "Open saved draft" for a folder-open icon.

## Lighter light-mode watermark
The background seal read too loud in light mode (dark-on-light contrast). Dropped its opacity so it's a faint texture instead of a visible image. Dark mode unchanged.

## Dead CSS removal
Deleted the legacy HSL `:root`/`.light` token block in `index.css`. The unlayered oklch `:root`/`.dark` tokens always won, and the app only ever toggles the `dark` class — the old block never applied. Verified both themes still render correctly.

Version bumped to 1.1.53. Build, type-check, lint, and all 1202 tests pass.