### PR TITLE
feat(guide): interactive feature tutorials in the Features tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.53",
+  "version": "1.1.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.53",
+      "version": "1.1.54",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.53",
+  "version": "1.1.54",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/editor/ClassificationSection.tsx
+++ b/src/components/editor/ClassificationSection.tsx
@@ -223,7 +223,7 @@ export function ClassificationSection() {
             </div>
 
             {/* Classification Level */}
-            <div className="space-y-2">
+            <div data-tour="classification-level" className="space-y-2">
               <Label htmlFor="classLevel">Classification Level</Label>
               <Select
                 value={classLevel}

--- a/src/components/editor/ClassificationSection.tsx
+++ b/src/components/editor/ClassificationSection.tsx
@@ -179,7 +179,7 @@ export function ClassificationSection() {
   const isCustom = classLevel === 'custom';
 
   return (
-    <Accordion type="single" collapsible>
+    <Accordion data-tour="classification" type="single" collapsible>
       <AccordionItem value="classification">
         <AccordionTrigger>
           <div className="flex items-center gap-2">

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -389,6 +389,7 @@ export function EnclosuresManager() {
 
               <div className="space-y-2 mt-2">
                 <Button
+                  data-tour="enclosure-add"
                   variant="outline"
                   onClick={() => addEnclosure('')}
                   className="w-full"
@@ -399,6 +400,7 @@ export function EnclosuresManager() {
 
                 {/* Drop zone for PDFs */}
                 <label
+                  data-tour="enclosure-attach"
                   className={`flex flex-col items-center justify-center gap-2 p-4 border-2 border-dashed rounded-lg cursor-pointer transition-colors ${
                     isDraggingOver
                       ? 'border-primary bg-primary/10'

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -290,7 +290,7 @@ export function EnclosuresManager() {
   }, [handleUploadNewEnclosure]);
 
   return (
-    <Accordion type="single" collapsible>
+    <Accordion data-tour="enclosures" type="single" collapsible>
       <AccordionItem value="enclosures">
         <AccordionTrigger>
           <span className="flex items-center gap-2">

--- a/src/components/editor/ProfileBar.tsx
+++ b/src/components/editor/ProfileBar.tsx
@@ -122,7 +122,7 @@ export function ProfileBar() {
   };
 
   return (
-    <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border bg-secondary/20">
+    <div data-tour="profiles" className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border bg-secondary/20">
       <Select value={selectedProfile || '__none__'} onValueChange={handleProfileChange}>
         <SelectTrigger className="w-40 h-7 text-xs">
           <SelectValue placeholder="Select Profile" />

--- a/src/components/editor/ProfileBar.tsx
+++ b/src/components/editor/ProfileBar.tsx
@@ -138,6 +138,7 @@ export function ProfileBar() {
       </Select>
 
       <Button
+        data-tour="profile-create"
         variant="ghost"
         size="icon"
         className="h-7 w-7"

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -226,7 +226,7 @@ export function SignatureSection({ config }: SignatureSectionProps) {
             )}
 
             {/* Name fields */}
-            <div className="grid grid-cols-3 gap-2 sm:gap-4">
+            <div data-tour="signature-name" className="grid grid-cols-3 gap-2 sm:gap-4">
               <div className="space-y-2 col-span-2 sm:col-span-1">
                 <Label htmlFor="sigFirst">First Name</Label>
                 <Input
@@ -469,7 +469,7 @@ export function SignatureSection({ config }: SignatureSectionProps) {
             </div>
 
             {/* Signature Type Selection */}
-            <div className="space-y-3">
+            <div data-tour="signature-style" className="space-y-3">
               <Label>Signature Style</Label>
               {/* All signature options available */}
                 <div className="grid grid-cols-3 gap-2">

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -174,7 +174,7 @@ export function SignatureSection({ config }: SignatureSectionProps) {
 
   return (
     <>
-    <Accordion type="single" collapsible>
+    <Accordion data-tour="signature" type="single" collapsible>
       <AccordionItem value="signature">
         <AccordionTrigger>
           <span className="flex items-center gap-2">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -759,6 +759,7 @@ export function Header({
 
           {/* Batch Generation button - hidden below xl */}
           <Button
+            data-tour="batch"
             variant="outline"
             size="sm"
             className="h-8 px-2 xl:px-3 hidden xl:flex"

--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -838,7 +838,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
                   already has placeholders, and the inline `addStatus` toast
                   surfaces the action's effect now that the UI no longer
                   visually changes around it. */}
-              <div className="space-y-3 rounded-lg border border-border/50 bg-muted/20 p-4">
+              <div data-tour="batch-addvar" className="space-y-3 rounded-lg border border-border/50 bg-muted/20 p-4">
                 <div className="flex items-center gap-2">
                   <Plus className="h-4 w-4 text-primary" />
                   <Label>Add Variable to Document</Label>
@@ -945,7 +945,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
                     </div>
                   </div>
 
-                  <div className="space-y-2">
+                  <div data-tour="batch-commonvars" className="space-y-2">
                     <Label className="text-sm">
                       {isFormsMode
                         ? `${formType === 'navmc_10274' ? 'NAVMC 10274' : 'NAVMC 118(11)'} Variables (click to copy)`
@@ -1133,6 +1133,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
               Cancel
             </Button>
             <Button
+              data-tour="batch-generate"
               onClick={handleGenerateBatch}
               disabled={hasNoPlaceholders || isGenerating || rows.length === 0 || !isReadyToGenerate}
               className="tracking-wide"

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -767,6 +767,8 @@ const openProfileModal = () => useUIStore.getState().setProfileModalOpen(true);
 const closeProfileModal = () => useUIStore.getState().setProfileModalOpen(false);
 const openShareModal = () => useUIStore.getState().setShareModal('share');
 const closeShareModal = () => useUIStore.getState().setShareModal(null);
+const openTemplateLoader = () => useUIStore.getState().setTemplateLoaderOpen(true);
+const closeTemplateLoader = () => useUIStore.getState().setTemplateLoaderOpen(false);
 
 // Expand an inline accordion section (Enclosures, etc.) so a guided step can
 // spotlight a control inside it. Clicks the section trigger only when it is
@@ -876,8 +878,21 @@ const POWER_FEATURES: PowerFeature[] = [
     tour: [
       {
         target: '[data-tour="templates"]',
-        title: 'Templates live here',
-        body: 'Pick a document type, then open Templates to start from a ready-made document.',
+        title: 'Open Templates',
+        body: 'Pick a document type, then open Templates to start from a ready-made document instead of a blank page.',
+        action: closeTemplateLoader,
+      },
+      {
+        target: '[data-tour="template-search"]',
+        title: 'Find one',
+        body: 'Search by name, description, or SSIC, or filter by category, then click a template to preview it.',
+        action: openTemplateLoader,
+      },
+      {
+        target: '[data-tour="template-load"]',
+        title: 'Load it',
+        body: 'Loads the subject, paragraphs, and references into the editor. Your profile letterhead stays on top.',
+        action: openTemplateLoader,
       },
     ],
   },

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -749,15 +749,15 @@ function ExamplesTab({ onClose }: { onClose: () => void }) {
 
 // The power features that are easy to miss. Shown in the guide's "Features"
 // tab: a one-line summary, quick numbered steps for people who learn fast, and
-// a "Show me" spotlight that points at the real control in the live UI.
+// a guided walkthrough that points at the real controls in the live UI.
 interface PowerFeature {
   icon: LucideIcon;
   title: string;
   where: string;
   body: string;
   steps: string[];
-  /** Guided walkthrough launched by "Show me" — one or more spotlight steps
-   *  that can open the feature's surface and point at each control in turn. */
+  /** Guided walkthrough launched by "Walk me through it": one or more spotlight
+   *  steps that can open the feature's surface and point at each control. */
   tour: TourStep[];
 }
 
@@ -787,13 +787,13 @@ const POWER_FEATURES: PowerFeature[] = [
     icon: Layers,
     title: 'Batch generation',
     where: 'Toolbar → Batch',
-    body: 'Produce one finished document per row from a single template — award citations, promotion letters, anything repeated across people.',
+    body: 'Produce one finished document per row from a single template: award citations, promotion letters, or anything repeated across people.',
     steps: [
       'Open Batch from the toolbar.',
       'Drop a {{NAME}} placeholder (any label) into a field.',
       'Paste tab-separated rows straight from a spreadsheet.',
       'Map columns to placeholders, then review each row.',
-      'Generate the set — one PDF per row.',
+      'Generate the set: one PDF per row.',
     ],
     tour: [
       {
@@ -805,13 +805,13 @@ const POWER_FEATURES: PowerFeature[] = [
       {
         target: '[data-tour="batch-addvar"]',
         title: 'Add a variable',
-        body: 'Pick a variable and a field, then Add. That drops a {{placeholder}} into your document — the column DonDocs fills per row.',
+        body: 'Pick a variable and a field, then Add. That drops a {{placeholder}} into your document. DonDocs fills that column for every row.',
         action: openBatch,
       },
       {
         target: '[data-tour="batch-commonvars"]',
         title: 'Or copy a common one',
-        body: 'Not sure what to use? These common variables copy with one click — paste one into any field.',
+        body: 'Not sure what to use? These common variables copy with one click. Paste one into any field.',
         action: openBatch,
       },
       {
@@ -842,7 +842,7 @@ const POWER_FEATURES: PowerFeature[] = [
       {
         target: '[data-tour="profile-name"]',
         title: 'Name it',
-        body: 'Give the profile a name you will recognize — your command, say.',
+        body: 'Give the profile a name you will recognize, like your command.',
         action: openProfileModal,
       },
       {
@@ -854,7 +854,7 @@ const POWER_FEATURES: PowerFeature[] = [
       {
         target: '[data-tour="profile-signature"]',
         title: 'Add your signature block',
-        body: 'Name, rank or title, and position — they carry into every document you draft with this profile.',
+        body: 'Name, rank or title, and position. They carry into every document you draft with this profile.',
         action: openProfileModal,
       },
       {
@@ -873,7 +873,7 @@ const POWER_FEATURES: PowerFeature[] = [
     steps: [
       'Pick your document type.',
       'Click Templates, then search or filter the list.',
-      'Select one and load it — your profile letterhead stays on top.',
+      'Select one and load it. Your profile letterhead stays on top.',
     ],
     tour: [
       {
@@ -908,14 +908,14 @@ const POWER_FEATURES: PowerFeature[] = [
     ],
     tour: [
       {
-        target: '[data-tour="enclosures"]',
+        target: '[data-tour="enclosures"] [data-slot="accordion-trigger"]',
         title: 'Enclosures',
         body: 'Where you list enclosures on the letter and attach PDF files.',
       },
       {
         target: '[data-tour="enclosure-add"]',
         title: 'Add an enclosure',
-        body: 'Click Add Enclosure and give it a title — it is listed on the letter automatically.',
+        body: 'Click Add Enclosure and give it a title. It is listed on the letter automatically.',
         action: () => expandSection('enclosures'),
       },
       {
@@ -938,20 +938,20 @@ const POWER_FEATURES: PowerFeature[] = [
     ],
     tour: [
       {
-        target: '[data-tour="signature"]',
+        target: '[data-tour="signature"] [data-slot="accordion-trigger"]',
         title: 'Signature block',
-        body: 'How your letter is signed — typed name, an image, or a digital field.',
+        body: 'How your letter is signed: typed name, an image, or a digital field.',
       },
       {
         target: '[data-tour="signature-name"]',
         title: 'Who is signing',
-        body: 'Fill in the name, then rank or title and position below — they print under the signature line.',
+        body: 'Fill in the name, then rank or title and position below. They print under the signature line.',
         action: () => expandSection('signature'),
       },
       {
         target: '[data-tour="signature-style"]',
         title: 'Pick a signature style',
-        body: 'Typed only, Upload image (a scanned signature), or Digital field — an empty field for CAC/PKI signing in Adobe after you download.',
+        body: 'Three styles: Typed only, Upload image (a scanned signature), or Digital field for CAC/PKI signing in Adobe after you download.',
         action: () => expandSection('signature'),
       },
     ],
@@ -963,7 +963,7 @@ const POWER_FEATURES: PowerFeature[] = [
     body: 'Send a document as a password-protected link. Nothing is stored on a server; the recipient needs both the link and the password you set.',
     steps: [
       'Open Save → Create share link and set a password.',
-      'Generate the link — it copies to your clipboard.',
+      'Generate the link. It copies to your clipboard.',
       'Send the link and password separately to the recipient.',
       'They open it with Save → Open from share link.',
     ],
@@ -977,7 +977,7 @@ const POWER_FEATURES: PowerFeature[] = [
       {
         target: '[data-tour="share-password"]',
         title: 'Set a password',
-        body: 'The document is encrypted in your browser — nothing is stored on a server. The recipient needs this password to open it.',
+        body: 'The document is encrypted in your browser. Nothing is stored on a server, and the recipient needs this password to open it.',
         action: openShareModal,
       },
       {
@@ -1001,7 +1001,7 @@ const POWER_FEATURES: PowerFeature[] = [
     ],
     tour: [
       {
-        target: '[data-tour="classification"]',
+        target: '[data-tour="classification"] [data-slot="accordion-trigger"]',
         title: 'Classification',
         body: 'Set the document marking and the banner that appears at the top.',
       },
@@ -1150,7 +1150,7 @@ export function DocumentGuideModal() {
           <div className="flex-1 min-h-0 overflow-y-auto">
             <div className="p-6 space-y-2.5">
               <p className="text-sm text-muted-foreground">
-                DonDocs does more than draft a single letter. Expand a feature for the quick steps, or pick “Show me” to be taken straight to it.
+                DonDocs does more than draft a single letter. Expand a feature for the quick steps, or pick “Walk me through it” for a guided tour of the real controls.
               </p>
               {POWER_FEATURES.map((f) => {
                 const Icon = f.icon;

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -763,6 +763,20 @@ interface PowerFeature {
 
 const openBatch = () => useUIStore.getState().setBatchModalOpen(true);
 const closeBatch = () => useUIStore.getState().setBatchModalOpen(false);
+const openProfileModal = () => useUIStore.getState().setProfileModalOpen(true);
+const closeProfileModal = () => useUIStore.getState().setProfileModalOpen(false);
+
+// Expand an inline accordion section (Enclosures, etc.) so a guided step can
+// spotlight a control inside it. Clicks the section trigger only when it is
+// currently collapsed, so re-running the step on Back never toggles it shut.
+const expandSection = (tourKey: string) => {
+  const item = document
+    .querySelector(`[data-tour="${tourKey}"]`)
+    ?.querySelector('[data-slot="accordion-item"]');
+  if (item?.getAttribute('data-state') === 'closed') {
+    (item.querySelector('[data-slot="accordion-trigger"]') as HTMLElement | null)?.click();
+  }
+};
 
 const POWER_FEATURES: PowerFeature[] = [
   {
@@ -816,9 +830,34 @@ const POWER_FEATURES: PowerFeature[] = [
     ],
     tour: [
       {
-        target: '[data-tour="profiles"]',
-        title: 'Profiles live here',
-        body: 'Create, switch, and edit saved letterhead profiles from this selector.',
+        target: '[data-tour="profile-create"]',
+        title: 'Create a profile',
+        body: 'Profiles save your letterhead and sender details so you never retype them. Start one with the + button.',
+        action: closeProfileModal,
+      },
+      {
+        target: '[data-tour="profile-name"]',
+        title: 'Name it',
+        body: 'Give the profile a name you will recognize — your command, say.',
+        action: openProfileModal,
+      },
+      {
+        target: '[data-tour="profile-letterhead"]',
+        title: 'Fill the letterhead once',
+        body: 'Your unit lines, address, and SSIC. Browse Units autofills these from the directory.',
+        action: openProfileModal,
+      },
+      {
+        target: '[data-tour="profile-signature"]',
+        title: 'Add your signature block',
+        body: 'Name, rank or title, and position — they carry into every document you draft with this profile.',
+        action: openProfileModal,
+      },
+      {
+        target: '[data-tour="profile-save"]',
+        title: 'Save and reuse',
+        body: 'Create the profile, then switch to it anytime from the selector. The pencil edits it later.',
+        action: openProfileModal,
       },
     ],
   },
@@ -853,8 +892,20 @@ const POWER_FEATURES: PowerFeature[] = [
     tour: [
       {
         target: '[data-tour="enclosures"]',
-        title: 'Enclosures live here',
-        body: 'Expand this section to add enclosures and attach PDFs.',
+        title: 'Enclosures',
+        body: 'Where you list enclosures on the letter and attach PDF files.',
+      },
+      {
+        target: '[data-tour="enclosure-add"]',
+        title: 'Add an enclosure',
+        body: 'Click Add Enclosure and give it a title — it is listed on the letter automatically.',
+        action: () => expandSection('enclosures'),
+      },
+      {
+        target: '[data-tour="enclosure-attach"]',
+        title: 'Attach a PDF',
+        body: 'Optionally attach a PDF (drag and drop works). It merges into the final export, after the letter.',
+        action: () => expandSection('enclosures'),
       },
     ],
   },

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { HelpCircle, ChevronDown, ChevronRight, FileText, CheckCircle2, Lightbulb, BookOpen, Sparkles, ArrowRight, RotateCcw, Search, Eye, Check, Zap, Layers, Users, FolderOpen, Paperclip, PenLine, Link2, Shield, type LucideIcon } from 'lucide-react';
+import { HelpCircle, ChevronDown, ChevronRight, FileText, CheckCircle2, Lightbulb, BookOpen, Sparkles, ArrowRight, RotateCcw, Search, Eye, Check, Zap, Layers, Users, FolderOpen, Paperclip, PenLine, Link2, Shield, MapPin, type LucideIcon } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -11,6 +11,8 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useUIStore } from '@/stores/uiStore';
 import { useDocumentStore } from '@/stores/documentStore';
+import { useTourStore } from '@/stores/tourStore';
+import type { TourStep } from '@/components/tour/tourSteps';
 import { DOCUMENT_TYPE_GUIDES, GUIDE_CATEGORIES, GUIDE_GROUPS, type DocumentTypeGuide } from '@/data/documentGuide';
 import { EXAMPLE_DOCUMENTS, EXAMPLE_CATEGORIES, type ExampleDocument } from '@/data/exampleDocuments';
 import { DOC_TYPE_LABELS, type DocumentData } from '@/types/document';
@@ -746,49 +748,171 @@ function ExamplesTab({ onClose }: { onClose: () => void }) {
 }
 
 // The power features that are easy to miss. Shown in the guide's "Features"
-// tab so people discover what DonDocs can do beyond drafting a single letter.
-const POWER_FEATURES: { icon: LucideIcon; title: string; where: string; body: string }[] = [
+// tab: a one-line summary, quick numbered steps for people who learn fast, and
+// a "Show me" spotlight that points at the real control in the live UI.
+interface PowerFeature {
+  icon: LucideIcon;
+  title: string;
+  where: string;
+  body: string;
+  steps: string[];
+  /** Guided walkthrough launched by "Show me" — one or more spotlight steps
+   *  that can open the feature's surface and point at each control in turn. */
+  tour: TourStep[];
+}
+
+const openBatch = () => useUIStore.getState().setBatchModalOpen(true);
+const closeBatch = () => useUIStore.getState().setBatchModalOpen(false);
+
+const POWER_FEATURES: PowerFeature[] = [
   {
     icon: Layers,
     title: 'Batch generation',
     where: 'Toolbar → Batch',
-    body: 'Generate many documents at once. Put {{NAME}} (or any label) in a field, paste a list of values, and DonDocs produces one finished document per row. Ideal for award citations, promotion letters, or anything repeated across people.',
+    body: 'Produce one finished document per row from a single template — award citations, promotion letters, anything repeated across people.',
+    steps: [
+      'Open Batch from the toolbar.',
+      'Drop a {{NAME}} placeholder (any label) into a field.',
+      'Paste tab-separated rows straight from a spreadsheet.',
+      'Map columns to placeholders, then review each row.',
+      'Generate the set — one PDF per row.',
+    ],
+    tour: [
+      {
+        target: '[data-tour="batch"]',
+        title: 'Open Batch',
+        body: 'Batch lives on the toolbar. It turns one template into many finished documents.',
+        action: closeBatch,
+      },
+      {
+        target: '[data-tour="batch-addvar"]',
+        title: 'Add a variable',
+        body: 'Pick a variable and a field, then Add. That drops a {{placeholder}} into your document — the column DonDocs fills per row.',
+        action: openBatch,
+      },
+      {
+        target: '[data-tour="batch-commonvars"]',
+        title: 'Or copy a common one',
+        body: 'Not sure what to use? These common variables copy with one click — paste one into any field.',
+        action: openBatch,
+      },
+      {
+        target: '[data-tour="batch-generate"]',
+        title: 'Generate the set',
+        body: 'Paste your rows from a spreadsheet (each row becomes a document), then Generate makes one PDF per row.',
+        action: openBatch,
+      },
+    ],
   },
   {
     icon: Users,
     title: 'Profiles',
     where: 'Top-left selector',
-    body: 'Save your unit letterhead and sender details as a reusable profile so you never retype them. Switch profiles to draft for a different command.',
+    body: 'Save your unit letterhead and sender details once, then reuse or switch between commands without retyping.',
+    steps: [
+      'Fill in your letterhead and sender details once.',
+      'Click the + by the profile selector to save them as a profile.',
+      'Switch profiles anytime from the dropdown; edit with the pencil.',
+    ],
+    tour: [
+      {
+        target: '[data-tour="profiles"]',
+        title: 'Profiles live here',
+        body: 'Create, switch, and edit saved letterhead profiles from this selector.',
+      },
+    ],
   },
   {
     icon: FolderOpen,
     title: 'Templates',
     where: 'Next to document type',
     body: 'Start from a ready-made document for common formats instead of a blank page.',
+    steps: [
+      'Pick your document type.',
+      'Click Templates, then search or filter the list.',
+      'Select one and load it — your profile letterhead stays on top.',
+    ],
+    tour: [
+      {
+        target: '[data-tour="templates"]',
+        title: 'Templates live here',
+        body: 'Pick a document type, then open Templates to start from a ready-made document.',
+      },
+    ],
   },
   {
     icon: Paperclip,
     title: 'Enclosures',
     where: 'Enclosures section',
     body: 'Attach PDF enclosures. They are listed on the letter and merged into the final PDF automatically.',
+    steps: [
+      'Open the Enclosures section and click Add Enclosure.',
+      'Title it, and optionally attach a PDF (drag and drop works).',
+      'Attached PDFs merge into the export, in order, after the letter.',
+    ],
+    tour: [
+      {
+        target: '[data-tour="enclosures"]',
+        title: 'Enclosures live here',
+        body: 'Expand this section to add enclosures and attach PDFs.',
+      },
+    ],
   },
   {
     icon: PenLine,
     title: 'Signature',
     where: 'Signature section',
     body: 'Add a signature block, an optional signature image, or a digital signature field on the exported PDF.',
+    steps: [
+      'Open Signature Block and fill name, rank/title, and office code.',
+      'Choose a style: Typed only, Upload image, or Digital field.',
+      'Optionally check "By direction" and set the authority.',
+    ],
+    tour: [
+      {
+        target: '[data-tour="signature"]',
+        title: 'Signature lives here',
+        body: 'Expand this section to fill the signature block or add a signature image.',
+      },
+    ],
   },
   {
     icon: Link2,
     title: 'Encrypted share link',
     where: 'Save → Create share link',
     body: 'Send a document as a password-protected link. Nothing is stored on a server; the recipient needs both the link and the password you set.',
+    steps: [
+      'Open Save → Create share link and set a password.',
+      'Generate the link — it copies to your clipboard.',
+      'Send the link and password separately to the recipient.',
+      'They open it with Save → Open from share link.',
+    ],
+    tour: [
+      {
+        target: '[data-tour="save"]',
+        title: 'Share links live here',
+        body: 'Open this menu, then Create share link, to send a password-protected copy.',
+      },
+    ],
   },
   {
     icon: Shield,
     title: 'Classification & portion marks',
     where: 'Classification section',
     body: 'Set the document classification and per-paragraph portion marks. The banner is derived from the highest marking in the document.',
+    steps: [
+      'Open the Classification section and set the classification level.',
+      'Fill the marking fields that appear (CUI or classified).',
+      'Set per-paragraph portion marks in the body editor.',
+      'The banner is derived from the highest marking.',
+    ],
+    tour: [
+      {
+        target: '[data-tour="classification"]',
+        title: 'Classification lives here',
+        body: 'Expand this section to set the classification and portion marks.',
+      },
+    ],
   },
 ];
 
@@ -800,6 +924,16 @@ export function DocumentGuideModal() {
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [expandedGuide, setExpandedGuide] = useState<string | null>(null);
+  const [expandedFeature, setExpandedFeature] = useState<string | null>(null);
+
+  // "Show me": close the guide, then run the feature's guided walkthrough once
+  // the dialog has finished animating out so the page is interactive again.
+  const handleShowMe = (tour: TourStep[]) => {
+    setDocumentGuideOpen(false);
+    window.setTimeout(() => {
+      useTourStore.getState().startSteps(tour);
+    }, 300);
+  };
 
   // Get categories for selected group
   const groupCategories = useMemo(() => {
@@ -915,22 +1049,57 @@ export function DocumentGuideModal() {
 
         {activeTab === 'features' && (
           <div className="flex-1 min-h-0 overflow-y-auto">
-            <div className="p-6 space-y-3">
+            <div className="p-6 space-y-2.5">
               <p className="text-sm text-muted-foreground">
-                DonDocs does more than draft a single letter. Here is what each feature does and where to find it.
+                DonDocs does more than draft a single letter. Expand a feature for the quick steps, or pick “Show me” to be taken straight to it.
               </p>
               {POWER_FEATURES.map((f) => {
                 const Icon = f.icon;
+                const isOpen = expandedFeature === f.title;
                 return (
-                  <div key={f.title} className="flex items-start gap-3 rounded-lg border bg-card/50 p-3">
-                    <Icon className="h-5 w-5 text-primary shrink-0 mt-0.5" />
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <h4 className="font-medium text-sm">{f.title}</h4>
-                        <span className="text-[11px] text-muted-foreground bg-muted rounded px-1.5 py-0.5">{f.where}</span>
+                  <div key={f.title} className="rounded-lg border bg-card/50 overflow-hidden">
+                    <button
+                      type="button"
+                      onClick={() => setExpandedFeature(isOpen ? null : f.title)}
+                      aria-expanded={isOpen}
+                      className="w-full flex items-start gap-3 p-3 text-left hover:bg-muted/40 transition-colors"
+                    >
+                      <Icon className="h-5 w-5 text-primary shrink-0 mt-0.5" />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <h4 className="font-medium text-sm">{f.title}</h4>
+                          <span className="text-[11px] text-muted-foreground bg-muted rounded px-1.5 py-0.5">{f.where}</span>
+                        </div>
+                        <p className="text-sm text-muted-foreground mt-0.5">{f.body}</p>
                       </div>
-                      <p className="text-sm text-muted-foreground mt-0.5">{f.body}</p>
-                    </div>
+                      {isOpen ? (
+                        <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0 mt-1" />
+                      ) : (
+                        <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0 mt-1" />
+                      )}
+                    </button>
+                    {isOpen && (
+                      <div className="px-3 pb-3 pl-11">
+                        <ol className="space-y-2">
+                          {f.steps.map((step, i) => (
+                            <li key={i} className="flex gap-2.5 text-sm text-muted-foreground">
+                              <span className="flex-none w-5 h-5 rounded-full border text-[11px] flex items-center justify-center text-foreground mt-px">
+                                {i + 1}
+                              </span>
+                              <span className="leading-snug">{step}</span>
+                            </li>
+                          ))}
+                        </ol>
+                        <button
+                          type="button"
+                          onClick={() => handleShowMe(f.tour)}
+                          className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline"
+                        >
+                          <MapPin className="h-3.5 w-3.5" />
+                          {f.tour.length > 1 ? 'Walk me through it' : 'Show me where'}
+                        </button>
+                      </div>
+                    )}
                   </div>
                 );
               })}

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -12,6 +12,7 @@ import { Input } from '@/components/ui/input';
 import { useUIStore } from '@/stores/uiStore';
 import { useDocumentStore } from '@/stores/documentStore';
 import { useTourStore } from '@/stores/tourStore';
+import { useOnboardingStore } from '@/stores/onboardingStore';
 import type { TourStep } from '@/components/tour/tourSteps';
 import { DOCUMENT_TYPE_GUIDES, GUIDE_CATEGORIES, GUIDE_GROUPS, type DocumentTypeGuide } from '@/data/documentGuide';
 import { EXAMPLE_DOCUMENTS, EXAMPLE_CATEGORIES, type ExampleDocument } from '@/data/exampleDocuments';
@@ -751,6 +752,8 @@ function ExamplesTab({ onClose }: { onClose: () => void }) {
 // tab: a one-line summary, quick numbered steps for people who learn fast, and
 // a guided walkthrough that points at the real controls in the live UI.
 interface PowerFeature {
+  /** Stable onboarding key — marks this feature learned once its walkthrough finishes. */
+  key: string;
   icon: LucideIcon;
   title: string;
   where: string;
@@ -784,6 +787,7 @@ const expandSection = (tourKey: string) => {
 
 const POWER_FEATURES: PowerFeature[] = [
   {
+    key: 'batch',
     icon: Layers,
     title: 'Batch generation',
     where: 'Toolbar → Batch',
@@ -823,6 +827,7 @@ const POWER_FEATURES: PowerFeature[] = [
     ],
   },
   {
+    key: 'profiles',
     icon: Users,
     title: 'Profiles',
     where: 'Top-left selector',
@@ -866,6 +871,7 @@ const POWER_FEATURES: PowerFeature[] = [
     ],
   },
   {
+    key: 'templates',
     icon: FolderOpen,
     title: 'Templates',
     where: 'Next to document type',
@@ -897,6 +903,7 @@ const POWER_FEATURES: PowerFeature[] = [
     ],
   },
   {
+    key: 'enclosures',
     icon: Paperclip,
     title: 'Enclosures',
     where: 'Enclosures section',
@@ -927,6 +934,7 @@ const POWER_FEATURES: PowerFeature[] = [
     ],
   },
   {
+    key: 'signature',
     icon: PenLine,
     title: 'Signature',
     where: 'Signature section',
@@ -957,6 +965,7 @@ const POWER_FEATURES: PowerFeature[] = [
     ],
   },
   {
+    key: 'share',
     icon: Link2,
     title: 'Encrypted share link',
     where: 'Save → Create share link',
@@ -989,6 +998,7 @@ const POWER_FEATURES: PowerFeature[] = [
     ],
   },
   {
+    key: 'classification',
     icon: Shield,
     title: 'Classification & portion marks',
     where: 'Classification section',
@@ -1024,13 +1034,16 @@ export function DocumentGuideModal() {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [expandedGuide, setExpandedGuide] = useState<string | null>(null);
   const [expandedFeature, setExpandedFeature] = useState<string | null>(null);
+  const completed = useOnboardingStore((s) => s.completed);
+  const learnedCount = POWER_FEATURES.filter((f) => completed[f.key]).length;
 
   // "Show me": close the guide, then run the feature's guided walkthrough once
   // the dialog has finished animating out so the page is interactive again.
-  const handleShowMe = (tour: TourStep[]) => {
+  // The key marks the feature learned when its walkthrough reaches the end.
+  const handleShowMe = (tour: TourStep[], key: string) => {
     setDocumentGuideOpen(false);
     window.setTimeout(() => {
-      useTourStore.getState().startSteps(tour);
+      useTourStore.getState().startSteps(tour, key);
     }, 300);
   };
 
@@ -1152,17 +1165,47 @@ export function DocumentGuideModal() {
               <p className="text-sm text-muted-foreground">
                 DonDocs does more than draft a single letter. Expand a feature for the quick steps, or pick “Walk me through it” for a guided tour of the real controls.
               </p>
+              <div className="rounded-lg border bg-card/50 px-3.5 py-3">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-medium">
+                    {learnedCount} of {POWER_FEATURES.length} features learned
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {learnedCount === POWER_FEATURES.length ? 'All caught up' : 'Keep going'}
+                  </span>
+                </div>
+                <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+                  <div
+                    className="h-full bg-green-500 transition-all duration-300"
+                    style={{ width: `${(learnedCount / POWER_FEATURES.length) * 100}%` }}
+                  />
+                </div>
+              </div>
               {POWER_FEATURES.map((f) => {
                 const Icon = f.icon;
                 const isOpen = expandedFeature === f.title;
+                const isLearned = !!completed[f.key];
                 return (
                   <div key={f.title} className="rounded-lg border bg-card/50 overflow-hidden">
                     <button
                       type="button"
                       onClick={() => setExpandedFeature(isOpen ? null : f.title)}
                       aria-expanded={isOpen}
-                      className="w-full flex items-start gap-3 p-3 text-left hover:bg-muted/40 transition-colors"
+                      className="w-full flex items-start gap-2.5 p-3 text-left hover:bg-muted/40 transition-colors"
                     >
+                      {isLearned ? (
+                        <span
+                          className="flex-none mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-500/15 text-green-600 dark:text-green-400"
+                          aria-label="Learned"
+                        >
+                          <Check className="h-3 w-3" />
+                        </span>
+                      ) : (
+                        <span
+                          className="flex-none mt-0.5 h-5 w-5 rounded-full border-2 border-muted-foreground/25"
+                          aria-hidden="true"
+                        />
+                      )}
                       <Icon className="h-5 w-5 text-primary shrink-0 mt-0.5" />
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2 flex-wrap">
@@ -1191,7 +1234,7 @@ export function DocumentGuideModal() {
                         </ol>
                         <button
                           type="button"
-                          onClick={() => handleShowMe(f.tour)}
+                          onClick={() => handleShowMe(f.tour, f.key)}
                           className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline"
                         >
                           <MapPin className="h-3.5 w-3.5" />

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -765,6 +765,8 @@ const openBatch = () => useUIStore.getState().setBatchModalOpen(true);
 const closeBatch = () => useUIStore.getState().setBatchModalOpen(false);
 const openProfileModal = () => useUIStore.getState().setProfileModalOpen(true);
 const closeProfileModal = () => useUIStore.getState().setProfileModalOpen(false);
+const openShareModal = () => useUIStore.getState().setShareModal('share');
+const closeShareModal = () => useUIStore.getState().setShareModal(null);
 
 // Expand an inline accordion section (Enclosures, etc.) so a guided step can
 // spotlight a control inside it. Clicks the section trigger only when it is
@@ -941,8 +943,21 @@ const POWER_FEATURES: PowerFeature[] = [
     tour: [
       {
         target: '[data-tour="save"]',
-        title: 'Share links live here',
-        body: 'Open this menu, then Create share link, to send a password-protected copy.',
+        title: 'Share starts here',
+        body: 'Open the Save menu, then Create share link, to send a password-protected copy.',
+        action: closeShareModal,
+      },
+      {
+        target: '[data-tour="share-password"]',
+        title: 'Set a password',
+        body: 'The document is encrypted in your browser — nothing is stored on a server. The recipient needs this password to open it.',
+        action: openShareModal,
+      },
+      {
+        target: '[data-tour="share-generate"]',
+        title: 'Generate the link',
+        body: 'Creates a link that copies to your clipboard. Send the link and the password separately; the recipient opens it with Save → Open from share link.',
+        action: openShareModal,
       },
     ],
   },

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -924,8 +924,20 @@ const POWER_FEATURES: PowerFeature[] = [
     tour: [
       {
         target: '[data-tour="signature"]',
-        title: 'Signature lives here',
-        body: 'Expand this section to fill the signature block or add a signature image.',
+        title: 'Signature block',
+        body: 'How your letter is signed — typed name, an image, or a digital field.',
+      },
+      {
+        target: '[data-tour="signature-name"]',
+        title: 'Who is signing',
+        body: 'Fill in the name, then rank or title and position below — they print under the signature line.',
+        action: () => expandSection('signature'),
+      },
+      {
+        target: '[data-tour="signature-style"]',
+        title: 'Pick a signature style',
+        body: 'Typed only, Upload image (a scanned signature), or Digital field — an empty field for CAC/PKI signing in Adobe after you download.',
+        action: () => expandSection('signature'),
       },
     ],
   },
@@ -975,8 +987,14 @@ const POWER_FEATURES: PowerFeature[] = [
     tour: [
       {
         target: '[data-tour="classification"]',
-        title: 'Classification lives here',
-        body: 'Expand this section to set the classification and portion marks.',
+        title: 'Classification',
+        body: 'Set the document marking and the banner that appears at the top.',
+      },
+      {
+        target: '[data-tour="classification-level"]',
+        title: 'Set the level',
+        body: 'Choose the classification. The right marking fields (CUI or classified) appear below, and the banner is derived from the highest marking. Per-paragraph portion marks live in the body editor.',
+        action: () => expandSection('classification'),
       },
     ],
   },

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -360,7 +360,7 @@ export function ProfileModal() {
           {/* Scrollable Content */}
           <div className="flex-1 overflow-y-auto min-h-0">
             <div className="space-y-4 px-6 py-4">
-              <div className="space-y-2">
+              <div data-tour="profile-name" className="space-y-2">
                 <Label htmlFor="profileName">Profile Name</Label>
                 <Input
                   id="profileName"
@@ -371,7 +371,7 @@ export function ProfileModal() {
                 />
               </div>
 
-              <div className="border-t pt-4">
+              <div data-tour="profile-letterhead" className="border-t pt-4">
                 <div className="flex items-center justify-between mb-3">
                   <h4 className="text-sm font-medium">Letterhead Information</h4>
                   <Button
@@ -467,7 +467,7 @@ export function ProfileModal() {
                 </div>
               </div>
 
-              <div className="border-t pt-4">
+              <div data-tour="profile-signature" className="border-t pt-4">
                 <h4 className="text-sm font-medium mb-3">Signature Block</h4>
                 <div className="grid grid-cols-3 gap-3">
                   <div className="space-y-2">
@@ -706,7 +706,7 @@ export function ProfileModal() {
             <Button variant="outline" onClick={handleClose}>
               Cancel
             </Button>
-            <Button onClick={handleSave}>
+            <Button data-tour="profile-save" onClick={handleSave}>
               {isEditing ? 'Save Changes' : 'Create Profile'}
             </Button>
           </DialogFooter>

--- a/src/components/modals/ShareModal.tsx
+++ b/src/components/modals/ShareModal.tsx
@@ -172,7 +172,7 @@ export function ShareModal({
             </p>
           )}
 
-          <div className="space-y-2">
+          <div data-tour="share-password" className="space-y-2">
             <Label htmlFor="share-password">
               {isImport ? 'Password' : 'Password for this link'}
             </Label>
@@ -248,6 +248,7 @@ export function ShareModal({
             </Button>
           ) : (
             <Button
+              data-tour="share-generate"
               onClick={handleGenerateLink}
               disabled={!canSubmit || working}
             >

--- a/src/components/modals/TemplateLoaderModal.tsx
+++ b/src/components/modals/TemplateLoaderModal.tsx
@@ -147,7 +147,7 @@ export function TemplateLoaderModal() {
           </DialogTitle>
         </DialogHeader>
 
-        <div className="p-4 border-b shrink-0 space-y-3 bg-background z-10">
+        <div data-tour="template-search" className="p-4 border-b shrink-0 space-y-3 bg-background z-10">
           {/* Search */}
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
@@ -255,6 +255,7 @@ export function TemplateLoaderModal() {
             Cancel
           </Button>
           <Button
+            data-tour="template-load"
             onClick={handleLoadTemplate}
             disabled={!selectedTemplate}
             className="hover:bg-primary/90"

--- a/src/components/tour/TourOverlay.tsx
+++ b/src/components/tour/TourOverlay.tsx
@@ -55,53 +55,50 @@ export function TourOverlay() {
     // Batch modal) before the element exists. Run that side-effect first.
     step.action?.();
 
-    let cancelled = false;
-    const cleanups: Array<() => void> = [];
-
-    const attach = (el: HTMLElement) => {
-      el.scrollIntoView({ block: 'center', inline: 'nearest', behavior: reduce ? 'auto' : 'smooth' });
-      const update = () => {
-        const r = el.getBoundingClientRect();
-        if (r.width === 0 && r.height === 0) {
-          setRect(null); // hidden (e.g. collapsed at this breakpoint)
-        } else {
-          setRect({ top: r.top, left: r.left, width: r.width, height: r.height });
-        }
-      };
-      update();
-      // Recompute after the smooth scroll settles.
-      const settle = window.setTimeout(update, reduce ? 0 : 280);
-      window.addEventListener('scroll', update, true);
-      window.addEventListener('resize', update);
-      cleanups.push(() => {
-        window.clearTimeout(settle);
-        window.removeEventListener('scroll', update, true);
-        window.removeEventListener('resize', update);
-      });
-    };
-
-    // Locate the target, retrying briefly so an element mounted by action()
-    // (a modal opening, a section expanding) is caught instead of falling
-    // straight through to the centered fallback.
-    const locate = (attemptsLeft: number) => {
-      if (cancelled) return;
+    // We re-query the selector on every tick rather than hold an element
+    // reference. The overlay is passive, so the user can open and close the
+    // surface underneath it: re-querying means a freshly-mounted modal is
+    // caught within a tick, and a closed one yields "not found" → the spotlight
+    // re-centers instead of stranding on stale coordinates.
+    let scrolled: Element | null = null;
+    const measure = () => {
       const el = step.target ? document.querySelector<HTMLElement>(step.target) : null;
-      if (el) {
-        attach(el);
+      // A target inside a closing/closed Radix layer (a dismissed modal that is
+      // still mounted for its exit animation) counts as gone — otherwise the
+      // spotlight strands on a control the user just closed.
+      if (!el || el.closest('[data-state="closed"]')) {
+        setRect((prev) => (prev === null ? prev : null));
+        scrolled = null;
         return;
       }
-      if (step.target && attemptsLeft > 0) {
-        const t = window.setTimeout(() => locate(attemptsLeft - 1), 60);
-        cleanups.push(() => window.clearTimeout(t));
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 && r.height === 0) {
+        setRect((prev) => (prev === null ? prev : null)); // hidden / collapsed
         return;
       }
-      setRect(null); // no target (or it never appeared) → centered card
+      if (scrolled !== el) {
+        scrolled = el;
+        el.scrollIntoView({ block: 'center', inline: 'nearest', behavior: reduce ? 'auto' : 'smooth' });
+      }
+      setRect((prev) =>
+        prev &&
+        Math.abs(prev.top - r.top) < 0.5 &&
+        Math.abs(prev.left - r.left) < 0.5 &&
+        Math.abs(prev.width - r.width) < 0.5 &&
+        Math.abs(prev.height - r.height) < 0.5
+          ? prev // unchanged — skip the re-render
+          : { top: r.top, left: r.left, width: r.width, height: r.height }
+      );
     };
-    locate(10); // ~600ms budget for an async-mounted modal to appear
 
+    measure();
+    const poll = window.setInterval(measure, 150);
+    window.addEventListener('scroll', measure, true);
+    window.addEventListener('resize', measure);
     return () => {
-      cancelled = true;
-      cleanups.forEach((fn) => fn());
+      window.clearInterval(poll);
+      window.removeEventListener('scroll', measure, true);
+      window.removeEventListener('resize', measure);
     };
   }, [active, stepIndex, step]);
 
@@ -141,17 +138,17 @@ export function TourOverlay() {
     cardStyle = { top: '50%', left: '50%', transform: 'translate(-50%, -50%)', width: CARD_W };
   }
 
-  // Portaled to <body> and layered above Radix dialogs (z-50) and the
-  // browser-compat notice (z-100), so a guided step can spotlight a control
-  // inside an open modal — the dim covers the modal and the cutout reveals it.
+  // Passive coach overlay: it highlights and explains, but never blocks the
+  // page. The dim and spotlight are click-through (pointer-events-none) so the
+  // user can keep using the app — only the coachmark itself is interactive.
+  // Non-modal, so tapping outside the card interacts with the app instead of
+  // dismissing the tour. Portaled to <body> and layered above Radix dialogs
+  // (z-50) so a guided step can spotlight a control inside an open modal.
   return createPortal(
-    <div role="dialog" aria-modal="true" aria-label="Product tour">
-      {/* Click-catcher: blocks interaction with the page beneath the tour.
-          Explicit pointer-events so it works even if <body> is locked. */}
-      <div className="fixed inset-0 z-[110] pointer-events-auto" />
-
+    <div role="region" aria-label="Product tour">
       {/* The dim + spotlight. With a target, a transparent box punches a hole
-          via its huge spread shadow; without one, a plain full-screen dim. */}
+          via its huge spread shadow; without one, a plain full-screen dim.
+          Both are click-through — nothing here intercepts pointer events. */}
       {rect ? (
         <div
           className="fixed z-[111] pointer-events-none rounded-lg ring-2 ring-primary transition-all duration-200"
@@ -160,17 +157,20 @@ export function TourOverlay() {
             left: rect.left - PAD,
             width: rect.width + PAD * 2,
             height: rect.height + PAD * 2,
-            boxShadow: '0 0 0 9999px rgba(0,0,0,0.62)',
+            boxShadow: '0 0 0 9999px rgba(0,0,0,0.5)',
           }}
         />
       ) : (
-        <div className="fixed inset-0 z-[111] pointer-events-none bg-black/60" />
+        <div className="fixed inset-0 z-[111] pointer-events-none bg-black/50" />
       )}
 
-      {/* Coachmark */}
+      {/* Coachmark — the only interactive surface. Stop pointer events from
+          reaching the document so an open Radix dialog beneath doesn't treat a
+          tap on the card as an outside-click and dismiss itself. */}
       <div
         ref={cardRef}
         tabIndex={-1}
+        onPointerDown={(e) => e.stopPropagation()}
         className="fixed z-[112] pointer-events-auto rounded-xl border bg-popover text-popover-foreground p-4 shadow-elevated outline-none"
         style={cardStyle}
       >

--- a/src/components/tour/TourOverlay.tsx
+++ b/src/components/tour/TourOverlay.tsx
@@ -79,6 +79,10 @@ export function TourOverlay() {
       if (scrolled !== el) {
         scrolled = el;
         el.scrollIntoView({ block: 'center', inline: 'nearest', behavior: reduce ? 'auto' : 'smooth' });
+      } else if (r.top < 8 || r.bottom > window.innerHeight - 8) {
+        // The target drifted out of view — e.g. a section finished expanding
+        // and pushed it down. Re-center instantly so the spotlight follows.
+        el.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'auto' });
       }
       setRect((prev) =>
         prev &&

--- a/src/components/tour/TourOverlay.tsx
+++ b/src/components/tour/TourOverlay.tsx
@@ -63,10 +63,12 @@ export function TourOverlay() {
     let scrolled: Element | null = null;
     const measure = () => {
       const el = step.target ? document.querySelector<HTMLElement>(step.target) : null;
-      // A target inside a closing/closed Radix layer (a dismissed modal that is
-      // still mounted for its exit animation) counts as gone — otherwise the
-      // spotlight strands on a control the user just closed.
-      if (!el || el.closest('[data-state="closed"]')) {
+      // A target inside a closing/closed Radix dialog (a dismissed modal still
+      // mounted for its exit animation) counts as gone — otherwise the
+      // spotlight strands on a control the user just closed. Scoped to dialogs
+      // so a collapsed accordion header (also data-state="closed", but visible)
+      // can still be spotlighted.
+      if (!el || el.closest('[role="dialog"][data-state="closed"]')) {
         setRect((prev) => (prev === null ? prev : null));
         scrolled = null;
         return;

--- a/src/components/tour/TourOverlay.tsx
+++ b/src/components/tour/TourOverlay.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { X, ArrowRight } from 'lucide-react';
 import { useTourStore } from '@/stores/tourStore';
 import { Button } from '@/components/ui/button';
 
@@ -118,13 +119,19 @@ export function TourOverlay() {
     }
     cardRef.current?.focus();
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') end();
-      else if (e.key === 'ArrowRight') next();
-      else if (e.key === 'ArrowLeft') prev();
+      // Only Escape is handled — typing and arrow keys flow to whatever field
+      // is focused (the tour spotlights real inputs) and never drive the tour;
+      // navigation happens solely through the on-card Back/Next buttons.
+      if (e.key !== 'Escape') return;
+      // Exit the tour. Capture-phase + stop so a spotlighted Radix dialog
+      // doesn't also handle Escape and close itself, stranding the walkthrough.
+      e.preventDefault();
+      e.stopPropagation();
+      end();
     };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [active, stepIndex, next, prev, end]);
+    window.addEventListener('keydown', onKey, true);
+    return () => window.removeEventListener('keydown', onKey, true);
+  }, [active, stepIndex, end]);
 
   if (!active || !step) return null;
 
@@ -144,17 +151,24 @@ export function TourOverlay() {
     cardStyle = { top: '50%', left: '50%', transform: 'translate(-50%, -50%)', width: CARD_W };
   }
 
-  // Passive coach overlay: it highlights and explains, but never blocks the
-  // page. The dim and spotlight are click-through (pointer-events-none) so the
-  // user can keep using the app — only the coachmark itself is interactive.
-  // Non-modal, so tapping outside the card interacts with the app instead of
-  // dismissing the tour. Portaled to <body> and layered above Radix dialogs
-  // (z-50) so a guided step can spotlight a control inside an open modal.
+  // Locked coach overlay: the tour is modal, so only its own controls (the
+  // corner ×, Back, Next, or Esc) advance or exit it. Incidental clicks and
+  // keys can't break the step. Portaled to <body> and layered above Radix
+  // dialogs (z-50) so a guided step can spotlight a control inside a modal.
   return createPortal(
     <div role="region" aria-label="Product tour">
-      {/* The dim + spotlight. With a target, a transparent box punches a hole
-          via its huge spread shadow; without one, a plain full-screen dim.
-          Both are click-through — nothing here intercepts pointer events. */}
+      {/* Click blocker: catches every pointer event on the page beneath the
+          tour. No onClick, so tapping the dim does nothing (never dismisses
+          the tour); stopPropagation keeps a spotlighted dialog from treating
+          the tap as an outside-click and closing itself. */}
+      <div
+        className="fixed inset-0 z-[110] pointer-events-auto"
+        onPointerDown={(e) => e.stopPropagation()}
+      />
+
+      {/* The dim + spotlight (visual only). With a target, a transparent box
+          punches a hole via its huge spread shadow; without one, a plain
+          full-screen dim. */}
       {rect ? (
         <div
           className="fixed z-[111] pointer-events-none rounded-lg ring-2 ring-primary transition-all duration-200"
@@ -180,33 +194,44 @@ export function TourOverlay() {
         className="fixed z-[112] pointer-events-auto rounded-xl border bg-popover text-popover-foreground p-4 shadow-elevated outline-none"
         style={cardStyle}
       >
-        {!isSingle && (
-          <div className="text-xs text-muted-foreground mb-1">
-            {stepIndex + 1} of {steps.length}
-          </div>
-        )}
-        <h3 className="text-sm font-semibold mb-1">{step.title}</h3>
+        {/* Exit, tucked into the corner so it stays out of the controls. */}
+        <button
+          type="button"
+          onClick={end}
+          aria-label="Exit tour"
+          className="absolute top-2 right-2 inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+        >
+          <X className="h-4 w-4" />
+        </button>
+        <h3 className="text-sm font-semibold mb-1 pr-6">{step.title}</h3>
         <p className="text-[13px] text-muted-foreground leading-relaxed mb-3">{step.body}</p>
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-3">
+          {/* Progress: the current step is a pill, the rest small dots. */}
           {isSingle ? (
             <span />
           ) : (
-            <button
-              type="button"
-              onClick={end}
-              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Skip tour
-            </button>
+            <div className="flex items-center gap-1.5" aria-hidden="true">
+              {steps.map((_, i) => (
+                <span
+                  key={i}
+                  className={
+                    i === stepIndex
+                      ? 'h-1.5 w-4 rounded-full bg-primary transition-all'
+                      : 'h-1.5 w-1.5 rounded-full bg-muted-foreground/30 transition-all'
+                  }
+                />
+              ))}
+            </div>
           )}
           <div className="flex gap-2">
             {stepIndex > 0 && (
-              <Button variant="outline" size="sm" onClick={prev}>
+              <Button variant="ghost" size="sm" onClick={prev}>
                 Back
               </Button>
             )}
             <Button size="sm" onClick={next}>
               {isSingle ? 'Got it' : isLast ? 'Done' : 'Next'}
+              {!isSingle && !isLast && <ArrowRight className="h-3.5 w-3.5 ml-1" />}
             </Button>
           </div>
         </div>

--- a/src/components/tour/TourOverlay.tsx
+++ b/src/components/tour/TourOverlay.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTourStore } from '@/stores/tourStore';
-import { TOUR_STEPS } from '@/components/tour/tourSteps';
 import { Button } from '@/components/ui/button';
 
 interface Rect {
@@ -32,6 +32,7 @@ const prefersReducedMotion = () =>
 export function TourOverlay() {
   const active = useTourStore((s) => s.active);
   const stepIndex = useTourStore((s) => s.stepIndex);
+  const steps = useTourStore((s) => s.steps);
   const next = useTourStore((s) => s.next);
   const prev = useTourStore((s) => s.prev);
   const end = useTourStore((s) => s.end);
@@ -39,45 +40,68 @@ export function TourOverlay() {
   const [rect, setRect] = useState<Rect | null>(null);
   const cardRef = useRef<HTMLDivElement>(null);
 
-  const step = TOUR_STEPS[stepIndex];
-  const isLast = stepIndex === TOUR_STEPS.length - 1;
+  const step = steps[stepIndex];
+  const isLast = stepIndex === steps.length - 1;
+  // A one-off "Show me" spotlight is a single step; drop the step counter and
+  // soften the action label so it doesn't read like a multi-step walkthrough.
+  const isSingle = steps.length === 1;
 
   // Locate + track the target rect for the current step.
   useEffect(() => {
     if (!active || !step) return;
     const reduce = prefersReducedMotion();
-    const el = step.target
-      ? document.querySelector<HTMLElement>(step.target)
-      : null;
 
-    if (!el) {
-      // Legitimate "sync React state with the DOM" measurement; the target is
-      // absent (hidden at this breakpoint) so we fall back to a centered card.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setRect(null);
-      return;
-    }
+    // A guided step may need to open the surface its target lives in (e.g. the
+    // Batch modal) before the element exists. Run that side-effect first.
+    step.action?.();
 
-    el.scrollIntoView({ block: 'center', inline: 'nearest', behavior: reduce ? 'auto' : 'smooth' });
+    let cancelled = false;
+    const cleanups: Array<() => void> = [];
 
-    const update = () => {
-      const r = el.getBoundingClientRect();
-      if (r.width === 0 && r.height === 0) {
-        setRect(null); // hidden (e.g. collapsed at this breakpoint)
-      } else {
-        setRect({ top: r.top, left: r.left, width: r.width, height: r.height });
-      }
+    const attach = (el: HTMLElement) => {
+      el.scrollIntoView({ block: 'center', inline: 'nearest', behavior: reduce ? 'auto' : 'smooth' });
+      const update = () => {
+        const r = el.getBoundingClientRect();
+        if (r.width === 0 && r.height === 0) {
+          setRect(null); // hidden (e.g. collapsed at this breakpoint)
+        } else {
+          setRect({ top: r.top, left: r.left, width: r.width, height: r.height });
+        }
+      };
+      update();
+      // Recompute after the smooth scroll settles.
+      const settle = window.setTimeout(update, reduce ? 0 : 280);
+      window.addEventListener('scroll', update, true);
+      window.addEventListener('resize', update);
+      cleanups.push(() => {
+        window.clearTimeout(settle);
+        window.removeEventListener('scroll', update, true);
+        window.removeEventListener('resize', update);
+      });
     };
 
-    update();
-    // Recompute after the smooth scroll settles.
-    const settle = window.setTimeout(update, reduce ? 0 : 280);
-    window.addEventListener('scroll', update, true);
-    window.addEventListener('resize', update);
+    // Locate the target, retrying briefly so an element mounted by action()
+    // (a modal opening, a section expanding) is caught instead of falling
+    // straight through to the centered fallback.
+    const locate = (attemptsLeft: number) => {
+      if (cancelled) return;
+      const el = step.target ? document.querySelector<HTMLElement>(step.target) : null;
+      if (el) {
+        attach(el);
+        return;
+      }
+      if (step.target && attemptsLeft > 0) {
+        const t = window.setTimeout(() => locate(attemptsLeft - 1), 60);
+        cleanups.push(() => window.clearTimeout(t));
+        return;
+      }
+      setRect(null); // no target (or it never appeared) → centered card
+    };
+    locate(10); // ~600ms budget for an async-mounted modal to appear
+
     return () => {
-      window.clearTimeout(settle);
-      window.removeEventListener('scroll', update, true);
-      window.removeEventListener('resize', update);
+      cancelled = true;
+      cleanups.forEach((fn) => fn());
     };
   }, [active, stepIndex, step]);
 
@@ -117,17 +141,20 @@ export function TourOverlay() {
     cardStyle = { top: '50%', left: '50%', transform: 'translate(-50%, -50%)', width: CARD_W };
   }
 
-  return (
+  // Portaled to <body> and layered above Radix dialogs (z-50) and the
+  // browser-compat notice (z-100), so a guided step can spotlight a control
+  // inside an open modal — the dim covers the modal and the cutout reveals it.
+  return createPortal(
     <div role="dialog" aria-modal="true" aria-label="Product tour">
       {/* Click-catcher: blocks interaction with the page beneath the tour.
           Explicit pointer-events so it works even if <body> is locked. */}
-      <div className="fixed inset-0 z-[60] pointer-events-auto" />
+      <div className="fixed inset-0 z-[110] pointer-events-auto" />
 
       {/* The dim + spotlight. With a target, a transparent box punches a hole
           via its huge spread shadow; without one, a plain full-screen dim. */}
       {rect ? (
         <div
-          className="fixed z-[61] pointer-events-none rounded-lg ring-2 ring-primary transition-all duration-200"
+          className="fixed z-[111] pointer-events-none rounded-lg ring-2 ring-primary transition-all duration-200"
           style={{
             top: rect.top - PAD,
             left: rect.left - PAD,
@@ -137,29 +164,35 @@ export function TourOverlay() {
           }}
         />
       ) : (
-        <div className="fixed inset-0 z-[61] pointer-events-none bg-black/60" />
+        <div className="fixed inset-0 z-[111] pointer-events-none bg-black/60" />
       )}
 
       {/* Coachmark */}
       <div
         ref={cardRef}
         tabIndex={-1}
-        className="fixed z-[62] pointer-events-auto rounded-xl border bg-popover text-popover-foreground p-4 shadow-elevated outline-none"
+        className="fixed z-[112] pointer-events-auto rounded-xl border bg-popover text-popover-foreground p-4 shadow-elevated outline-none"
         style={cardStyle}
       >
-        <div className="text-xs text-muted-foreground mb-1">
-          {stepIndex + 1} of {TOUR_STEPS.length}
-        </div>
+        {!isSingle && (
+          <div className="text-xs text-muted-foreground mb-1">
+            {stepIndex + 1} of {steps.length}
+          </div>
+        )}
         <h3 className="text-sm font-semibold mb-1">{step.title}</h3>
         <p className="text-[13px] text-muted-foreground leading-relaxed mb-3">{step.body}</p>
         <div className="flex items-center justify-between">
-          <button
-            type="button"
-            onClick={end}
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Skip tour
-          </button>
+          {isSingle ? (
+            <span />
+          ) : (
+            <button
+              type="button"
+              onClick={end}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Skip tour
+            </button>
+          )}
           <div className="flex gap-2">
             {stepIndex > 0 && (
               <Button variant="outline" size="sm" onClick={prev}>
@@ -167,11 +200,12 @@ export function TourOverlay() {
               </Button>
             )}
             <Button size="sm" onClick={next}>
-              {isLast ? 'Done' : 'Next'}
+              {isSingle ? 'Got it' : isLast ? 'Done' : 'Next'}
             </Button>
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/src/components/tour/tourSteps.ts
+++ b/src/components/tour/tourSteps.ts
@@ -12,6 +12,13 @@ export interface TourStep {
   target?: string;
   title: string;
   body: string;
+  /**
+   * Optional side-effect run when this step becomes active — e.g. open the
+   * modal or expand the section the target lives in, so a guided walkthrough
+   * can spotlight a control that is not yet on screen. Must be idempotent: it
+   * re-runs when the user navigates back to the step.
+   */
+  action?: () => void;
 }
 
 export const TOUR_STEPS: TourStep[] = [

--- a/src/stores/onboardingStore.ts
+++ b/src/stores/onboardingStore.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+/**
+ * Tracks which feature walkthroughs the user has finished, so the guide can
+ * show onboarding progress (checks per feature + an overall tally). A feature
+ * is marked learned only when its "Walk me through it" tour reaches the last
+ * step — skipping or exiting early does not count. Persisted to localStorage.
+ */
+interface OnboardingState {
+  /** Feature key → learned. Absent/false means not yet completed. */
+  completed: Record<string, boolean>;
+  markComplete: (key: string) => void;
+}
+
+export const useOnboardingStore = create<OnboardingState>()(
+  persist(
+    (set) => ({
+      completed: {},
+      markComplete: (key) =>
+        set((s) => (s.completed[key] ? s : { completed: { ...s.completed, [key]: true } })),
+    }),
+    { name: 'dondocs-onboarding' }
+  )
+);

--- a/src/stores/tourStore.ts
+++ b/src/stores/tourStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { TOUR_STEPS } from '@/components/tour/tourSteps';
+import { TOUR_STEPS, type TourStep } from '@/components/tour/tourSteps';
 
 const TOUR_STORAGE_KEY = 'dondocs-tour-completed';
 // Version of the TOUR CONTENT (not the app). Bump when the steps change
@@ -9,8 +9,16 @@ const TOUR_VERSION = '1';
 interface TourState {
   active: boolean;
   stepIndex: number;
-  /** Open the tour from the first step (used by replays and first-run). */
+  /** The steps currently being shown — the full intro tour, or an ad-hoc
+   *  spotlight launched from the guide's "Show me" buttons. */
+  steps: TourStep[];
+  /** Whether ending should record the first-run flag. Only the intro tour
+   *  marks itself seen; a one-off "Show me" spotlight must not. */
+  markOnEnd: boolean;
+  /** Open the full intro tour from the first step (replays + first-run). */
   start: () => void;
+  /** Spotlight an arbitrary set of steps (e.g. one feature's location). */
+  startSteps: (steps: TourStep[]) => void;
   next: () => void;
   prev: () => void;
   /** Close the tour and mark it seen so first-run does not nag again. */
@@ -33,13 +41,20 @@ function clearBodyPointerLock(): void {
 export const useTourStore = create<TourState>((set, get) => ({
   active: false,
   stepIndex: 0,
+  steps: TOUR_STEPS,
+  markOnEnd: true,
   start: () => {
     clearBodyPointerLock();
-    set({ active: true, stepIndex: 0 });
+    set({ active: true, stepIndex: 0, steps: TOUR_STEPS, markOnEnd: true });
+  },
+  startSteps: (steps) => {
+    if (steps.length === 0) return;
+    clearBodyPointerLock();
+    set({ active: true, stepIndex: 0, steps, markOnEnd: false });
   },
   next: () => {
-    const { stepIndex } = get();
-    if (stepIndex >= TOUR_STEPS.length - 1) {
+    const { stepIndex, steps } = get();
+    if (stepIndex >= steps.length - 1) {
       get().end();
       return;
     }
@@ -48,14 +63,17 @@ export const useTourStore = create<TourState>((set, get) => ({
   prev: () => set((s) => ({ stepIndex: Math.max(0, s.stepIndex - 1) })),
   end: () => {
     // Mark seen whether the user finished or skipped — first-run is one-time;
-    // explicit replays via start() ignore this flag.
-    try {
-      localStorage.setItem(TOUR_STORAGE_KEY, TOUR_VERSION);
-    } catch {
-      /* storage unavailable — nothing to persist */
+    // explicit replays via start() ignore this flag. A "Show me" spotlight
+    // (markOnEnd === false) must not stand in for the first-run tour.
+    if (get().markOnEnd) {
+      try {
+        localStorage.setItem(TOUR_STORAGE_KEY, TOUR_VERSION);
+      } catch {
+        /* storage unavailable — nothing to persist */
+      }
     }
     clearBodyPointerLock();
-    set({ active: false, stepIndex: 0 });
+    set({ active: false, stepIndex: 0, steps: TOUR_STEPS, markOnEnd: true });
   },
 }));
 

--- a/src/stores/tourStore.ts
+++ b/src/stores/tourStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { TOUR_STEPS, type TourStep } from '@/components/tour/tourSteps';
+import { useOnboardingStore } from '@/stores/onboardingStore';
 
 const TOUR_STORAGE_KEY = 'dondocs-tour-completed';
 // Version of the TOUR CONTENT (not the app). Bump when the steps change
@@ -15,10 +16,14 @@ interface TourState {
   /** Whether ending should record the first-run flag. Only the intro tour
    *  marks itself seen; a one-off "Show me" spotlight must not. */
   markOnEnd: boolean;
+  /** Onboarding key for the active walkthrough. Marked learned only when the
+   *  tour reaches its last step (not when skipped/exited). null = don't track. */
+  completionKey: string | null;
   /** Open the full intro tour from the first step (replays + first-run). */
   start: () => void;
-  /** Spotlight an arbitrary set of steps (e.g. one feature's location). */
-  startSteps: (steps: TourStep[]) => void;
+  /** Spotlight an arbitrary set of steps (e.g. one feature's walkthrough).
+   *  Pass an onboarding key to mark the feature learned on completion. */
+  startSteps: (steps: TourStep[], completionKey?: string) => void;
   next: () => void;
   prev: () => void;
   /** Close the tour and mark it seen so first-run does not nag again. */
@@ -43,18 +48,22 @@ export const useTourStore = create<TourState>((set, get) => ({
   stepIndex: 0,
   steps: TOUR_STEPS,
   markOnEnd: true,
+  completionKey: null,
   start: () => {
     clearBodyPointerLock();
-    set({ active: true, stepIndex: 0, steps: TOUR_STEPS, markOnEnd: true });
+    set({ active: true, stepIndex: 0, steps: TOUR_STEPS, markOnEnd: true, completionKey: null });
   },
-  startSteps: (steps) => {
+  startSteps: (steps, completionKey) => {
     if (steps.length === 0) return;
     clearBodyPointerLock();
-    set({ active: true, stepIndex: 0, steps, markOnEnd: false });
+    set({ active: true, stepIndex: 0, steps, markOnEnd: false, completionKey: completionKey ?? null });
   },
   next: () => {
-    const { stepIndex, steps } = get();
+    const { stepIndex, steps, completionKey } = get();
     if (stepIndex >= steps.length - 1) {
+      // Reaching the final step = finished. Record the feature as learned
+      // before closing (an early × / Esc / Skip never gets here).
+      if (completionKey) useOnboardingStore.getState().markComplete(completionKey);
       get().end();
       return;
     }
@@ -73,7 +82,7 @@ export const useTourStore = create<TourState>((set, get) => ({
       }
     }
     clearBodyPointerLock();
-    set({ active: false, stepIndex: 0, steps: TOUR_STEPS, markOnEnd: true });
+    set({ active: false, stepIndex: 0, steps: TOUR_STEPS, markOnEnd: true, completionKey: null });
   },
 }));
 

--- a/tests/unit/tourStore.test.ts
+++ b/tests/unit/tourStore.test.ts
@@ -8,16 +8,23 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useTourStore, hasCompletedTour } from '@/stores/tourStore';
+import { useOnboardingStore } from '@/stores/onboardingStore';
 import { TOUR_STEPS } from '@/components/tour/tourSteps';
 
 const SPOTLIGHT = [
   { target: '[data-tour="batch"]', title: 'Batch lives here', body: 'Open this to generate one per row.' },
 ];
 
+const TWO_STEP = [
+  { target: '[data-tour="a"]', title: 'A', body: 'first' },
+  { target: '[data-tour="b"]', title: 'B', body: 'second' },
+];
+
 describe('tourStore', () => {
   beforeEach(() => {
     localStorage.clear();
-    useTourStore.setState({ active: false, stepIndex: 0, steps: TOUR_STEPS, markOnEnd: true });
+    useTourStore.setState({ active: false, stepIndex: 0, steps: TOUR_STEPS, markOnEnd: true, completionKey: null });
+    useOnboardingStore.setState({ completed: {} });
   });
 
   it('start() runs the full intro tour and ending records it as seen', () => {
@@ -57,5 +64,26 @@ describe('tourStore', () => {
     useTourStore.getState().end();
     expect(useTourStore.getState().steps).toBe(TOUR_STEPS);
     expect(useTourStore.getState().markOnEnd).toBe(true);
+  });
+
+  it('finishing a walkthrough marks its onboarding key learned', () => {
+    useTourStore.getState().startSteps(TWO_STEP, 'enclosures');
+    useTourStore.getState().next(); // step 1 -> 2
+    useTourStore.getState().next(); // past the last step = finished
+    expect(useTourStore.getState().active).toBe(false);
+    expect(useOnboardingStore.getState().completed.enclosures).toBe(true);
+  });
+
+  it('exiting a walkthrough early does NOT mark it learned', () => {
+    useTourStore.getState().startSteps(TWO_STEP, 'enclosures');
+    useTourStore.getState().next(); // advance to step 2 (not finished)
+    useTourStore.getState().end();  // user hits the corner X / Esc
+    expect(useOnboardingStore.getState().completed.enclosures).toBeUndefined();
+  });
+
+  it('a walkthrough with no key never touches onboarding', () => {
+    useTourStore.getState().startSteps(SPOTLIGHT); // no completionKey
+    useTourStore.getState().next(); // single step -> finishes
+    expect(useOnboardingStore.getState().completed).toEqual({});
   });
 });

--- a/tests/unit/tourStore.test.ts
+++ b/tests/unit/tourStore.test.ts
@@ -1,0 +1,61 @@
+/**
+ * tourStore drives both the first-run product tour and the guide's per-feature
+ * "Show me" spotlights. The two share one overlay but must not share one fate:
+ * dismissing a one-off spotlight must NOT record the first-run tour as seen,
+ * or a brand-new user who clicks "Show me" before the intro tour would never
+ * get the intro. These tests lock in that boundary (the `markOnEnd` guard) plus
+ * the basics of the generalized step set.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTourStore, hasCompletedTour } from '@/stores/tourStore';
+import { TOUR_STEPS } from '@/components/tour/tourSteps';
+
+const SPOTLIGHT = [
+  { target: '[data-tour="batch"]', title: 'Batch lives here', body: 'Open this to generate one per row.' },
+];
+
+describe('tourStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useTourStore.setState({ active: false, stepIndex: 0, steps: TOUR_STEPS, markOnEnd: true });
+  });
+
+  it('start() runs the full intro tour and ending records it as seen', () => {
+    useTourStore.getState().start();
+    expect(useTourStore.getState().active).toBe(true);
+    expect(useTourStore.getState().steps).toBe(TOUR_STEPS);
+
+    useTourStore.getState().end();
+    expect(useTourStore.getState().active).toBe(false);
+    expect(hasCompletedTour()).toBe(true);
+  });
+
+  it('startSteps() spotlights ad-hoc steps without marking the first-run tour seen', () => {
+    useTourStore.getState().startSteps(SPOTLIGHT);
+    expect(useTourStore.getState().active).toBe(true);
+    expect(useTourStore.getState().steps).toEqual(SPOTLIGHT);
+
+    useTourStore.getState().end();
+    expect(useTourStore.getState().active).toBe(false);
+    // The one-off spotlight must not stand in for the first-run intro tour.
+    expect(hasCompletedTour()).toBe(false);
+  });
+
+  it('next() ends based on the active step set, not the intro-tour length', () => {
+    useTourStore.getState().startSteps(SPOTLIGHT); // single step
+    useTourStore.getState().next(); // advancing past the only step closes it
+    expect(useTourStore.getState().active).toBe(false);
+  });
+
+  it('startSteps([]) is a no-op', () => {
+    useTourStore.getState().startSteps([]);
+    expect(useTourStore.getState().active).toBe(false);
+  });
+
+  it('end() resets back to the intro tour for the next first-run check', () => {
+    useTourStore.getState().startSteps(SPOTLIGHT);
+    useTourStore.getState().end();
+    expect(useTourStore.getState().steps).toBe(TOUR_STEPS);
+    expect(useTourStore.getState().markOnEnd).toBe(true);
+  });
+});


### PR DESCRIPTION
Makes the Guide's **Features** tab actually teach the power features — for both fast learners and people who want to be shown exactly where things are.

## What's new

**Accordion how-tos.** Each feature expands to a short numbered list of steps. Fast to skim, no modal-hopping.

**"Show me where" / "Walk me through it".** Each feature has a button that closes the Guide and spotlights the real control in the live UI.
- Most features: a single spotlight on where the feature lives.
- **Batch** ships a full **multi-step guided walkthrough**: it opens the Batch modal and steps through each control in turn — add a variable → common variables → generate — with Next/Back. This is the reference pattern; the other six can get the same treatment next.

## Under the hood

- **Generalized the tour engine** so it runs any step set, not just the first-run intro tour. Each step can run a side-effect (open a modal, expand a section) before spotlighting, and the overlay now portals above Radix dialogs (`z-[110]+`) so it can highlight controls *inside* an open modal while keeping its own Next button clickable.
- Single-step spotlights drop the "N of M" counter and read **Got it**.
- A one-off spotlight does **not** mark the first-run intro tour as seen (so a new user who clicks "Show me" still gets their intro) — guarded and covered by a new `tourStore` test.
- Tagged the live targets: the Batch toolbar button + its internal controls, Profiles, Enclosures, Signature, Classification (Templates/Save already tagged). Toolbar buttons otherwise unchanged.

## Try it
Guide (the **?**-adjacent "When to use…" button) → **Features** tab → expand **Batch generation** → **Walk me through it**. Then try another feature's **Show me where**.

Version bumped to 1.1.54. Type-check, lint, build, and all 1207 tests pass (added 5).