### PR TITLE
UI refresh, document finder rebuild, and getting-started onboarding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.54",
+  "version": "1.1.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.54",
+      "version": "1.1.55",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.1.54",
+  "version": "1.1.55",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,8 @@ import { TemplateLoaderModal } from '@/components/modals/TemplateLoaderModal';
 import { DocumentGuideModal } from '@/components/modals/DocumentGuideModal';
 import { WelcomeModal } from '@/components/modals/WelcomeModal';
 import { TourOverlay } from '@/components/tour/TourOverlay';
+import { ActivationChecklist } from '@/components/onboarding/ActivationChecklist';
+import { useOnboardingStore } from '@/stores/onboardingStore';
 import { PIIWarningModal } from '@/components/modals/PIIWarningModal';
 import { LogViewerModal } from '@/components/modals/LogViewerModal';
 import { EnclosureErrorModal } from '@/components/modals/EnclosureErrorModal';
@@ -656,7 +658,12 @@ function App() {
 
       onProgress?.({ kind: 'pdf-saving' });
       const blob = new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' });
-      return await downloadPdfBlob(blob, 'correspondence.pdf', preOpenedWindow);
+      const downloaded = await downloadPdfBlob(blob, 'correspondence.pdf', preOpenedWindow);
+      // First real PDF checks off "Build your first document" in the getting-
+      // started checklist (markComplete is idempotent). Both the normal and the
+      // PII-confirmed download paths end here.
+      if (downloaded) useOnboardingStore.getState().markComplete('first_document');
+      return downloaded;
     }
     return false;
   }, [compile]);
@@ -864,7 +871,12 @@ function App() {
 
       onProgress?.({ kind: 'pdf-saving' });
       const blob = new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' });
-      return await downloadPdfBlob(blob, 'correspondence.pdf', preOpenedWindow);
+      const downloaded = await downloadPdfBlob(blob, 'correspondence.pdf', preOpenedWindow);
+      // First real PDF checks off "Build your first document" in the getting-
+      // started checklist (markComplete is idempotent). Both the normal and the
+      // PII-confirmed download paths end here.
+      if (downloaded) useOnboardingStore.getState().markComplete('first_document');
+      return downloaded;
     }
     return false;
   }, [compile]);
@@ -1058,6 +1070,8 @@ function App() {
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
+        // Exporting a form PDF also completes the checklist's first-document step.
+        useOnboardingStore.getState().markComplete('first_document');
       } else {
         console.error('No PDF generated - missing templates or unsupported form type');
       }
@@ -1456,6 +1470,7 @@ ${texFiles['body.tex'] || '% No body content'}
       <DocumentGuideModal />
       <WelcomeModal />
       <TourOverlay />
+      <ActivationChecklist />
       <PIIWarningModal
         detectionResult={piiDetectionResult}
         onCancel={handleCancelPIIDownload}

--- a/src/components/editor/Form11811Section.tsx
+++ b/src/components/editor/Form11811Section.tsx
@@ -68,7 +68,7 @@ export function Form11811Section() {
             <span className="font-medium">Marine Identification</span>
           </AccordionTrigger>
           <AccordionContent className="space-y-4 pt-2">
-            <div className="grid grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="lastName">Last Name</Label>
                 <InputWithVariables
@@ -104,7 +104,7 @@ export function Form11811Section() {
               </div>
             </div>
 
-            <div className="grid grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="edipi">EDIPI</Label>
                 <InputWithVariables

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -118,7 +118,7 @@ export function Form6105Section() {
             <span className="font-medium">Header Information</span>
           </AccordionTrigger>
           <AccordionContent className="space-y-4 pt-2">
-            <div className="grid grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <div className="space-y-2">
                 <Label htmlFor="actionNo">1. Action No.</Label>
                 <Input

--- a/src/components/editor/JointLetterSection.tsx
+++ b/src/components/editor/JointLetterSection.tsx
@@ -258,7 +258,7 @@ export function JointLetterSection() {
               </div>
 
               {/* SSIC / Serial / Date */}
-              <div className="grid grid-cols-3 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="jointJuniorSSIC">SSIC</Label>
                   <div className="flex gap-1">

--- a/src/components/editor/MOASection.tsx
+++ b/src/components/editor/MOASection.tsx
@@ -135,7 +135,7 @@ export function MOASection() {
               </div>
 
               {/* SSIC / Serial / Date */}
-              <div className="grid grid-cols-3 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="seniorSSIC">SSIC</Label>
                   <div className="flex gap-1">
@@ -283,7 +283,7 @@ export function MOASection() {
               </div>
 
               {/* SSIC / Serial / Date */}
-              <div className="grid grid-cols-3 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="juniorSSIC">SSIC</Label>
                   <div className="flex gap-1">
@@ -419,7 +419,7 @@ export function MOASection() {
                     onClick={() => setField('signatureType', 'none' as SignatureType)}
                   >
                     <span className="text-xs">Typed Only</span>
-                    <span className="text-[10px] text-muted-foreground">Overscored names</span>
+                    <span className="text-xs text-muted-foreground">Overscored names</span>
                   </Button>
                   <Button
                     type="button"

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect, type ChangeEvent } from 'react';
-import { Moon, Sun, Download, FileText, RefreshCw, Bug, Save, RotateCcw, Shield, HelpCircle, Info, Layers, Search, Keyboard, Menu, FileDown, FileUp, ScrollText, SlidersHorizontal, Minimize2, Maximize2, Check, Settings, Undo2, Redo2, Eraser, Compass, PanelRight, PanelRightClose, Link2, FileInput, X, Zap, Loader2, Lightbulb, FolderOpen } from 'lucide-react';
+import { Moon, Sun, Download, FileText, RefreshCw, Bug, Save, RotateCcw, Shield, HelpCircle, Info, Layers, Search, Keyboard, Menu, FileDown, FileUp, ScrollText, SlidersHorizontal, Minimize2, Maximize2, Check, Settings, Undo2, Redo2, Eraser, Compass, PanelRight, PanelRightClose, Link2, FileInput, X, Zap, Loader2, Lightbulb, FolderOpen, Rocket } from 'lucide-react';
 import { GithubIcon } from '@/components/icons/GithubIcon';
 import { Button } from '@/components/ui/button';
 import {
@@ -28,6 +28,7 @@ import { STORAGE_KEYS } from '@/lib/constants';
 import { canonicalizeUnitAddress } from '@/lib/unitAddress';
 import { useLogStore } from '@/stores/logStore';
 import { useTourStore } from '@/stores/tourStore';
+import { useOnboardingStore } from '@/stores/onboardingStore';
 import { safeReportUrl, BUG_REPORT_PRIVACY_NOTICE, BUG_REPORT_LOG_PROMPT } from '@/lib/bugReport';
 
 interface HeaderProps {
@@ -55,6 +56,9 @@ interface HeaderProps {
 const GITHUB_REPO_URL = 'https://github.com/marinecoders/dondocs';
 const GITHUB_NEW_ISSUE_URL = 'https://github.com/marinecoders/dondocs/issues/new';
 const STORAGE_KEY = STORAGE_KEYS.DOCUMENT;
+// Marine Coders Eagle, Globe & Anchor seal — air-gap safe (same-origin SVG,
+// already preloaded for the background watermark).
+const marineCodersLogo = `${import.meta.env.BASE_URL}attachments/marine-coders-logo.svg`;
 
 /**
  * Build a prefilled "New issue" URL for the Help-menu bug report button.
@@ -187,6 +191,10 @@ export function Header({
   const togglePreview = useUIStore((s) => s.togglePreview);
   const fullQualityPreview = useUIStore((s) => s.fullQualityPreview);
   const setFullQualityPreview = useUIStore((s) => s.setFullQualityPreview);
+  // Reopen the getting-started checklist (clears its dismissal). Hidden once the
+  // onboarding is finished and the celebration has retired the launcher for good.
+  const checklistCelebrated = useOnboardingStore((s) => s.checklistCelebrated);
+  const reopenChecklist = () => useOnboardingStore.getState().setChecklistDismissed(false);
 
   // Document store actions only — we intentionally do NOT subscribe to any
   // document state here. The import/export/reset handlers below read the
@@ -514,7 +522,7 @@ export function Header({
     <header className="border-b-2 border-primary/40 bg-gradient-to-r from-card via-card to-secondary/30 shadow-card">
       {/* Dismissable beta release banner */}
       {!bannerDismissed && (
-        <div className="bg-amber-500/10 text-amber-700 dark:text-amber-300/90 text-[11px] font-medium py-0.5 text-center tracking-wide relative border-b border-amber-500/20">
+        <div className="bg-amber-500/10 text-amber-700 dark:text-amber-300/90 text-xs font-medium py-0.5 text-center tracking-wide relative border-b border-amber-500/20">
           Not an official DoW website. Beta release - report issues on GitHub.
           <button
             onClick={dismissBanner}
@@ -536,26 +544,35 @@ export function Header({
       />
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2 lg:gap-3 min-w-0">
-          <div className="flex items-center gap-2">
-            <FileText className="h-5 w-5 lg:h-6 lg:w-6 text-primary shrink-0" />
+          <div className="flex items-center gap-2.5">
+            {/* Brand mark — the Marine Coders Eagle, Globe & Anchor. The seal
+                SVG is solid white, so invert it to read on the light header
+                and leave it white in dark mode. */}
+            <img
+              src={marineCodersLogo}
+              alt="Marine Coders"
+              decoding="sync"
+              className="h-7 lg:h-8 w-auto shrink-0 invert dark:invert-0"
+            />
             <div className="flex flex-col min-w-0">
-              <h1 className="text-sm lg:text-lg font-bold text-foreground leading-tight truncate tracking-wide">
-                <span className="hidden sm:inline">Naval Correspondence</span>
-                <span className="sm:hidden">Naval Corr.</span>
+              <h1 className="text-base lg:text-lg font-semibold text-foreground leading-tight truncate">
+                DonDocs
               </h1>
-              <span className="text-xs text-muted-foreground hidden lg:block leading-tight tracking-wider uppercase">Generator</span>
+              <span className="text-xs text-muted-foreground hidden sm:block leading-tight truncate">Naval correspondence &amp; forms</span>
             </div>
           </div>
           {/* NIST 800-171 Compliance Badge - icon only below lg, full badge on lg+ */}
           <button
+            type="button"
             onClick={() => setNistModalOpen(true)}
             // Same readability fix as the Clear button + Compiling pill in
             // this PR (and the Templates button in PR #57): drop the
             // tinted bg (green-500/10 over the header card-bg muddied the
             // green text). Keep the green border + green text for the
             // "compliant/safe" status identity, hover gets the faint green
-            // bg as the interactivity signal.
-            className="flex items-center justify-center gap-1.5 rounded-md border border-green-500/30 text-green-600 dark:text-green-400 text-xs cursor-pointer hover:bg-green-500/10 dark:hover:bg-green-500/15 transition-colors p-1.5 lg:px-2 lg:py-1 shrink-0"
+            // bg as the interactivity signal. Neutral focus ring (not green)
+            // so keyboard users get an indicator without a new accent colour.
+            className="flex items-center justify-center gap-1.5 rounded-md border border-green-500/30 text-green-600 dark:text-green-400 text-xs cursor-pointer hover:bg-green-500/10 dark:hover:bg-green-500/15 transition-colors p-1.5 lg:px-2 lg:py-1 shrink-0 outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
             title="Click to learn about NIST 800-171 compliance"
           >
             <Shield className="h-4 w-4 lg:h-3 lg:w-3" />
@@ -598,6 +615,10 @@ export function Header({
             <Redo2 className="h-4 w-4" aria-hidden="true" />
           </Button>
 
+          {/* Group divider — only at xl, where the full toolbar shows and the
+              row would otherwise read as one undifferentiated wall of icons. */}
+          <div aria-hidden="true" className="hidden xl:block w-px h-5 self-center bg-border mx-1" />
+
           {/* Refresh - hidden below xl, in hamburger menu */}
           <Button
             variant="ghost"
@@ -629,6 +650,8 @@ export function Header({
               <span className="hidden 2xl:inline">Preview</span>
             </Button>
           )}
+
+          <div aria-hidden="true" className="hidden xl:block w-px h-5 self-center bg-border mx-1" />
 
           {/* Save/Load dropdown - always visible but compact on smaller screens */}
           <DropdownMenu>
@@ -733,6 +756,8 @@ export function Header({
             </DropdownMenuContent>
           </DropdownMenu>
 
+          <div aria-hidden="true" className="hidden xl:block w-px h-5 self-center bg-border mx-1" />
+
           {/* Guide button - hidden below xl */}
           <Button
             variant="outline"
@@ -782,6 +807,12 @@ export function Header({
                 <Compass className="h-4 w-4 mr-2" />
                 Take the Tour
               </DropdownMenuItem>
+              {!checklistCelebrated && (
+                <DropdownMenuItem onClick={reopenChecklist}>
+                  <Rocket className="h-4 w-4 mr-2" />
+                  Getting started
+                </DropdownMenuItem>
+              )}
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => setNistModalOpen(true)}>
                 <Shield className="h-4 w-4 mr-2" />
@@ -882,7 +913,7 @@ export function Header({
                 </div>
                 {fullQualityPreview && <Check className="h-4 w-4" />}
               </DropdownMenuItem>
-              <p className="px-2 pb-1.5 text-[10px] text-muted-foreground leading-tight">
+              <p className="px-2 pb-1.5 text-xs text-muted-foreground leading-tight">
                 Includes enclosures, hyperlinks, and signatures in live preview. May slow compilation.
               </p>
             </DropdownMenuContent>
@@ -936,6 +967,12 @@ export function Header({
                 <Compass className="h-4 w-4 mr-2" />
                 Take the Tour
               </DropdownMenuItem>
+              {!checklistCelebrated && (
+                <DropdownMenuItem onClick={reopenChecklist}>
+                  <Rocket className="h-4 w-4 mr-2" />
+                  Getting started
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem onClick={() => setNistModalOpen(true)}>
                 <Shield className="h-4 w-4 mr-2" />
                 NIST 800-171

--- a/src/components/modals/CompileErrorModal.tsx
+++ b/src/components/modals/CompileErrorModal.tsx
@@ -141,7 +141,7 @@ export function CompileErrorModal({ open, error, compileLog, onClose }: CompileE
                 </Button>
               </div>
               <pre
-                className="max-h-48 overflow-auto rounded-md bg-muted border border-border p-2 text-[11px] leading-tight font-mono whitespace-pre-wrap break-all text-foreground/80"
+                className="max-h-48 overflow-auto rounded-md bg-muted border border-border p-2 text-xs leading-tight font-mono whitespace-pre-wrap break-all text-foreground/80"
                 aria-label="Compile error log"
               >
                 {compileLog}

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -1,5 +1,27 @@
 import { useState, useMemo } from 'react';
-import { HelpCircle, ChevronDown, ChevronRight, FileText, CheckCircle2, Lightbulb, BookOpen, Sparkles, ArrowRight, RotateCcw, Search, Eye, Check, Zap, Layers, Users, FolderOpen, Paperclip, PenLine, Link2, Shield, MapPin, type LucideIcon } from 'lucide-react';
+import { HelpCircle, ChevronDown, ChevronRight, ChevronLeft, FileText, CheckCircle2, Lightbulb, BookOpen, Sparkles, ArrowRight, RotateCcw, Search, Eye, Check, Zap, Layers, Users, FolderOpen, Paperclip, PenLine, Link2, Shield, MapPin, File, Briefcase, Mail, ClipboardCheck, ClipboardList, BookMarked, Scale, Award, ScrollText, FileSignature, Star, type LucideIcon } from 'lucide-react';
+
+// Lucide icons for document types / groups / categories, keyed by id — the
+// app uses lucide everywhere else, so the guide should too (the old emoji
+// `icon` fields in documentGuide.ts are no longer rendered).
+const DOC_TYPE_ICONS: Record<string, LucideIcon> = {
+  naval_letter: FileText, standard_letter: File, business_letter: Briefcase,
+  multiple_address_letter: Mail, joint_letter: Users, same_page_endorsement: CheckCircle2,
+  new_page_endorsement: ClipboardCheck, mfr: BookMarked, mf: FileText,
+  plain_paper_memorandum: File, letterhead_memorandum: FileText, decision_memorandum: Scale,
+  executive_memorandum: Award, joint_memorandum: Users, moa: ScrollText, mou: FileSignature,
+  executive_correspondence: Star, navmc_10274: ClipboardList, navmc_118_11: ClipboardList,
+};
+const GROUP_ICONS: Record<string, LucideIcon> = { correspondence: FileText, forms: ClipboardList };
+const CATEGORY_ICONS: Record<string, LucideIcon> = {
+  Letters: FileText, Endorsements: CheckCircle2, Memoranda: FileText,
+  Agreements: ScrollText, Executive: Star, Forms: ClipboardList,
+};
+
+function DocIcon({ id, className }: { id: string; className?: string }) {
+  const Icon = DOC_TYPE_ICONS[id] ?? FileText;
+  return <Icon className={className ?? 'h-5 w-5 shrink-0 text-muted-foreground'} aria-hidden="true" />;
+}
 import {
   Dialog,
   DialogContent,
@@ -18,344 +40,56 @@ import { DOCUMENT_TYPE_GUIDES, GUIDE_CATEGORIES, GUIDE_GROUPS, type DocumentType
 import { EXAMPLE_DOCUMENTS, EXAMPLE_CATEGORIES, type ExampleDocument } from '@/data/exampleDocuments';
 import { DOC_TYPE_LABELS, type DocumentData } from '@/types/document';
 
-// Document Finder Questions and Logic
-interface Question {
-  id: string;
-  question: string;
-  options: {
-    label: string;
-    value: string;
-    icon?: string;
-  }[];
-}
-
-const FINDER_QUESTIONS: Question[] = [
-  {
-    id: 'recipient',
-    question: 'Who is the primary recipient?',
-    options: [
-      { label: 'Military command or unit', value: 'military', icon: '🎖️' },
-      { label: 'Civilian person or business', value: 'civilian', icon: '💼' },
-      { label: 'Multiple commands/addressees', value: 'multiple', icon: '📨' },
-      { label: 'For the record (no specific recipient)', value: 'record', icon: '📔' },
-    ],
-  },
-  {
-    id: 'purpose',
-    question: 'What is the main purpose?',
-    options: [
-      { label: 'Request, recommendation, or tasking', value: 'request', icon: '📋' },
-      { label: 'Provide information or status update', value: 'inform', icon: '📢' },
-      { label: 'Present options for a decision', value: 'decision', icon: '⚖️' },
-      { label: 'Document an event for the record', value: 'document', icon: '📝' },
-      { label: 'Establish an agreement between parties', value: 'agreement', icon: '🤝' },
-      { label: 'Endorse/forward another letter', value: 'response', icon: '↩️' },
-    ],
-  },
-  {
-    id: 'routing',
-    question: 'How will this be routed?',
-    options: [
-      { label: 'Direct to recipient', value: 'direct', icon: '➡️' },
-      { label: 'Through chain of command (via)', value: 'via', icon: '⬆️' },
-      { label: 'Internal within my command', value: 'internal', icon: '🏢' },
-    ],
-  },
-  {
-    id: 'formality',
-    question: 'What level of formality is needed?',
-    options: [
-      { label: 'Formal with official letterhead', value: 'formal', icon: '🏛️' },
-      { label: 'Routine/working level', value: 'informal', icon: '📄' },
-      { label: 'Flag/General officer level', value: 'executive', icon: '⭐' },
-    ],
-  },
-];
-
-interface FinderResult {
-  docType: string;
-  confidence: 'high' | 'medium';
-  reason: string;
-}
-
-function getRecommendations(answers: Record<string, string>): FinderResult[] {
-  const results: FinderResult[] = [];
-  const { recipient, purpose, routing, formality } = answers;
-
-  // ===========================================
-  // ENDORSEMENTS (Ch 7) - Responding to/forwarding another letter
-  // ===========================================
-  if (purpose === 'response') {
-    if (formality === 'informal' || routing === 'internal') {
-      results.push({
-        docType: 'same_page_endorsement',
-        confidence: 'high',
-        reason: 'Per Ch 7: Brief endorsements added directly below the basic letter when space permits',
-      });
-      results.push({
-        docType: 'new_page_endorsement',
-        confidence: 'medium',
-        reason: 'Use if endorsement is lengthy or basic letter page is full',
-      });
-    } else {
-      results.push({
-        docType: 'new_page_endorsement',
-        confidence: 'high',
-        reason: 'Per Ch 7: New page endorsement with own letterhead for formal/detailed responses',
-      });
-      results.push({
-        docType: 'same_page_endorsement',
-        confidence: 'medium',
-        reason: 'Alternative if endorsement is brief and fits on original letter',
-      });
-    }
-    return results;
-  }
-
-  // ===========================================
-  // AGREEMENTS (Ch 12) - MOA vs MOU
-  // MOA = Specific resource/funding commitments
-  // MOU = General understanding, roles, coordination
-  // ===========================================
-  if (purpose === 'agreement') {
-    if (formality === 'formal' || formality === 'executive') {
-      results.push({
-        docType: 'moa',
-        confidence: 'high',
-        reason: 'Per Ch 12: MOA for agreements with specific resource commitments, funding, or binding obligations',
-      });
-      results.push({
-        docType: 'mou',
-        confidence: 'medium',
-        reason: 'Alternative: MOU if establishing general understanding without specific resource commitments',
-      });
-    } else {
-      results.push({
-        docType: 'mou',
-        confidence: 'high',
-        reason: 'Per Ch 12: MOU for establishing working relationships and general coordination frameworks',
-      });
-      results.push({
-        docType: 'moa',
-        confidence: 'medium',
-        reason: 'Use MOA instead if agreement involves specific resources or funding',
-      });
-    }
-    return results;
-  }
-
-  // ===========================================
-  // FOR THE RECORD - MFR (Ch 10)
-  // ===========================================
-  if (recipient === 'record') {
-    results.push({
-      docType: 'mfr',
-      confidence: 'high',
-      reason: 'Per Ch 10: Memorandum for the Record documents events, decisions, or conversations for official record',
-    });
-    return results;
-  }
-
-  // ===========================================
-  // CIVILIAN RECIPIENTS - Business Letter (Ch 11)
-  // ===========================================
-  if (recipient === 'civilian') {
-    results.push({
-      docType: 'business_letter',
-      confidence: 'high',
-      reason: 'Per Ch 11: Business letter format for correspondence with civilians, contractors, and non-DoD entities',
-    });
-    return results;
-  }
-
-  // ===========================================
-  // DECISION MEMOS (Ch 12) - Presenting options
-  // ===========================================
-  if (purpose === 'decision') {
-    results.push({
-      docType: 'decision_memorandum',
-      confidence: 'high',
-      reason: 'Per Ch 12: Decision memo presents options with pros/cons and staff recommendation for command decision',
-    });
-    if (formality === 'executive') {
-      results.push({
-        docType: 'executive_memorandum',
-        confidence: 'medium',
-        reason: 'Alternative for flag/general officer level with executive summary format',
-      });
-    }
-    return results;
-  }
-
-  // ===========================================
-  // MULTIPLE ADDRESSEES (Ch 2)
-  // ===========================================
-  if (recipient === 'multiple') {
-    results.push({
-      docType: 'multiple_address_letter',
-      confidence: 'high',
-      reason: 'Per Ch 2: Multiple address letter for identical content to several commands simultaneously',
-    });
-    results.push({
-      docType: 'naval_letter',
-      confidence: 'medium',
-      reason: 'Alternative: Standard naval letter with distribution list in Copy To section',
-    });
-    return results;
-  }
-
-  // ===========================================
-  // EXECUTIVE/FLAG LEVEL (Ch 12)
-  // ===========================================
-  if (formality === 'executive') {
-    if (routing === 'internal' || purpose === 'inform') {
-      results.push({
-        docType: 'executive_memorandum',
-        confidence: 'high',
-        reason: 'Per Ch 12: Executive memo for staff-to-senior leadership communication, status updates, and briefings',
-      });
-    } else {
-      results.push({
-        docType: 'executive_correspondence',
-        confidence: 'high',
-        reason: 'Per Ch 12: Executive correspondence for flag-to-flag or communication with very senior officials',
-      });
-    }
-    results.push({
-      docType: 'naval_letter',
-      confidence: 'medium',
-      reason: 'Naval letter is also appropriate for formal executive matters requiring official record',
-    });
-    return results;
-  }
-
-  // ===========================================
-  // DOCUMENTING EVENTS (Ch 10)
-  // ===========================================
-  if (purpose === 'document') {
-    results.push({
-      docType: 'mfr',
-      confidence: 'high',
-      reason: 'Per Ch 10: MFR documents meetings, verbal orders, decisions, or events for the official record',
-    });
-    if (routing === 'internal') {
-      results.push({
-        docType: 'letterhead_memorandum',
-        confidence: 'medium',
-        reason: 'Alternative: Letterhead memo if document needs to be shared formally within command',
-      });
-    }
-    return results;
-  }
-
-  // ===========================================
-  // INTERNAL/ROUTINE COMMUNICATION (Ch 12)
-  // ===========================================
-  if (routing === 'internal') {
-    if (formality === 'informal') {
-      results.push({
-        docType: 'plain_paper_memorandum',
-        confidence: 'high',
-        reason: 'Per Ch 12: Plain paper memo for routine internal working-level communication',
-      });
-      results.push({
-        docType: 'mf',
-        confidence: 'medium',
-        reason: 'Alternative: "Memorandum For" format for direct communication to specific person/office',
-      });
-    } else {
-      results.push({
-        docType: 'letterhead_memorandum',
-        confidence: 'high',
-        reason: 'Per Ch 12: Letterhead memo for formal internal communications that may be forwarded',
-      });
-      results.push({
-        docType: 'mf',
-        confidence: 'medium',
-        reason: 'Alternative: "Memorandum For" for direct staff actions or information papers',
-      });
-    }
-    return results;
-  }
-
-  // ===========================================
-  // CHAIN OF COMMAND ROUTING (Ch 2)
-  // ===========================================
-  if (routing === 'via') {
-    results.push({
-      docType: 'naval_letter',
-      confidence: 'high',
-      reason: 'Per Ch 2: Naval letter with Via line for correspondence routed through chain of command',
-    });
-    if (formality === 'informal') {
-      results.push({
-        docType: 'standard_letter',
-        confidence: 'medium',
-        reason: 'Alternative: Standard letter (same format without letterhead) if letterhead not available',
-      });
-    }
-    return results;
-  }
-
-  // ===========================================
-  // DEFAULT - NAVAL LETTER (Ch 2)
-  // The standard format for official DoN correspondence
-  // ===========================================
-  if (formality === 'formal') {
-    results.push({
-      docType: 'naval_letter',
-      confidence: 'high',
-      reason: 'Per Ch 2: Naval letter is the standard format for official Department of the Navy correspondence',
-    });
-  } else {
-    results.push({
-      docType: 'naval_letter',
-      confidence: 'high',
-      reason: 'Per Ch 2: Naval letter is appropriate for most official military correspondence',
-    });
-    results.push({
-      docType: 'standard_letter',
-      confidence: 'medium',
-      reason: 'Alternative: Standard letter (same format) when letterhead is not required or available',
-    });
-  }
-
-  return results;
-}
+import {
+  getNextQuestion,
+  getRecommendations,
+  DOC_DIFFERENTIATORS,
+  splitReason,
+} from './documentFinderLogic';
 
 // Document Finder Component
+//
+// A branching interview driven by getNextQuestion(answers). Answers are kept in
+// an ordered stack so "Back" pops the last answer and re-derives the current
+// question — questions are skipped/added dynamically, so a fixed index won't do.
 function DocumentFinder({ onSelectGuide }: { onSelectGuide: (guideId: string) => void }) {
-  const [currentQuestion, setCurrentQuestion] = useState(0);
   const [answers, setAnswers] = useState<Record<string, string>>({});
-  const [showResults, setShowResults] = useState(false);
+  const [order, setOrder] = useState<string[]>([]);
+
+  const question = getNextQuestion(answers);
+  const showResults = question === null && order.length > 0;
+
+  const recommendations = useMemo(
+    () => (showResults ? getRecommendations(answers) : []),
+    [showResults, answers]
+  );
 
   const handleAnswer = (questionId: string, value: string) => {
-    const newAnswers = { ...answers, [questionId]: value };
-    setAnswers(newAnswers);
+    setAnswers((prev) => ({ ...prev, [questionId]: value }));
+    setOrder((prev) => [...prev, questionId]);
+  };
 
-    // Move to next question or show results
-    if (currentQuestion < FINDER_QUESTIONS.length - 1) {
-      setCurrentQuestion(currentQuestion + 1);
-    } else {
-      setShowResults(true);
-    }
+  const handleBack = () => {
+    if (order.length === 0) return;
+    const last = order[order.length - 1];
+    const nextAnswers = { ...answers };
+    delete nextAnswers[last];
+    setAnswers(nextAnswers);
+    setOrder(order.slice(0, -1));
   };
 
   const handleReset = () => {
-    setCurrentQuestion(0);
     setAnswers({});
-    setShowResults(false);
+    setOrder([]);
   };
 
-  const recommendations = useMemo(() => {
-    if (!showResults) return [];
-    return getRecommendations(answers);
-  }, [showResults, answers]);
-
-  const question = FINDER_QUESTIONS[currentQuestion];
-  const progress = ((currentQuestion + (showResults ? 1 : 0)) / FINDER_QUESTIONS.length) * 100;
-
   if (showResults) {
+    const wasUnsure = ['category', 'recipient', 'purpose', 'resources', 'formType'].some(
+      (k) => answers[k] === 'unsure'
+    );
+    const [a, b] = recommendations;
+    const showCompare = b && DOC_DIFFERENTIATORS[a.docType] && DOC_DIFFERENTIATORS[b.docType];
+
     return (
       <div className="p-4 space-y-4">
         <div className="text-center pb-4 border-b">
@@ -368,10 +102,22 @@ function DocumentFinder({ onSelectGuide }: { onSelectGuide: (guideId: string) =>
           </p>
         </div>
 
+        {wasUnsure && (
+          <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-xs text-muted-foreground">
+            <Lightbulb className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
+            <span>
+              You weren&apos;t sure on one or more answers, so these are the most common
+              formats for your situation. Open any card to see when it fits, or use
+              &ldquo;Start over&rdquo; to refine your answers.
+            </span>
+          </div>
+        )}
+
         <div className="space-y-3">
           {recommendations.map((rec, index) => {
             const guide = DOCUMENT_TYPE_GUIDES.find(g => g.id === rec.docType);
             if (!guide) return null;
+            const { cite, why } = splitReason(rec.reason);
 
             return (
               <button
@@ -382,24 +128,26 @@ function DocumentFinder({ onSelectGuide }: { onSelectGuide: (guideId: string) =>
                 }`}
               >
                 <div className="flex items-start gap-3">
-                  <span className="text-2xl">{guide.icon}</span>
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2">
+                  <DocIcon id={guide.id} className="h-6 w-6 shrink-0 text-primary mt-0.5" />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
                       <span className="font-semibold">{guide.name}</span>
-                      {rec.confidence === 'high' && index === 0 && (
+                      {index === 0 ? (
                         <Badge className="bg-green-500/10 text-green-600 border-green-500/30">
                           Best Match
                         </Badge>
-                      )}
-                      {rec.confidence === 'medium' && (
+                      ) : (
                         <Badge variant="outline" className="text-xs">
                           Alternative
                         </Badge>
                       )}
+                      {cite && (
+                        <Badge variant="outline" className="text-[10px] font-normal text-muted-foreground">
+                          {cite}
+                        </Badge>
+                      )}
                     </div>
-                    <p className="text-sm text-muted-foreground mt-1">
-                      {rec.reason}
-                    </p>
+                    <p className="text-sm text-muted-foreground mt-1">{why}</p>
                   </div>
                   <ArrowRight className="h-5 w-5 text-muted-foreground shrink-0" />
                 </div>
@@ -407,6 +155,26 @@ function DocumentFinder({ onSelectGuide }: { onSelectGuide: (guideId: string) =>
             );
           })}
         </div>
+
+        {showCompare && (
+          <div className="rounded-lg border bg-muted/30 p-3">
+            <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground mb-2">
+              <Scale className="h-3.5 w-3.5" />
+              How to choose
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              {[a, b].map((r) => {
+                const g = DOCUMENT_TYPE_GUIDES.find((x) => x.id === r.docType);
+                return (
+                  <div key={r.docType} className="space-y-0.5">
+                    <div className="text-sm font-medium">{g?.name ?? r.docType}</div>
+                    <div className="text-xs text-muted-foreground">{DOC_DIFFERENTIATORS[r.docType]}</div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
 
         <div className="pt-4 border-t">
           <Button variant="outline" onClick={handleReset} className="w-full">
@@ -418,25 +186,20 @@ function DocumentFinder({ onSelectGuide }: { onSelectGuide: (guideId: string) =>
     );
   }
 
+  if (!question) return null;
+
   return (
     <div className="p-4 space-y-6">
-      {/* Progress bar */}
-      <div className="space-y-2">
-        <div className="flex justify-between text-xs text-muted-foreground">
-          <span>Question {currentQuestion + 1} of {FINDER_QUESTIONS.length}</span>
-          <span>{Math.round(progress)}% complete</span>
-        </div>
-        <div className="h-2 bg-muted rounded-full overflow-hidden">
-          <div
-            className="h-full bg-primary transition-all duration-300"
-            style={{ width: `${progress}%` }}
-          />
-        </div>
+      <div className="text-xs font-medium text-muted-foreground">
+        Question {order.length + 1}
       </div>
 
       {/* Question */}
-      <div className="text-center py-4">
+      <div className="text-center py-2">
         <h3 className="text-lg font-semibold">{question.question}</h3>
+        {question.help && (
+          <p className="text-sm text-muted-foreground mt-1.5">{question.help}</p>
+        )}
       </div>
 
       {/* Options */}
@@ -448,29 +211,28 @@ function DocumentFinder({ onSelectGuide }: { onSelectGuide: (guideId: string) =>
             className="w-full text-left p-4 rounded-lg border hover:border-primary hover:bg-accent/50 transition-all group"
           >
             <div className="flex items-center gap-3">
-              <span className="text-xl">{option.icon}</span>
-              <span className="flex-1 font-medium">{option.label}</span>
-              <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+              <div className="flex-1 min-w-0">
+                <div className="font-medium">{option.label}</div>
+                {option.help && (
+                  <div className="text-xs text-muted-foreground mt-0.5">{option.help}</div>
+                )}
+              </div>
+              <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
             </div>
           </button>
         ))}
       </div>
 
-      {/* Back / Reset */}
-      {currentQuestion > 0 && (
-        <div className="pt-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => {
-              const prevQuestion = FINDER_QUESTIONS[currentQuestion - 1];
-              const newAnswers = { ...answers };
-              delete newAnswers[prevQuestion.id];
-              setAnswers(newAnswers);
-              setCurrentQuestion(currentQuestion - 1);
-            }}
-          >
-            Back to previous question
+      {/* Back / Start over */}
+      {order.length > 0 && (
+        <div className="flex items-center gap-2 pt-2">
+          <Button variant="ghost" size="sm" onClick={handleBack}>
+            <ChevronLeft className="h-4 w-4 mr-1" />
+            Back
+          </Button>
+          <Button variant="ghost" size="sm" onClick={handleReset} className="text-muted-foreground">
+            <RotateCcw className="h-4 w-4 mr-1.5" />
+            Start over
           </Button>
         </div>
       )}
@@ -490,7 +252,7 @@ function GuideCard({ guide, isExpanded, onToggle }: {
         className="w-full text-left p-4 hover:bg-accent/50 transition-colors"
       >
         <div className="flex items-start gap-3">
-          <span className="text-2xl">{guide.icon}</span>
+          <DocIcon id={guide.id} className="h-5 w-5 shrink-0 text-muted-foreground mt-0.5" />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2">
               <span className="font-semibold text-foreground">{guide.name}</span>
@@ -1029,7 +791,10 @@ export function DocumentGuideModal() {
   // Individual selectors — modal only re-renders on its own flag changing.
   const documentGuideOpen = useUIStore((s) => s.documentGuideOpen);
   const setDocumentGuideOpen = useUIStore((s) => s.setDocumentGuideOpen);
-  const [activeTab, setActiveTab] = useState<'finder' | 'browse' | 'examples' | 'features'>('finder');
+  // The active tab lives in the store so the activation checklist can deep-link
+  // straight to Features (it sets the tab, then opens the guide).
+  const activeTab = useUIStore((s) => s.documentGuideTab);
+  const setActiveTab = useUIStore((s) => s.setDocumentGuideTab);
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [expandedGuide, setExpandedGuide] = useState<string | null>(null);
@@ -1103,28 +868,15 @@ export function DocumentGuideModal() {
         <div className="px-4 py-2 border-b bg-muted/30 shrink-0">
           <div className="flex gap-1 p-1 bg-muted rounded-lg">
             <button
-              onClick={() => setActiveTab('finder')}
-              className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                activeTab === 'finder'
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              <Sparkles className="h-4 w-4" />
-              <span className="hidden sm:inline">Find My Doc</span>
-              <span className="sm:hidden">Find</span>
-            </button>
-            <button
               onClick={() => setActiveTab('browse')}
               className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                activeTab === 'browse'
+                activeTab === 'browse' || activeTab === 'finder'
                   ? 'bg-background text-foreground shadow-sm'
                   : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               <Search className="h-4 w-4" />
-              <span className="hidden sm:inline">Browse Types</span>
-              <span className="sm:hidden">Browse</span>
+              <span>Browse</span>
             </button>
             <button
               onClick={() => setActiveTab('examples')}
@@ -1155,6 +907,14 @@ export function DocumentGuideModal() {
 
         {activeTab === 'finder' && (
           <div className="flex-1 min-h-0 overflow-y-auto">
+            <button
+              type="button"
+              onClick={() => setActiveTab('browse')}
+              className="flex items-center gap-1.5 px-4 pt-4 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Back to browse
+            </button>
             <DocumentFinder onSelectGuide={handleSelectFromFinder} />
           </div>
         )}
@@ -1210,7 +970,7 @@ export function DocumentGuideModal() {
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2 flex-wrap">
                           <h4 className="font-medium text-sm">{f.title}</h4>
-                          <span className="text-[11px] text-muted-foreground bg-muted rounded px-1.5 py-0.5">{f.where}</span>
+                          <span className="text-xs text-muted-foreground bg-muted rounded px-1.5 py-0.5">{f.where}</span>
                         </div>
                         <p className="text-sm text-muted-foreground mt-0.5">{f.body}</p>
                       </div>
@@ -1225,7 +985,7 @@ export function DocumentGuideModal() {
                         <ol className="space-y-2">
                           {f.steps.map((step, i) => (
                             <li key={i} className="flex gap-2.5 text-sm text-muted-foreground">
-                              <span className="flex-none w-5 h-5 rounded-full border text-[11px] flex items-center justify-center text-foreground mt-px">
+                              <span className="flex-none w-5 h-5 rounded-full border text-xs flex items-center justify-center text-foreground mt-px">
                                 {i + 1}
                               </span>
                               <span className="leading-snug">{step}</span>
@@ -1278,7 +1038,7 @@ export function DocumentGuideModal() {
                           className="w-full text-left p-6 rounded-lg border-2 hover:border-primary hover:bg-accent/50 transition-all group"
                         >
                           <div className="flex items-center gap-4">
-                            <span className="text-4xl">{group.icon}</span>
+                            {(() => { const GI = GROUP_ICONS[group.id] ?? FileText; return <GI className="h-8 w-8 shrink-0 text-primary" aria-hidden="true" />; })()}
                             <div className="flex-1">
                               <div className="flex items-center gap-2">
                                 <span className="text-xl font-semibold">{group.name}</span>
@@ -1293,6 +1053,17 @@ export function DocumentGuideModal() {
                         </button>
                       );
                     })}
+                  </div>
+                  <div className="text-center pt-2">
+                    <button
+                      type="button"
+                      onClick={() => setActiveTab('finder')}
+                      className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      <Sparkles className="h-4 w-4 text-primary" />
+                      Not sure which to use? Answer a few questions
+                      <ArrowRight className="h-3.5 w-3.5" />
+                    </button>
                   </div>
                 </div>
               </div>
@@ -1343,7 +1114,7 @@ export function DocumentGuideModal() {
                               : 'bg-background border hover:bg-accent'
                           }`}
                         >
-                          <span>{cat.icon}</span>
+                          {(() => { const CI = CATEGORY_ICONS[cat.id] ?? FileText; return <CI className="h-3.5 w-3.5" aria-hidden="true" />; })()}
                           {cat.name}
                           <Badge
                             variant={selectedCategory === cat.id ? 'outline' : 'secondary'}
@@ -1363,9 +1134,7 @@ export function DocumentGuideModal() {
                     {selectedCategory && (
                       <div className="pb-2 mb-2 border-b">
                         <div className="flex items-center gap-2">
-                          <span className="text-xl">
-                            {GUIDE_CATEGORIES.find(c => c.id === selectedCategory)?.icon}
-                          </span>
+                          {(() => { const CI = CATEGORY_ICONS[selectedCategory] ?? FileText; return <CI className="h-5 w-5 shrink-0 text-primary" aria-hidden="true" />; })()}
                           <div>
                             <h3 className="font-semibold">{GUIDE_CATEGORIES.find(c => c.id === selectedCategory)?.name}</h3>
                             <p className="text-sm text-muted-foreground">

--- a/src/components/modals/DownloadProgressModal.tsx
+++ b/src/components/modals/DownloadProgressModal.tsx
@@ -339,7 +339,7 @@ export function DownloadProgressModal({ phase, onClose, onRetry }: DownloadProgr
                     </Button>
                   </div>
                   <pre
-                    className="max-h-48 overflow-auto rounded-md bg-muted border border-border p-2 text-[11px] leading-tight font-mono whitespace-pre-wrap break-all text-foreground/80"
+                    className="max-h-48 overflow-auto rounded-md bg-muted border border-border p-2 text-xs leading-tight font-mono whitespace-pre-wrap break-all text-foreground/80"
                     aria-label="Error log output"
                   >
                     {phase.compileLog}

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -469,7 +469,7 @@ export function ProfileModal() {
 
               <div data-tour="profile-signature" className="border-t pt-4">
                 <h4 className="text-sm font-medium mb-3">Signature Block</h4>
-                <div className="grid grid-cols-3 gap-3">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                   <div className="space-y-2">
                     <Label htmlFor="sigFirst">First Name</Label>
                     <Input

--- a/src/components/modals/documentFinderLogic.ts
+++ b/src/components/modals/documentFinderLogic.ts
@@ -1,0 +1,338 @@
+// Document Finder — questions and recommendation logic.
+//
+// Pure, framework-free: the finder UI (DocumentFinder in DocumentGuideModal)
+// renders these, and tests/unit/documentFinder.test.ts enumerates them. Kept in
+// its own module so the component file can stay a component-only export (and so
+// the decision tree is testable without mounting any React).
+//
+// The finder is a short branching interview, not a fixed list. A first
+// "category" question splits correspondence / Marine Corps form / for-the-record;
+// two follow-ups (joint signature, agreement resources) appear only when they
+// apply. `getNextQuestion` walks FLOW and returns the first askable, unanswered
+// question — null means we have enough to recommend. Every branching question
+// carries an "I'm not sure" option so a clerk who doesn't know the jargon still
+// reaches a sensible result instead of a dead end.
+
+export interface QuestionOption {
+  label: string;
+  value: string;
+  help?: string;
+}
+
+export interface Question {
+  id: string;
+  question: string;
+  help?: string;
+  options: QuestionOption[];
+}
+
+export const QUESTIONS: Record<string, Question> = {
+  category: {
+    id: 'category',
+    question: 'What are you trying to create?',
+    help: "Pick the closest — we'll narrow it down from there.",
+    options: [
+      { label: 'A letter, memo, or other written correspondence', value: 'correspondence', help: 'Anything sent to a command, person, or business.' },
+      { label: 'A Marine Corps personnel / service-record form', value: 'usmc_form', help: 'Page 11 (NAVMC 118(11)) or an administrative-action form. Marine Corps only.' },
+      { label: 'A record of a counseling, event, or decision for the file', value: 'record', help: 'No one receives it — it just goes in the file.' },
+    ],
+  },
+  formType: {
+    id: 'formType',
+    question: 'What does the form need to do?',
+    help: 'Marine Corps service-record items (MCO P1070.12K).',
+    options: [
+      { label: 'Make a service-record entry — counseling, 6105 notice, or commendation', value: 'page11', help: "Goes on the Marine's Page 11 (NAVMC 118(11))." },
+      { label: 'Process an administrative action — separation, NJP, or admin decision', value: 'adminAction', help: 'Uses the Administrative Action form (NAVMC 10274).' },
+      { label: "I'm not sure", value: 'unsure', help: "We'll show both and explain the difference." },
+    ],
+  },
+  recipient: {
+    id: 'recipient',
+    question: 'Who is the primary recipient?',
+    options: [
+      { label: 'Another military command, unit, or service member', value: 'military', help: 'Another command or a member acting in an official capacity.' },
+      { label: 'A civilian person or business', value: 'civilian', help: 'Contractors, vendors, the public, or any non-DoD entity.' },
+      { label: 'Several commands or addressees at once', value: 'multiple', help: 'The same content going to multiple recipients.' },
+      { label: "I'm not sure", value: 'unsure', help: "We'll show the most common formats and the difference." },
+    ],
+  },
+  jointSignature: {
+    id: 'jointSignature',
+    question: 'Will two different commands co-sign this document?',
+    help: 'A joint document is signed by both commands so they speak with one voice. This is rare — most letters have a single signer.',
+    options: [
+      { label: 'No — one command signs', value: 'no', help: 'The normal case.' },
+      { label: 'Yes — two commands both sign it', value: 'yes', help: 'About two signers, not two recipients.' },
+    ],
+  },
+  purpose: {
+    id: 'purpose',
+    question: 'What is the main purpose?',
+    options: [
+      { label: 'Make a request, recommendation, or tasking', value: 'request' },
+      { label: 'Provide information or a status update', value: 'inform' },
+      { label: 'Present options for someone to decide', value: 'decision' },
+      { label: 'Document an event for the record', value: 'document' },
+      { label: 'Establish an agreement between two parties', value: 'agreement' },
+      { label: 'Endorse or forward a letter I received', value: 'response' },
+      { label: "I'm not sure", value: 'unsure' },
+    ],
+  },
+  resources: {
+    id: 'resources',
+    question: 'Does this agreement commit specific resources?',
+    help: 'Money, people, equipment, or measurable deliverables — vs. just defining roles.',
+    options: [
+      { label: 'Yes — it commits funding, personnel, or deliverables', value: 'yes', help: 'e.g., "we will fund $50k" or "we will provide 3 instructors."' },
+      { label: 'No — it defines roles or a framework for cooperation', value: 'no', help: 'e.g., "we agree to coordinate scheduling" — no money or people committed.' },
+      { label: "I'm not sure yet", value: 'unsure', help: "We'll show both and explain when each applies." },
+    ],
+  },
+  routing: {
+    id: 'routing',
+    question: 'How will this be routed?',
+    options: [
+      { label: 'Direct to the recipient', value: 'direct', help: 'Straight to the addressee.' },
+      { label: 'Through the chain of command (Via line)', value: 'via', help: 'Passes through one or more commands first.' },
+      { label: 'Internal, within my own command', value: 'internal', help: 'Stays inside your command or office.' },
+    ],
+  },
+  formality: {
+    id: 'formality',
+    question: 'What level of formality is needed?',
+    options: [
+      { label: 'Formal, on official letterhead', value: 'formal' },
+      { label: 'Routine / working level', value: 'informal' },
+      { label: 'Flag / General-officer level', value: 'executive', help: 'Signed by or addressed to an admiral or general.' },
+    ],
+  },
+};
+
+// Canonical question order + the condition under which each is asked. Skips are
+// declarative here so the flow stays readable; getNextQuestion does the walk.
+export const FLOW: { id: string; ask: (a: Record<string, string>) => boolean }[] = [
+  { id: 'category', ask: () => true },
+  { id: 'formType', ask: (a) => a.category === 'usmc_form' },
+  { id: 'recipient', ask: (a) => a.category === 'correspondence' },
+  { id: 'jointSignature', ask: (a) => a.category === 'correspondence' && a.recipient === 'military' },
+  { id: 'purpose', ask: (a) => a.category === 'correspondence' },
+  { id: 'resources', ask: (a) => a.category === 'correspondence' && a.purpose === 'agreement' },
+  { id: 'routing', ask: (a) => a.category === 'correspondence' && a.purpose !== 'agreement' },
+  { id: 'formality', ask: (a) => a.category === 'correspondence' && a.purpose !== 'agreement' },
+];
+
+/** First askable, unanswered question for the current answers; null ⇒ show results. */
+export function getNextQuestion(answers: Record<string, string>): Question | null {
+  for (const step of FLOW) {
+    if (step.ask(answers) && answers[step.id] === undefined) {
+      return QUESTIONS[step.id];
+    }
+  }
+  return null;
+}
+
+export interface FinderResult {
+  docType: string;
+  confidence: 'high' | 'medium';
+  reason: string;
+}
+
+// Maps a finder interview to recommended document types. Ordered, early-return
+// rules — the FIRST matching rule wins, so rule order is load-bearing (e.g. R5
+// joint sits above R6-R12; R10's MF precedence above the default letters). The
+// design covers all 19 types; see the enumeration test in
+// tests/unit/documentFinder.test.ts which guards that none go unreachable.
+export function getRecommendations(answers: Record<string, string>): FinderResult[] {
+  const { category, formType, recipient, jointSignature, purpose, routing, formality } = answers;
+  const joint = jointSignature === 'yes';           // safe default: undefined → false
+  const res = answers.resources ?? 'unsure';         // MOA/MOU axis, defaults to unsure
+  const results: FinderResult[] = [];
+  const add = (docType: string, confidence: 'high' | 'medium', reason: string) =>
+    results.push({ docType, confidence, reason });
+  // At most three cards; rule order is high-first, so the cap never drops the
+  // best match. Only results[0] is badged "Best Match" in the render.
+  const top3 = () => results.slice(0, 3);
+
+  // R0 — Marine Corps forms (NAVMC). The only path that reaches the Forms group.
+  if (category === 'usmc_form') {
+    if (formType === 'page11') {
+      add('navmc_118_11', 'high', 'Per MCO P1070.12K: Page 11 (NAVMC 118(11)) service-record entry for counseling, 6105 notices, and commendations');
+    } else if (formType === 'adminAction') {
+      add('navmc_10274', 'high', 'Per MCO P1070.12K: Administrative Action form (NAVMC 10274) for separations, NJP, and command admin decisions');
+    } else {
+      add('navmc_118_11', 'high', 'Per MCO P1070.12K: use a Page 11 (NAVMC 118(11)) to record counseling or an event in the service record');
+      add('navmc_10274', 'medium', 'Per MCO P1070.12K: use the Administrative Action form (NAVMC 10274) for a separation, NJP, or formal admin decision');
+    }
+    return top3();
+  }
+
+  // R1 — For the record (Q0 fast path). No recipient context, so do NOT nudge a
+  // USMC-only Page 11 here; that lives behind the explicit form path (R0).
+  if (category === 'record') {
+    add('mfr', 'high', 'Per Ch 10: Memorandum for the Record documents meetings, decisions, or events for the official record');
+    return top3();
+  }
+
+  // R2 — Endorsements. Single-command forwards; joint is intentionally ignored
+  // (a joint letter is not an endorsement).
+  if (purpose === 'response') {
+    if (formality === 'informal' || routing === 'internal') {
+      add('same_page_endorsement', 'high', 'Per Ch 7: Brief endorsement added below the basic letter when space permits');
+      add('new_page_endorsement', 'medium', 'Use a new-page endorsement if it is lengthy or the basic letter page is full');
+    } else {
+      add('new_page_endorsement', 'high', 'Per Ch 7: New-page endorsement on its own letterhead for formal or detailed responses');
+      add('same_page_endorsement', 'medium', 'Alternative if the endorsement is brief and fits on the original letter');
+    }
+    return top3();
+  }
+
+  // R3 — Civilian recipient.
+  if (recipient === 'civilian') {
+    add('business_letter', 'high', 'Per Ch 11: Business-letter format for civilians, contractors, and non-DoD entities');
+    return top3();
+  }
+
+  // R4 — Agreements. Resources-driven (MOA = commitments, MOU = framework).
+  // Joint co-signature surfaces joint variants without overriding MOA/MOU.
+  if (purpose === 'agreement') {
+    if (res === 'yes') {
+      add('moa', 'high', 'Per Ch 12: MOA when the agreement commits specific funding, personnel, or measurable deliverables');
+      add('mou', 'medium', 'Use an MOU instead if it only frames roles and cooperation without committing resources');
+    } else if (res === 'no') {
+      add('mou', 'high', 'Per Ch 12: MOU to define roles, responsibilities, and a framework for cooperation without committing resources');
+      add('moa', 'medium', 'Upgrade to an MOA if you later commit specific funding, personnel, or deliverables');
+    } else {
+      add('mou', 'high', 'Per Ch 12: Start with an MOU for the working framework — it is the lower-commitment option');
+      add('moa', 'medium', 'Choose an MOA if the agreement will commit specific resources or funding');
+    }
+    if (joint) {
+      add('joint_letter', 'medium', 'Per Ch 2: Joint letter when two commands co-sign the agreement to speak with one voice');
+      add('joint_memorandum', 'medium', 'Per Ch 12: Joint memorandum when two staffs present a single coordinated position internally');
+    }
+    return top3();
+  }
+
+  // R5 — Joint correspondence, non-agreement. Sits ABOVE R6-R12: a co-signed
+  // document's format is driven by whether it leaves the command (joint letter)
+  // or stays an internal coordinated staff product (joint memo). Q-JOINT is only
+  // asked when recipient==='military', so joint implies military here.
+  if (joint && recipient === 'military') {
+    if (routing === 'via' || routing === 'direct') {
+      add('joint_letter', 'high', 'Per Ch 2: Joint letter when two commands co-sign correspondence that leaves the command to speak with one voice');
+      add('joint_memorandum', 'medium', 'Use a joint memorandum if this stays an internal coordinated staff position rather than outgoing correspondence');
+    } else {
+      add('joint_memorandum', 'high', 'Per Ch 12: Joint memorandum when two staffs co-sign an internal coordinated position');
+      add('joint_letter', 'medium', 'Use a joint letter if it instead leaves the command as official outgoing correspondence');
+    }
+    return top3();
+  }
+
+  // R6 — Decision memos.
+  if (purpose === 'decision') {
+    add('decision_memorandum', 'high', 'Per Ch 12: Decision memo presents options with pros/cons and a staff recommendation');
+    if (formality === 'executive') {
+      add('executive_memorandum', 'medium', 'Alternative at flag/general-officer level using an executive-summary format');
+    } else {
+      add('naval_letter', 'medium', 'Use a naval letter if the decision must be formally requested up the chain of command');
+    }
+    return top3();
+  }
+
+  // R7 — Multiple addressees (single-signer).
+  if (recipient === 'multiple') {
+    add('multiple_address_letter', 'high', 'Per Ch 2: Multiple-address letter for identical content sent to several commands at once');
+    add('naval_letter', 'medium', 'Alternative: a naval letter with the recipients in a distribution / Copy To list');
+    return top3();
+  }
+
+  // R8 — Executive / flag level. Both executive types co-appear.
+  if (formality === 'executive') {
+    if (routing === 'internal' || purpose === 'inform') {
+      add('executive_memorandum', 'high', 'Per Ch 12: Executive memo for staff-to-senior briefings and status to senior leadership');
+      add('executive_correspondence', 'medium', 'Use executive correspondence if this goes peer-to-peer between flag/general officers');
+    } else {
+      add('executive_correspondence', 'high', 'Per Ch 12: Executive correspondence for flag-to-flag, peer senior-official communication');
+      add('executive_memorandum', 'medium', 'Use an executive memo if this is a staff-to-senior briefing within the chain');
+    }
+    add('naval_letter', 'medium', 'A naval letter is also appropriate for formal executive matters needing an official record');
+    return top3();
+  }
+
+  // R9 — Documenting an event.
+  if (purpose === 'document') {
+    add('mfr', 'high', 'Per Ch 10: MFR documents meetings, verbal orders, decisions, or events for the official record');
+    if (routing === 'internal') {
+      add('letterhead_memorandum', 'medium', 'Alternative: a letterhead memo if the record must be shared formally within the command');
+    } else if (routing === 'via') {
+      add('naval_letter', 'medium', 'Use a naval letter if the documented matter must be forwarded up the chain of command');
+    }
+    return top3();
+  }
+
+  // R10 — Internal / routine. MF precedence: a formal "Memorandum For" addressed
+  // to a person/office leads for staff actions and information; letterhead memo
+  // leads when it may be forwarded externally.
+  if (routing === 'internal') {
+    if (formality === 'informal') {
+      add('plain_paper_memorandum', 'high', 'Per Ch 12: Plain-paper memo for routine internal working-level communication');
+      add('standard_letter', 'medium', 'Alternative: a plain-paper standard letter for an internal draft or review copy');
+    } else if (purpose === 'inform' || purpose === 'request') {
+      add('mf', 'high', 'Per Ch 10: "Memorandum For" addressed to a specific person/office for internal staff action');
+      add('letterhead_memorandum', 'medium', 'Use a letterhead memo if it may be forwarded externally or needs an SSIC');
+    } else {
+      add('letterhead_memorandum', 'high', 'Per Ch 12: Letterhead memo for formal internal communications that may be forwarded');
+      add('mf', 'medium', 'Alternative: "Memorandum For" format addressed to a specific person/office');
+    }
+    return top3();
+  }
+
+  // R11 — Chain-of-command routing (via).
+  if (routing === 'via') {
+    add('naval_letter', 'high', 'Per Ch 2: Naval letter with a Via line for correspondence routed through the chain of command');
+    if (formality === 'informal') {
+      add('standard_letter', 'medium', 'Alternative: a standard letter (same format, no letterhead) for a draft or when letterhead is unavailable');
+    }
+    return top3();
+  }
+
+  // R12 — Default (direct routing).
+  if (formality === 'formal') {
+    add('naval_letter', 'high', 'Per Ch 2: Naval letter is the standard format for official Department of the Navy correspondence');
+  } else {
+    add('naval_letter', 'high', 'Per Ch 2: Naval letter is appropriate for most official military correspondence');
+    add('standard_letter', 'medium', 'Alternative: a standard letter (same format) when letterhead is not required or available');
+  }
+  return top3();
+}
+
+/** A short, context-independent contrast for each type, for the "How to choose"
+ *  strip when a rule returns two candidates differing on one axis. */
+export const DOC_DIFFERENTIATORS: Record<string, string> = {
+  moa: 'Commits specific resources or funding',
+  mou: 'Frames roles & cooperation, no resources',
+  same_page_endorsement: 'Brief — fits on the basic letter',
+  new_page_endorsement: 'Longer — its own letterhead page',
+  joint_letter: 'Leaves the command as outgoing correspondence',
+  joint_memorandum: 'Stays an internal coordinated staff position',
+  executive_memorandum: 'Staff → senior leadership',
+  executive_correspondence: 'Flag-to-flag, peer level',
+  multiple_address_letter: 'Built for several addressees at once',
+  naval_letter: 'Standard single-recipient official letter',
+  plain_paper_memorandum: 'Routine internal, working level',
+  standard_letter: 'Same format, no letterhead',
+  mf: 'Addressed to a specific person/office',
+  letterhead_memorandum: 'Formal, may be forwarded / needs SSIC',
+  decision_memorandum: 'Presents options for a decision',
+  mfr: 'Records an event for the file',
+  navmc_118_11: 'Service-record (Page 11) entry',
+  navmc_10274: 'Administrative-action processing',
+  business_letter: 'For civilian / non-DoD recipients',
+};
+
+/** Split a reason into its citation chip ("Ch 10", "MCO P1070.12K") and the
+ *  plain-language "why". Reasons that don't start with "Per …:" render whole. */
+export function splitReason(reason: string): { cite: string | null; why: string } {
+  const m = reason.match(/^Per ([^:]+):\s*(.*)$/);
+  return m ? { cite: m[1], why: m[2] } : { cite: null, why: reason };
+}

--- a/src/components/onboarding/ActivationChecklist.tsx
+++ b/src/components/onboarding/ActivationChecklist.tsx
@@ -1,0 +1,335 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  ChevronDown,
+  X,
+  ArrowRight,
+  PartyPopper,
+  GraduationCap,
+  UserPlus,
+  FileText,
+  Compass,
+  CheckCircle2,
+  type LucideIcon,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ProgressRing } from './ProgressRing';
+import { useOnboardingStore } from '@/stores/onboardingStore';
+import { useProfileStore } from '@/stores/profileStore';
+import { useTourStore, GUIDED_TOUR_KEY } from '@/stores/tourStore';
+import { useUIStore } from '@/stores/uiStore';
+
+// The 7 power-feature keys the guide tracks; "all learned" is one checklist step.
+const POWER_KEYS = ['batch', 'profiles', 'templates', 'enclosures', 'signature', 'share', 'classification'] as const;
+// Profiles the app ships with — a user "created a profile" once they have one
+// whose name isn't a default.
+const DEFAULT_PROFILE_NAMES = ['23d Marine Regiment', 'Marine Innovation Unit'];
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
+interface ChecklistRow {
+  glyph: LucideIcon;
+  title: string;
+  sub: string;
+  done: boolean;
+  /** Shown in place of the arrow while incomplete (e.g. the features tally). */
+  badge?: string;
+  action: () => void;
+}
+
+/**
+ * Floating "getting started" activation checklist — the persistent, at-a-glance
+ * hub that nudges a new user through the four things that make DonDocs click,
+ * and checks each off automatically as it's done. A collapsed pill (a progress
+ * ring + "Get set up") expands into the card; finishing all four fires a one-off
+ * celebration and retires the launcher for good. Dismissible (✕) and re-openable
+ * from Help → Getting started. Hidden while the product tour is running so the
+ * two onboarding surfaces never fight.
+ *
+ * Completion is derived live from the real stores, never stored on the widget:
+ * the tour flag, a non-default profile, the `first_document` export milestone,
+ * and the 7 feature walkthroughs. Only the launcher's own lifecycle
+ * (dismissed / celebrated) is persisted, in the onboarding store.
+ */
+export function ActivationChecklist() {
+  const completed = useOnboardingStore((s) => s.completed);
+  const profiles = useProfileStore((s) => s.profiles);
+  const dismissed = useOnboardingStore((s) => s.checklistDismissed);
+  const celebrated = useOnboardingStore((s) => s.checklistCelebrated);
+  const setDismissed = useOnboardingStore((s) => s.setChecklistDismissed);
+  const setCelebrated = useOnboardingStore((s) => s.setChecklistCelebrated);
+  // Hide the launcher while a tour is running so they don't compete.
+  const tourActive = useTourStore((s) => s.active);
+
+  // Credit the tour only when the user actually finished it (reaching the last
+  // step marks GUIDED_TOUR_KEY) — skipping or ×-ing out does not count. Reading
+  // the onboarding map also keeps this reactive.
+  const tourDone = !!completed[GUIDED_TOUR_KEY];
+  const profileDone = Object.keys(profiles).some((n) => !DEFAULT_PROFILE_NAMES.includes(n));
+  const docDone = !!completed['first_document'];
+  const learnedCount = POWER_KEYS.filter((k) => completed[k]).length;
+  const featuresDone = learnedCount === POWER_KEYS.length;
+
+  const rows: ChecklistRow[] = [
+    {
+      glyph: GraduationCap,
+      title: 'Take the guided tour',
+      sub: 'A 60-second look around the editor',
+      done: tourDone,
+      action: () => useTourStore.getState().start(),
+    },
+    {
+      glyph: UserPlus,
+      title: 'Create your command profile',
+      sub: 'Save your letterhead and signature once, reuse everywhere',
+      done: profileDone,
+      action: () => useUIStore.getState().setProfileModalOpen(true),
+    },
+    {
+      glyph: FileText,
+      title: 'Build your first document',
+      sub: 'Pick a template and export a PDF',
+      done: docDone,
+      action: () => useUIStore.getState().setTemplateLoaderOpen(true),
+    },
+    {
+      glyph: Compass,
+      title: 'Explore the power features',
+      sub: 'Batch, sharing, classification, and more',
+      done: featuresDone,
+      badge: featuresDone ? undefined : `${learnedCount}/${POWER_KEYS.length}`,
+      action: () => {
+        useUIStore.getState().setDocumentGuideTab('features');
+        useUIStore.getState().setDocumentGuideOpen(true);
+      },
+    },
+  ];
+
+  const done = rows.filter((r) => r.done).length;
+  const total = rows.length;
+
+  const [open, setOpen] = useState(false);
+  const pillRef = useRef<HTMLButtonElement>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const wasOpen = useRef(false);
+
+  // The celebration is derived, not stored: it shows while every step is done
+  // but the terminal `checklistCelebrated` flag hasn't been set yet. An effect
+  // retires it after a beat; "Start drafting" retires it at once. (setCelebrated
+  // is a store action, so this is not a React setState-in-effect.)
+  const showCelebration = done === total && !celebrated;
+  useEffect(() => {
+    if (!showCelebration) return;
+    const t = window.setTimeout(() => setCelebrated(true), 4500);
+    return () => window.clearTimeout(t);
+  }, [showCelebration, setCelebrated]);
+
+  // On open, move focus into the card — the first actionable row, or the card
+  // itself when every row is done (a disabled button can't take focus, which
+  // would otherwise strand focus on document.body). Escape collapses, handled at
+  // the window in capture phase so it works wherever focus landed (mirrors the
+  // tour overlay).
+  useEffect(() => {
+    if (open) {
+      const card = cardRef.current;
+      const firstEnabled = card?.querySelector<HTMLButtonElement>('ul button:not([disabled])');
+      (firstEnabled ?? card)?.focus();
+      wasOpen.current = true;
+      const onKey = (e: KeyboardEvent) => {
+        if (e.key !== 'Escape') return;
+        e.stopPropagation();
+        setOpen(false);
+      };
+      window.addEventListener('keydown', onKey, true);
+      return () => window.removeEventListener('keydown', onKey, true);
+    }
+    // Collapsed: hand focus back to the launcher pill — but only when returning
+    // from the open card, never on the initial mount (which would steal focus).
+    if (wasOpen.current) {
+      wasOpen.current = false;
+      pillRef.current?.focus();
+    }
+  }, [open]);
+
+  // The first-run tour owns the screen; never compete with it.
+  if (tourActive) return null;
+  // A finished celebration retires the launcher for good.
+  if (celebrated) return null;
+  // Hidden until re-opened from Help. A dismissed user who then finishes
+  // everything is retired quietly (the `celebrated` guard above), with no
+  // surprise celebration popping from the corner.
+  if (dismissed && !celebrated) return null;
+
+  const reduce = prefersReducedMotion();
+  // Focus returns to the pill via the open effect (after it re-mounts), so these
+  // just flip state.
+  const collapse = () => setOpen(false);
+  const hide = () => {
+    setOpen(false);
+    setDismissed(true);
+  };
+
+  // z-40 keeps the launcher above page content but BELOW Radix modals (z-50),
+  // so a modal a row opens covers the pill instead of it floating over the dim.
+  // The tour (z-110+) still layers above, and we return null while it runs.
+  const anchor = 'fixed bottom-5 right-5 sm:bottom-6 sm:right-6 z-40 origin-bottom-right';
+  const cardChrome =
+    'w-[340px] max-w-[calc(100vw-2.5rem)] rounded-xl border border-border bg-popover text-popover-foreground shadow-elevated overflow-hidden';
+  const cardMotion = reduce ? '' : 'animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-2 duration-200 ease-out';
+
+  // ── Celebration ──────────────────────────────────────────────────────────
+  if (showCelebration) {
+    return (
+      <div className={anchor}>
+        <div className={`${cardChrome} ${cardMotion}`} role="dialog" aria-label="Onboarding complete">
+          <div className="p-6 text-center">
+            <div
+              className={`mx-auto mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-green-500/10 text-green-600 dark:text-green-400 ${
+                reduce ? '' : 'animate-in zoom-in-50 duration-300'
+              }`}
+            >
+              <PartyPopper className="h-6 w-6" />
+            </div>
+            <h3 className="text-base font-semibold">You&apos;re all set</h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              You&apos;ve found everything you need. Time to draft.
+            </p>
+            <p className="sr-only" role="status" aria-live="polite">
+              All steps complete. DonDocs is ready.
+            </p>
+            <Button size="sm" className="mt-4" onClick={() => setCelebrated(true)}>
+              Start drafting
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Collapsed pill ───────────────────────────────────────────────────────
+  if (!open) {
+    return (
+      <div className={anchor}>
+        <button
+          ref={pillRef}
+          type="button"
+          onClick={() => setOpen(true)}
+          aria-label={`Get set up — ${done} of ${total} steps complete`}
+          aria-expanded={false}
+          aria-haspopup="dialog"
+          className="inline-flex h-11 items-center gap-2.5 rounded-full border border-border bg-popover pl-1.5 pr-3.5 text-popover-foreground shadow-elevated outline-none transition-[transform,border-color] duration-150 hover:-translate-y-px hover:border-primary/40 active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transition-none max-sm:w-11 max-sm:justify-center max-sm:px-0"
+        >
+          <ProgressRing size={28} done={done} total={total} />
+          <span className="hidden text-[13px] font-medium leading-none sm:inline">Get set up</span>
+        </button>
+      </div>
+    );
+  }
+
+  // ── Expanded card ────────────────────────────────────────────────────────
+  return (
+    <div className={anchor}>
+      <div
+        ref={cardRef}
+        tabIndex={-1}
+        className={`${cardChrome} ${cardMotion} outline-none`}
+        role="dialog"
+        aria-label="Getting started checklist"
+      >
+        {/* Header */}
+        <div className="flex items-center gap-2 px-4 pt-3.5 pb-2">
+          <ProgressRing size={26} done={done} total={total} />
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-semibold leading-tight">Getting started</div>
+            <div className="text-xs text-muted-foreground">
+              {done === total ? 'All set — nice work' : `${done} of ${total} done`}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={collapse}
+            aria-label="Collapse checklist"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <ChevronDown className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={hide}
+            aria-label="Hide getting-started checklist"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Macro progress rail */}
+        <div className="mx-4 mb-1 h-1 overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-[width] duration-500 ease-out motion-reduce:transition-none"
+            style={{ width: `${(done / total) * 100}%` }}
+          />
+        </div>
+        <p className="sr-only" role="status" aria-live="polite">{`${done} of ${total} steps complete`}</p>
+
+        {/* Items */}
+        <ul className="p-1.5">
+          {rows.map((row) => {
+            const Glyph = row.glyph;
+            return (
+              <li key={row.title}>
+                <button
+                  type="button"
+                  disabled={row.done}
+                  onClick={() => {
+                    row.action();
+                    setOpen(false);
+                  }}
+                  aria-label={
+                    row.done
+                      ? `${row.title} — completed`
+                      : row.badge
+                        ? `${row.title} — ${row.badge.replace('/', ' of ')} learned`
+                        : `${row.title} — not started`
+                  }
+                  className={`group flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left transition-colors ${
+                    row.done ? 'cursor-default' : 'hover:bg-muted/60'
+                  }`}
+                >
+                  {row.done ? (
+                    <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
+                  ) : (
+                    <Glyph className="h-5 w-5 shrink-0 text-muted-foreground" />
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <div
+                      className={`text-sm font-medium leading-snug ${
+                        row.done ? 'text-muted-foreground line-through' : 'text-foreground'
+                      }`}
+                    >
+                      {row.title}
+                    </div>
+                    {!row.done && <div className="text-xs text-muted-foreground">{row.sub}</div>}
+                  </div>
+                  {!row.done &&
+                    (row.badge ? (
+                      <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
+                        {row.badge}
+                      </span>
+                    ) : (
+                      <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+                    ))}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+
+        {/* Footer */}
+        <div className="border-t border-border px-4 py-2.5">
+          <p className="text-[11px] text-muted-foreground">Reopen anytime from the Help menu.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/ProgressRing.tsx
+++ b/src/components/onboarding/ProgressRing.tsx
@@ -1,0 +1,45 @@
+import { Check } from 'lucide-react';
+
+/**
+ * A small circular progress ring with the count in the middle. The arc fills
+ * clockwise from twelve o'clock (the `-rotate-90` flips the SVG's 3-o'clock
+ * start); at full it swaps the count for a green check. `pathLength={total}`
+ * lets the dash math read in whole steps regardless of the real circumference.
+ */
+export function ProgressRing({ size, done, total }: { size: number; done: number; total: number }) {
+  const complete = done >= total;
+  return (
+    <span
+      className="relative inline-flex items-center justify-center"
+      style={{ width: size, height: size }}
+    >
+      <svg viewBox="0 0 36 36" width={size} height={size} className="-rotate-90" aria-hidden="true">
+        <circle
+          cx="18"
+          cy="18"
+          r="15.5"
+          fill="none"
+          strokeWidth="3"
+          stroke="currentColor"
+          className="text-muted-foreground/25"
+        />
+        <circle
+          cx="18"
+          cy="18"
+          r="15.5"
+          fill="none"
+          strokeWidth="3"
+          strokeLinecap="round"
+          stroke="currentColor"
+          pathLength={total}
+          strokeDasharray={total}
+          strokeDashoffset={total - done}
+          className="text-primary transition-[stroke-dashoffset] duration-500 ease-out motion-reduce:transition-none"
+        />
+      </svg>
+      <span className="absolute inline-flex items-center justify-center text-[11px] font-semibold tabular-nums leading-none text-foreground">
+        {complete ? <Check className="h-3 w-3 text-green-600 dark:text-green-400" /> : `${done}/${total}`}
+      </span>
+    </span>
+  );
+}

--- a/src/components/tour/TourOverlay.tsx
+++ b/src/components/tour/TourOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { X, ArrowRight } from 'lucide-react';
 import { useTourStore } from '@/stores/tourStore';
@@ -12,9 +12,67 @@ interface Rect {
 }
 
 const CARD_W = 304;
-const CARD_H_EST = 188; // generous estimate for placement math only
+const CARD_H_EST = 210; // initial estimate before the card is measured
 const GAP = 12; // space between target and card
 const PAD = 6; // spotlight padding around the target
+
+const clamp = (v: number, lo: number, hi: number) => Math.min(Math.max(v, lo), Math.max(lo, hi));
+
+/**
+ * Choose a coachmark position that never covers the spotlight. Tries below,
+ * above, right, then left of the padded spotlight rect — each candidate sits
+ * fully outside it, so the highlighted control stays visible — and picks the
+ * first that fits on screen. The card size is capped to the viewport first, so
+ * the math never assumes a card larger than the screen.
+ *
+ * A side fits whenever the target is small enough on that axis to leave a
+ * card-plus-gap band; combined with the adaptive scroll in `measure` (which
+ * parks the target near an edge on short viewports), at least one side fits for
+ * any normal control on any display. The fallback runs only when the highlighted
+ * element is itself larger than the screen minus the card — then the card is
+ * pinned to the roomiest edge so it covers as little of the spotlight as
+ * possible (nothing can show both fully in that case).
+ */
+interface Placement {
+  top: number;
+  left: number;
+  /** When set, cap the card to this height (it scrolls) so it fits a tight gap. */
+  maxH?: number;
+}
+
+function placeCoachmark(rect: Rect, vw: number, vh: number, cardW: number, cardH: number): Placement {
+  const cw = Math.min(cardW, vw - 2 * GAP);
+  const ch = Math.min(cardH, vh - 2 * GAP);
+  const sTop = rect.top - PAD;
+  const sBottom = rect.top + rect.height + PAD;
+  const sLeft = rect.left - PAD;
+  const sRight = rect.left + rect.width + PAD;
+  // Centered on the target for the vertical placements / on it for the side ones.
+  const cx = clamp(rect.left + rect.width / 2 - cw / 2, GAP, vw - cw - GAP);
+  const cy = clamp(rect.top + rect.height / 2 - ch / 2, GAP, vh - ch - GAP);
+
+  // Try each side at the card's full size — each candidate is fully outside the
+  // padded spotlight, so the highlight stays visible.
+  if (sBottom + GAP + ch <= vh - GAP) return { top: sBottom + GAP, left: cx }; // below
+  if (sTop - GAP - ch >= GAP) return { top: sTop - GAP - ch, left: cx }; // above
+  if (sRight + GAP + cw <= vw - GAP) return { top: cy, left: sRight + GAP }; // right
+  if (sLeft - GAP - cw >= GAP) return { top: cy, left: sLeft - GAP - cw }; // left
+
+  // The card is taller than any side's gap. Drop it into the larger vertical
+  // band and cap its height there — it scrolls internally — so it still never
+  // covers the spotlight. Width is never capped, which keeps placement stable
+  // (the card's measured natural height doesn't change under it).
+  const gapBelow = vh - sBottom - 2 * GAP;
+  const gapAbove = sTop - 2 * GAP;
+  if (Math.max(gapBelow, gapAbove) >= 100) {
+    return gapBelow >= gapAbove
+      ? { top: sBottom + GAP, left: cx, maxH: gapBelow }
+      : { top: GAP, left: cx, maxH: gapAbove };
+  }
+  // The highlight nearly fills the viewport (it's larger than the screen minus a
+  // usable card) — overlap is unavoidable; pin the card to the bottom.
+  return { top: clamp(vh - ch - GAP, GAP, vh - GAP), left: cx };
+}
 
 const prefersReducedMotion = () =>
   typeof window !== 'undefined' &&
@@ -39,7 +97,9 @@ export function TourOverlay() {
   const end = useTourStore((s) => s.end);
 
   const [rect, setRect] = useState<Rect | null>(null);
+  const [cardSize, setCardSize] = useState({ w: CARD_W, h: CARD_H_EST });
   const cardRef = useRef<HTMLDivElement>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
 
   const step = steps[stepIndex];
   const isLast = stepIndex === steps.length - 1;
@@ -79,13 +139,23 @@ export function TourOverlay() {
         setRect((prev) => (prev === null ? prev : null)); // hidden / collapsed
         return;
       }
+      // Reserve room for the card by where we park the target: center it when
+      // the viewport is tall enough to also fit the card on one side (looks
+      // best), otherwise pull the target to the top so a full card height stays
+      // free below it. 'start' is always at least as good as 'center' for fitting
+      // the card, so prefer it on any viewport too short to center — this is the
+      // lever that keeps the card off the spotlight on small / landscape displays.
+      const vh = window.innerHeight;
+      const block: ScrollLogicalPosition =
+        vh >= r.height + 2 * CARD_H_EST + 3 * GAP ? 'center' : 'start';
       if (scrolled !== el) {
         scrolled = el;
-        el.scrollIntoView({ block: 'center', inline: 'nearest', behavior: reduce ? 'auto' : 'smooth' });
-      } else if (r.top < 8 || r.bottom > window.innerHeight - 8) {
-        // The target drifted out of view — e.g. a section finished expanding
-        // and pushed it down. Re-center instantly so the spotlight follows.
-        el.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'auto' });
+        el.scrollIntoView({ block, inline: 'nearest', behavior: reduce ? 'auto' : 'smooth' });
+      } else if (r.top < -1 || r.bottom > vh + 1) {
+        // The target was clipped — e.g. a section finished expanding and pushed
+        // it off-screen. Re-anchor instantly so the spotlight follows. (Only on
+        // real clipping, so an intentional top-parked target isn't re-scrolled.)
+        el.scrollIntoView({ block, inline: 'nearest', behavior: 'auto' });
       }
       setRect((prev) =>
         prev &&
@@ -133,23 +203,44 @@ export function TourOverlay() {
     return () => window.removeEventListener('keydown', onKey, true);
   }, [active, stepIndex, end]);
 
+  // Measure the card's real size so placement reserves the right amount of room
+  // (the body length varies per step). Re-runs when the step content changes or
+  // the target moves/resizes; the value guard makes redundant runs a no-op.
+  useLayoutEffect(() => {
+    const el = cardRef.current;
+    if (!el) return;
+    const w = el.offsetWidth;
+    // The card's NATURAL height, independent of any maxHeight cap we apply for
+    // placement — so the measurement can't feed back into the cap and oscillate.
+    // The body is the only flexible part, so swap its visible height for its
+    // full content height: cardHeight - bodyVisible + bodyContent.
+    const body = bodyRef.current;
+    const h = body
+      ? el.offsetHeight - body.clientHeight + body.scrollHeight
+      : el.scrollHeight;
+    setCardSize((p) => (p.w === w && p.h === h ? p : { w, h }));
+  }, [active, stepIndex, rect]);
+
   if (!active || !step) return null;
 
-  // Position the coachmark: below the target if it fits, otherwise above;
-  // clamped to the viewport. Centered when there is no target.
+  // Position the coachmark beside the target — below / above / right / left,
+  // whichever fits — so it never covers the spotlight. On a viewport too small
+  // for the card beside the target, placeCoachmark caps it to the largest gap
+  // (maxH) and it scrolls; overflow-auto keeps the Back/Next buttons reachable.
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
   let cardStyle: React.CSSProperties;
   if (rect) {
-    const below = rect.top + rect.height + PAD + GAP;
-    const fitsBelow = below + CARD_H_EST < window.innerHeight;
-    const top = fitsBelow ? below : Math.max(GAP, rect.top - PAD - GAP - CARD_H_EST);
-    const left = Math.min(
-      Math.max(GAP, rect.left + rect.width / 2 - CARD_W / 2),
-      window.innerWidth - CARD_W - GAP
-    );
-    cardStyle = { top, left, width: CARD_W };
+    const p = placeCoachmark(rect, vw, vh, cardSize.w, cardSize.h);
+    cardStyle = { top: p.top, left: p.left, maxHeight: p.maxH ?? 'calc(100dvh - 1.5rem)' };
   } else {
-    cardStyle = { top: '50%', left: '50%', transform: 'translate(-50%, -50%)', width: CARD_W };
+    cardStyle = { top: '50%', left: '50%', transform: 'translate(-50%, -50%)', maxHeight: 'calc(100dvh - 1.5rem)' };
   }
+  cardStyle = {
+    ...cardStyle,
+    width: CARD_W,
+    maxWidth: 'calc(100vw - 1.5rem)',
+  };
 
   // Locked coach overlay: the tour is modal, so only its own controls (the
   // corner ×, Back, Next, or Esc) advance or exit it. Incidental clicks and
@@ -191,7 +282,7 @@ export function TourOverlay() {
         ref={cardRef}
         tabIndex={-1}
         onPointerDown={(e) => e.stopPropagation()}
-        className="fixed z-[112] pointer-events-auto rounded-xl border bg-popover text-popover-foreground p-4 shadow-elevated outline-none"
+        className="fixed z-[112] pointer-events-auto flex flex-col rounded-xl border bg-popover text-popover-foreground p-4 shadow-elevated outline-none overflow-hidden"
         style={cardStyle}
       >
         {/* Exit, tucked into the corner so it stays out of the controls. */}
@@ -203,9 +294,14 @@ export function TourOverlay() {
         >
           <X className="h-4 w-4" />
         </button>
-        <h3 className="text-sm font-semibold mb-1 pr-6">{step.title}</h3>
-        <p className="text-[13px] text-muted-foreground leading-relaxed mb-3">{step.body}</p>
-        <div className="flex items-center justify-between gap-3">
+        <h3 className="shrink-0 text-sm font-semibold mb-1 pr-6">{step.title}</h3>
+        {/* Only the body scrolls when the card is capped to a tight gap on a
+            short screen; the title above and the controls below stay pinned, so
+            Back/Next are always inside the box. */}
+        <div ref={bodyRef} className="min-h-0 flex-1 overflow-y-auto">
+          <p className="text-sm text-muted-foreground leading-relaxed">{step.body}</p>
+        </div>
+        <div className="shrink-0 flex items-center justify-between gap-3 pt-3">
           {/* Progress: the current step is a pill, the rest small dots. */}
           {isSingle ? (
             <span />

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-all duration-200 shadow-sm overflow-hidden",
+  "inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-all duration-150 shadow-sm overflow-hidden",
   {
     variants: {
       variant: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -32,7 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn("leading-tight font-semibold", className)}
       {...props}
     />
   )

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -12,7 +12,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-all duration-150 outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/60 backdrop-blur-sm",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/70 backdrop-blur-sm",
         className
       )}
       {...props}
@@ -69,7 +69,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-80 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="focus-visible:ring-ring/50 data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-3 right-3 inline-flex h-7 w-7 items-center justify-center rounded-md opacity-70 transition-all hover:opacity-100 hover:bg-muted focus-visible:ring-[3px] focus-visible:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -110,7 +110,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      className={cn("text-lg leading-snug font-semibold", className)}
       {...props}
     />
   )
@@ -123,7 +123,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-muted-foreground text-sm leading-relaxed", className)}
       {...props}
     />
   )

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-all duration-200 outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm hover:border-primary/40 hover:shadow-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-all duration-150 outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm hover:border-primary/40 hover:shadow-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -13,7 +13,7 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-2 text-xs leading-tight font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className
       )}
       {...props}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -40,7 +40,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background data-[state=active]:border-primary/40 data-[state=active]:shadow-sm dark:data-[state=active]:text-foreground dark:data-[state=active]:bg-input/30 dark:data-[state=active]:border-primary/50 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-border/60 px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow,border-color] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 hover:border-border [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[state=active]:bg-background data-[state=active]:border-primary/40 data-[state=active]:shadow-sm dark:data-[state=active]:text-foreground dark:data-[state=active]:bg-input/30 dark:data-[state=active]:border-primary/50 focus-visible:border-ring focus-visible:ring-ring/50 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-border/60 px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow,border-color] focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 hover:border-border [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-all duration-200 outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm break-words hover:border-primary/40 hover:shadow-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-all duration-150 outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm break-words hover:border-primary/40 hover:shadow-sm",
         className
       )}
       {...props}

--- a/src/data/documentGuide.ts
+++ b/src/data/documentGuide.ts
@@ -2,7 +2,6 @@ export interface DocumentTypeGuide {
   id: string;
   name: string;
   category: string;
-  icon: string; // emoji for visual appeal
   summary: string;
   whenToUse: string[];
   keyFeatures: string[];
@@ -16,7 +15,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'naval_letter',
     name: 'Naval Letter (on letterhead)',
     category: 'Letters',
-    icon: '📄',
     summary: 'The standard format for official correspondence within and outside the Department of the Navy. Uses official letterhead and formal addressing.',
     whenToUse: [
       'Official correspondence to other commands or units',
@@ -45,7 +43,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'standard_letter',
     name: 'Standard Letter (plain paper)',
     category: 'Letters',
-    icon: '📝',
     summary: 'Same format as a naval letter but without official letterhead. Used when letterhead is not required or appropriate.',
     whenToUse: [
       'Internal correspondence where letterhead is unnecessary',
@@ -71,7 +68,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'business_letter',
     name: 'Business Letter',
     category: 'Letters',
-    icon: '💼',
     summary: 'Used for correspondence with individuals or organizations outside the Department of Defense. Uses a more traditional business format familiar to civilian recipients.',
     whenToUse: [
       'Correspondence with civilian businesses or contractors',
@@ -101,7 +97,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'multiple_address_letter',
     name: 'Multiple Address Letter',
     category: 'Letters',
-    icon: '📨',
     summary: 'Used when the same letter needs to be sent to multiple addressees. Efficient for distributing identical information to several commands.',
     whenToUse: [
       'Policy announcements to multiple commands',
@@ -127,7 +122,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'joint_letter',
     name: 'Joint Letter',
     category: 'Letters',
-    icon: '🤝',
     summary: 'A letter signed by two commanding officers or officials, typically from different organizations, presenting a unified position or coordinated action.',
     whenToUse: [
       'Coordinated actions between two commands',
@@ -156,7 +150,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'same_page_endorsement',
     name: 'Same-Page Endorsement',
     category: 'Endorsements',
-    icon: '✅',
     summary: 'A brief endorsement added to the same page as the basic letter, used when the endorsement is short and space permits.',
     whenToUse: [
       'Short recommendations (approve/disapprove)',
@@ -182,7 +175,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'new_page_endorsement',
     name: 'New-Page Endorsement',
     category: 'Endorsements',
-    icon: '📋',
     summary: 'An endorsement on a new page with its own letterhead, used when the endorsement requires more space or when same-page endorsement is not appropriate.',
     whenToUse: [
       'Lengthy endorsements with detailed comments',
@@ -211,7 +203,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'mfr',
     name: 'Memorandum for the Record (MFR)',
     category: 'Memoranda',
-    icon: '📔',
     summary: 'Documents information, decisions, or events for the official record. Creates a permanent record of something that occurred or was decided.',
     whenToUse: [
       'Documenting meetings or conversations',
@@ -240,7 +231,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'mf',
     name: 'Memorandum For',
     category: 'Memoranda',
-    icon: '📩',
     summary: 'A memorandum addressed to a specific person or office, typically used for internal communication within an organization.',
     whenToUse: [
       'Internal correspondence to a specific person',
@@ -266,7 +256,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'plain_paper_memorandum',
     name: 'Plain Paper Memorandum',
     category: 'Memoranda',
-    icon: '📃',
     summary: 'An informal memorandum without letterhead, used for routine internal communications where official letterhead is not required.',
     whenToUse: [
       'Routine internal communications',
@@ -292,7 +281,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'letterhead_memorandum',
     name: 'Letterhead Memorandum',
     category: 'Memoranda',
-    icon: '🏛️',
     summary: 'A formal memorandum on official letterhead, used for more formal internal communications or when the communication may leave the organization.',
     whenToUse: [
       'Formal internal communications',
@@ -318,7 +306,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'decision_memorandum',
     name: 'Decision Memorandum',
     category: 'Memoranda',
-    icon: '⚖️',
     summary: 'Presents options to a decision-maker with recommendations. Designed to facilitate command decisions by presenting clear choices.',
     whenToUse: [
       'Presenting options for commander decision',
@@ -347,7 +334,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'executive_memorandum',
     name: 'Executive Memorandum',
     category: 'Memoranda',
-    icon: '👔',
     summary: 'A memorandum for senior executives or flag officers, typically more polished and concise, focusing on strategic-level information.',
     whenToUse: [
       'Communication to flag/general officers',
@@ -373,7 +359,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'joint_memorandum',
     name: 'Joint Memorandum',
     category: 'Memoranda',
-    icon: '🤝',
     summary: 'A memorandum signed by two officials, typically representing coordinated staff positions or agreements between organizations.',
     whenToUse: [
       'Coordinated staff recommendations',
@@ -401,7 +386,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'moa',
     name: 'Memorandum of Agreement (MOA)',
     category: 'Agreements',
-    icon: '📜',
     summary: 'A formal agreement between two or more parties that documents specific terms, responsibilities, and often resource commitments. More binding than an MOU.',
     whenToUse: [
       'Agreements with specific resource commitments',
@@ -431,7 +415,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'mou',
     name: 'Memorandum of Understanding (MOU)',
     category: 'Agreements',
-    icon: '🤝',
     summary: 'Documents a mutual understanding between parties about their relationship, roles, or coordination. Less formal than an MOA, typically without specific resource commitments.',
     whenToUse: [
       'Establishing working relationships',
@@ -463,7 +446,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'executive_correspondence',
     name: 'Executive Correspondence',
     category: 'Executive',
-    icon: '⭐',
     summary: 'High-level correspondence from or to senior executives, designed for strategic communication at the highest levels of command.',
     whenToUse: [
       'Communication between flag/general officers',
@@ -491,7 +473,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'navmc_10274',
     name: 'NAVMC 10274 - Administrative Action',
     category: 'Forms',
-    icon: '📋',
     summary: 'Used to document and process administrative actions for Marine Corps personnel. Records formal administrative decisions and their disposition.',
     whenToUse: [
       'Documenting administrative actions',
@@ -517,7 +498,6 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
     id: 'navmc_118_11',
     name: 'NAVMC 118 (11) - Administrative Remarks',
     category: 'Forms',
-    icon: '📝',
     summary: 'The "Page 11" entry for Marine Corps service record books. Documents counselings, commendations, and significant administrative events.',
     whenToUse: [
       'Counseling documentation (positive or negative)',
@@ -543,20 +523,20 @@ export const DOCUMENT_TYPE_GUIDES: DocumentTypeGuide[] = [
 
 // Top-level guide groups (Correspondence vs Forms)
 export const GUIDE_GROUPS = [
-  { id: 'correspondence', name: 'Correspondence', icon: '📄', description: 'Letters, memos, and official documents' },
-  { id: 'forms', name: 'Forms', icon: '📋', description: 'Military forms (NAVMC, DD, SF)' },
+  { id: 'correspondence', name: 'Correspondence', description: 'Letters, memos, and official documents' },
+  { id: 'forms', name: 'Forms', description: 'Military forms (NAVMC, DD, SF)' },
 ];
 
 // Categories within each group
 export const GUIDE_CATEGORIES = [
   // Correspondence categories
-  { id: 'Letters', name: 'Letters', icon: '📄', description: 'Official correspondence formats', group: 'correspondence' },
-  { id: 'Endorsements', name: 'Endorsements', icon: '✅', description: 'Routing and recommendations', group: 'correspondence' },
-  { id: 'Memoranda', name: 'Memoranda', icon: '📝', description: 'Internal communication formats', group: 'correspondence' },
-  { id: 'Agreements', name: 'Agreements', icon: '🤝', description: 'Formal agreements between parties', group: 'correspondence' },
-  { id: 'Executive', name: 'Executive', icon: '⭐', description: 'Senior-level correspondence', group: 'correspondence' },
+  { id: 'Letters', name: 'Letters', description: 'Official correspondence formats', group: 'correspondence' },
+  { id: 'Endorsements', name: 'Endorsements', description: 'Routing and recommendations', group: 'correspondence' },
+  { id: 'Memoranda', name: 'Memoranda', description: 'Internal communication formats', group: 'correspondence' },
+  { id: 'Agreements', name: 'Agreements', description: 'Formal agreements between parties', group: 'correspondence' },
+  { id: 'Executive', name: 'Executive', description: 'Senior-level correspondence', group: 'correspondence' },
   // Forms categories
-  { id: 'Forms', name: 'NAVMC Forms', icon: '⚓', description: 'Marine Corps forms', group: 'forms' },
+  { id: 'Forms', name: 'NAVMC Forms', description: 'Marine Corps forms', group: 'forms' },
 ];
 
 export function getGuidesByCategory(category: string): DocumentTypeGuide[] {

--- a/src/index.css
+++ b/src/index.css
@@ -33,15 +33,17 @@
     overflow: hidden;
   }
 
-  /* Custom scrollbar styling */
+  /* Custom scrollbar styling. The tokens are oklch(), so the old
+     hsl(var(--muted-foreground) / a) syntax was invalid and silently fell
+     back to the default scrollbar — use color-mix on the oklch token. */
   * {
-    scrollbar-width: auto;
-    scrollbar-color: hsl(var(--muted-foreground) / 0.4) transparent;
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in oklab, var(--muted-foreground) 40%, transparent) transparent;
   }
 
   *::-webkit-scrollbar {
-    width: 12px;
-    height: 12px;
+    width: 10px;
+    height: 10px;
   }
 
   *::-webkit-scrollbar-track {
@@ -50,14 +52,15 @@
   }
 
   *::-webkit-scrollbar-thumb {
-    background: hsl(var(--muted-foreground) / 0.4);
+    background: color-mix(in oklab, var(--muted-foreground) 40%, transparent);
     border-radius: 6px;
     border: 2px solid transparent;
     background-clip: content-box;
+    transition: background-color 150ms;
   }
 
   *::-webkit-scrollbar-thumb:hover {
-    background: hsl(var(--muted-foreground) / 0.5);
+    background: color-mix(in oklab, var(--muted-foreground) 60%, transparent);
     background-clip: content-box;
   }
 
@@ -323,14 +326,14 @@
   --foreground: oklch(0.98 0 0);           /* White */
   --card: oklch(0.205 0.008 260);          /* Slate card — lifted off canvas */
   --card-foreground: oklch(0.98 0 0);
-  --popover: oklch(0.245 0.009 260);       /* Elevated — menus/dropdowns */
+  --popover: oklch(0.27 0.009 260);        /* Elevated — menus/dropdowns sit clearly above cards */
   --popover-foreground: oklch(0.98 0 0);
   --primary: oklch(0.55 0.20 25);          /* Bright USMC Red — WCAG AA on dark */
   --primary-foreground: oklch(0.98 0 0);   /* White on red */
   --secondary: oklch(0.23 0.008 260);      /* Dark slate */
   --secondary-foreground: oklch(0.98 0 0);
   --muted: oklch(0.23 0.008 260);
-  --muted-foreground: oklch(0.78 0.01 250);
+  --muted-foreground: oklch(0.82 0.02 250); /* Slightly brighter slate — easier read on deep canvas */
   --accent: oklch(0.80 0.15 85);           /* #f1b434 gold accent */
   --accent-foreground: oklch(0.14 0.008 260);
   --destructive: oklch(0.50 0.18 25);      /* Brighter red — WCAG AA */

--- a/src/stores/onboardingStore.ts
+++ b/src/stores/onboardingStore.ts
@@ -5,12 +5,27 @@ import { persist } from 'zustand/middleware';
  * Tracks which feature walkthroughs the user has finished, so the guide can
  * show onboarding progress (checks per feature + an overall tally). A feature
  * is marked learned only when its "Walk me through it" tour reaches the last
- * step — skipping or exiting early does not count. Persisted to localStorage.
+ * step — skipping or exiting early does not count.
+ *
+ * Also backs the floating "getting started" activation checklist: the same
+ * `completed` map carries a `first_document` milestone (set on the first PDF
+ * export), and two flags govern the launcher's lifecycle — `checklistDismissed`
+ * (the user hid it; reversible from Help) and `checklistCelebrated` (all steps
+ * done, the one-time celebration has fired, retire it for good). Persisted to
+ * localStorage; the whole store is saved (no partialize), so all of this
+ * survives reloads.
  */
 interface OnboardingState {
-  /** Feature key → learned. Absent/false means not yet completed. */
+  /** Feature key → learned. Absent/false means not yet completed. Also holds
+   *  the `first_document` checklist milestone (not one of the 7 features). */
   completed: Record<string, boolean>;
   markComplete: (key: string) => void;
+  /** User hid the activation checklist launcher. Reversible via Help → Getting started. */
+  checklistDismissed: boolean;
+  /** Terminal: every step is done and the celebration has shown once — retire it. */
+  checklistCelebrated: boolean;
+  setChecklistDismissed: (v: boolean) => void;
+  setChecklistCelebrated: (v: boolean) => void;
 }
 
 export const useOnboardingStore = create<OnboardingState>()(
@@ -19,6 +34,13 @@ export const useOnboardingStore = create<OnboardingState>()(
       completed: {},
       markComplete: (key) =>
         set((s) => (s.completed[key] ? s : { completed: { ...s.completed, [key]: true } })),
+      checklistDismissed: false,
+      checklistCelebrated: false,
+      setChecklistDismissed: (v) => set({ checklistDismissed: v }),
+      // Retiring the launcher also clears any lingering dismissal so no dead
+      // `checklistDismissed: true` is left stranded once it's celebrated.
+      setChecklistCelebrated: (v) =>
+        set(v ? { checklistCelebrated: true, checklistDismissed: false } : { checklistCelebrated: v }),
     }),
     { name: 'dondocs-onboarding' }
   )

--- a/src/stores/tourStore.ts
+++ b/src/stores/tourStore.ts
@@ -7,6 +7,15 @@ const TOUR_STORAGE_KEY = 'dondocs-tour-completed';
 // meaningfully so the first-run tour replays once for returning users.
 const TOUR_VERSION = '1';
 
+/**
+ * Onboarding key marked when the intro tour is *finished* (reaches the last
+ * step), not merely seen. `TOUR_STORAGE_KEY` above is set on any end — finish
+ * OR skip/Esc/× — so the first-run prompt never nags again; but the getting-
+ * started checklist should only credit the step when the user actually walked
+ * it through, so it reads this key instead.
+ */
+export const GUIDED_TOUR_KEY = 'guided_tour';
+
 interface TourState {
   active: boolean;
   stepIndex: number;
@@ -51,7 +60,9 @@ export const useTourStore = create<TourState>((set, get) => ({
   completionKey: null,
   start: () => {
     clearBodyPointerLock();
-    set({ active: true, stepIndex: 0, steps: TOUR_STEPS, markOnEnd: true, completionKey: null });
+    // completionKey so finishing the intro tour (reaching the last step) credits
+    // the checklist's "Take the guided tour" step — skipping/× does not.
+    set({ active: true, stepIndex: 0, steps: TOUR_STEPS, markOnEnd: true, completionKey: GUIDED_TOUR_KEY });
   },
   startSteps: (steps, completionKey) => {
     if (steps.length === 0) return;

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -47,6 +47,9 @@ interface UIState {
   templateLoaderOpen: boolean;
   piiWarningOpen: boolean;
   documentGuideOpen: boolean;
+  /** The Document Guide's active tab, lifted to the store so the activation
+   *  checklist can deep-link straight to Features before opening it. */
+  documentGuideTab: 'finder' | 'browse' | 'examples' | 'features';
   /** 'share' | 'import' when open, null when closed */
   shareModal: 'share' | 'import' | null;
   setProfileModalOpen: (open: boolean) => void;
@@ -60,6 +63,7 @@ interface UIState {
   setTemplateLoaderOpen: (open: boolean) => void;
   setPiiWarningOpen: (open: boolean) => void;
   setDocumentGuideOpen: (open: boolean) => void;
+  setDocumentGuideTab: (tab: UIState['documentGuideTab']) => void;
 
   // Mobile
   isMobile: boolean;
@@ -115,6 +119,7 @@ export const useUIStore = create<UIState>()(
       templateLoaderOpen: false,
       piiWarningOpen: false,
       documentGuideOpen: false,
+      documentGuideTab: 'browse',
       shareModal: null,
       setProfileModalOpen: (open) => set({ profileModalOpen: open }),
       setRestoreModalOpen: (open) => set({ restoreModalOpen: open }),
@@ -127,6 +132,7 @@ export const useUIStore = create<UIState>()(
       setTemplateLoaderOpen: (open) => set({ templateLoaderOpen: open }),
       setPiiWarningOpen: (open) => set({ piiWarningOpen: open }),
       setDocumentGuideOpen: (open) => set({ documentGuideOpen: open }),
+      setDocumentGuideTab: (tab) => set({ documentGuideTab: tab }),
 
       // Mobile
       isMobile: false,

--- a/tests/unit/documentFinder.test.ts
+++ b/tests/unit/documentFinder.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The Document Finder is a branching interview that maps a user's answers to one
+ * or more recommended document types. Its whole job is coverage: a clerk who
+ * doesn't know what they need must still be steerable to ANY of the 19 types.
+ *
+ * A prior version of the decision tree silently stranded four types —
+ * joint_letter, joint_memorandum, navmc_10274, navmc_118_11 — unreachable across
+ * all answer combinations. These tests enumerate every reachable answer path
+ * (respecting the conditional skips in the flow) and assert that:
+ *   - every one of the 19 catalogued types is recommended somewhere,
+ *   - the four formerly-dead types each get a high-confidence path,
+ *   - every recommended id is real, every leaf returns 1-3 results, and the
+ *     first result is always the high-confidence "best match".
+ * If a future edit re-orphans a type, this fails instead of shipping a finder
+ * that quietly can't reach it.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  getNextQuestion,
+  getRecommendations,
+} from '@/components/modals/documentFinderLogic';
+import { DOCUMENT_TYPE_GUIDES } from '@/data/documentGuide';
+
+type Answers = Record<string, string>;
+interface Leaf {
+  answers: Answers;
+  results: ReturnType<typeof getRecommendations>;
+}
+
+/**
+ * Depth-first walk of the interview: at each node ask getNextQuestion for the
+ * next question, branch on each of its options, and record getRecommendations
+ * once the interview is exhausted (getNextQuestion → null). This visits exactly
+ * the answer paths a real user can produce, including skipped questions.
+ */
+function enumerateLeaves(answers: Answers = {}): Leaf[] {
+  const q = getNextQuestion(answers);
+  if (!q) return [{ answers, results: getRecommendations(answers) }];
+  return q.options.flatMap((opt) =>
+    enumerateLeaves({ ...answers, [q.id]: opt.value })
+  );
+}
+
+const ALL_IDS = DOCUMENT_TYPE_GUIDES.map((g) => g.id);
+const leaves = enumerateLeaves();
+const everyResult = leaves.flatMap((l) => l.results);
+const recommendedIds = new Set(everyResult.map((r) => r.docType));
+const highIds = new Set(
+  everyResult.filter((r) => r.confidence === 'high').map((r) => r.docType)
+);
+
+describe('document finder — coverage', () => {
+  it('enumerates a non-trivial answer space', () => {
+    // Sanity: the DFS actually explores many distinct paths (guards against an
+    // accidental early-return that would make the other assertions vacuous).
+    expect(leaves.length).toBeGreaterThan(50);
+  });
+
+  it('the catalogue has all 19 expected types', () => {
+    expect(ALL_IDS).toHaveLength(19);
+  });
+
+  it('every catalogued document type is reachable', () => {
+    const unreachable = ALL_IDS.filter((id) => !recommendedIds.has(id));
+    expect(unreachable).toEqual([]);
+  });
+
+  it('the four formerly-dead types each have a high-confidence path', () => {
+    for (const id of ['joint_letter', 'joint_memorandum', 'navmc_10274', 'navmc_118_11']) {
+      expect(highIds.has(id)).toBe(true);
+    }
+  });
+
+  it('never recommends an id that is not in the catalogue', () => {
+    const known = new Set(ALL_IDS);
+    const bogus = [...recommendedIds].filter((id) => !known.has(id));
+    expect(bogus).toEqual([]);
+  });
+});
+
+describe('document finder — result invariants', () => {
+  it('every completed interview returns 1 to 3 results', () => {
+    for (const leaf of leaves) {
+      expect(leaf.results.length).toBeGreaterThanOrEqual(1);
+      expect(leaf.results.length).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it('the first result is always the high-confidence best match', () => {
+    for (const leaf of leaves) {
+      expect(leaf.results[0].confidence).toBe('high');
+    }
+  });
+
+  it('every best-match reason cites a SECNAV chapter or MCO', () => {
+    // High-confidence picks must justify themselves with doctrine; the medium
+    // "alternative" reasons are phrased as guidance ("Use X instead if …").
+    for (const r of everyResult.filter((x) => x.confidence === 'high')) {
+      expect(r.reason).toMatch(/^Per (Ch \d+|MCO P1070\.12K):/);
+    }
+  });
+});
+
+describe('document finder — key branches', () => {
+  const recs = (a: Answers) => getRecommendations(a).map((r) => r.docType);
+
+  it('Marine Corps form → Page 11 entry yields NAVMC 118(11)', () => {
+    expect(recs({ category: 'usmc_form', formType: 'page11' })[0]).toBe('navmc_118_11');
+  });
+
+  it('Marine Corps form → admin action yields NAVMC 10274', () => {
+    expect(recs({ category: 'usmc_form', formType: 'adminAction' })[0]).toBe('navmc_10274');
+  });
+
+  it('for-the-record yields an MFR and does not inject a USMC form', () => {
+    const r = recs({ category: 'record' });
+    expect(r[0]).toBe('mfr');
+    expect(r).not.toContain('navmc_118_11');
+  });
+
+  it('two commands co-signing outgoing correspondence → joint letter', () => {
+    const r = recs({
+      category: 'correspondence',
+      recipient: 'military',
+      jointSignature: 'yes',
+      purpose: 'request',
+      routing: 'via',
+      formality: 'formal',
+    });
+    expect(r[0]).toBe('joint_letter');
+  });
+
+  it('two commands co-signing an internal position → joint memorandum', () => {
+    const r = recs({
+      category: 'correspondence',
+      recipient: 'military',
+      jointSignature: 'yes',
+      purpose: 'inform',
+      routing: 'internal',
+      formality: 'formal',
+    });
+    expect(r[0]).toBe('joint_memorandum');
+  });
+
+  it('agreement committing resources → MOA over MOU', () => {
+    const r = recs({ category: 'correspondence', recipient: 'military', jointSignature: 'no', purpose: 'agreement', resources: 'yes' });
+    expect(r[0]).toBe('moa');
+    expect(r).toContain('mou');
+  });
+
+  it('agreement framing roles → MOU over MOA', () => {
+    const r = recs({ category: 'correspondence', recipient: 'military', jointSignature: 'no', purpose: 'agreement', resources: 'no' });
+    expect(r[0]).toBe('mou');
+    expect(r).toContain('moa');
+  });
+
+  it('civilian recipient → business letter', () => {
+    expect(recs({ category: 'correspondence', recipient: 'civilian', purpose: 'request', routing: 'direct', formality: 'formal' })[0]).toBe('business_letter');
+  });
+
+  it('formal internal information → Memorandum For leads', () => {
+    const r = recs({ category: 'correspondence', recipient: 'military', jointSignature: 'no', purpose: 'inform', routing: 'internal', formality: 'formal' });
+    expect(r[0]).toBe('mf');
+  });
+});


### PR DESCRIPTION
## Summary

A product-polish pass spanning the UI, the document guide, and onboarding.

### UI & design
- Consistent type scale and a clear label/value hierarchy
- Unified focus rings across inputs and controls
- Better dark-mode elevation and contrast; fixed a broken scrollbar style
- Snappier transitions; three-column form grids stack on mobile
- Header product identity: the DonDocs wordmark, unit seal, and a grouped toolbar

### Document guide & finder
- Three-tab guide with a consistent icon set in place of emoji
- Finder rebuilt as a short branching interview that can reach every document
  type — four were previously unreachable — with corrected mappings. The
  decision logic is a pure module covered by an enumeration test that guards
  coverage.

### Onboarding
- Getting-started checklist that auto-tracks the first tasks (take the tour,
  create a profile, build a document, explore the features), with a progress
  launcher, dismissal, and a one-time completion state
- Tour: credit only a finished tour, keep the coachmark off the highlighted
  element at any display size, and pin Back/Next inside the card

Verified in light and dark themes across desktop and mobile; the full test
suite passes.
