### PR TITLE
feat(pdf): unified in-app PDF viewer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,16 +155,12 @@ jobs:
           fi
 
   audit:
-    # `npm audit --audit-level=high` gate. Currently 19 high vulns —
-    # all from a single GHSA advisory transitive in @react-pdf-viewer/*
-    # (no upstream fix available; tracked separately in feat/ci-lint-security
-    # for the dep upgrade). Allowlisting that one advisory by ID lets
-    # the gate be effective immediately: any NEW high/critical vuln
-    # fails CI, while the known-and-tracked one doesn't false-fail.
-    #
-    # When the @react-pdf-viewer upgrade lands and the advisory is
-    # gone, drop the entry from KNOWN_ADVISORIES and the gate becomes
-    # vanilla `npm audit --audit-level=high`.
+    # Vanilla `npm audit --audit-level=high` gate — zero exceptions. The
+    # allowlist machinery this job used to carry existed for one advisory
+    # chain (pdfjs-dist via @react-pdf-viewer, no upstream fix); the react-pdf
+    # migration removed those packages, so the gate is now unconditional. If a
+    # new high/critical advisory has no fix, discuss before reintroducing any
+    # allowlist — the default answer is to replace the dependency.
     name: npm audit (high+)
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -175,42 +171,34 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - run: npm ci
-      - name: high-severity audit with explicit allowlist
+      - name: high-severity audit
+        run: npm audit --audit-level=high
+
+  pdf-worker-sync:
+    # Catches drift between the installed pdfjs-dist (via react-pdf) and the
+    # vendored public/lib/pdf.worker.min.mjs the app serves as its pdf.js
+    # worker. pdf.js hard-fails on a worker/API version mismatch, so a
+    # react-pdf upgrade without a re-vendored worker would break every preview
+    # surface at runtime while building green. Same guard pattern as
+    # "bundle in sync with tex/" above.
+    name: pdf worker in sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - name: re-vendor worker and assert no diff
         run: |
-          # Comma-separated GHSA / npm advisory IDs we accept (with reason).
-          # Add new entries as a separate PR with the reason inline.
-          # Both advisories are pdfjs-dist transitive via @react-pdf-viewer (dormant
-          # upstream, no fix). Tracked for the react-pdf migration that removes
-          # @react-pdf-viewer entirely; until then they are knowingly accepted.
-          export KNOWN_ADVISORIES="1104044,1118732"   # @react-pdf-viewer → pdfjs-dist
-          npm audit --json > audit.json || true
-          UNKNOWN=$(python3 <<'PY'
-          import json, os
-          allow = set(os.environ.get('KNOWN_ADVISORIES', '').split(','))
-          d = json.load(open('audit.json'))
-          bad = []
-          for name, info in d.get('vulnerabilities', {}).items():
-              sev = info.get('severity')
-              if sev not in ('high', 'critical'):
-                  continue
-              for v in info.get('via', []):
-                  if isinstance(v, dict) and v.get('source'):
-                      if str(v['source']) not in allow:
-                          bad.append(f'{name} via advisory {v["source"]} ({sev}, {v.get("title","")})')
-          for b in sorted(set(bad)):
-              print(b)
-          PY
-          )
-          if [ -n "$UNKNOWN" ]; then
-            echo "::error::New high/critical vulnerabilities not in the allowlist:"
-            echo "$UNKNOWN"
-            echo ""
-            echo "Either upgrade the offending dep or, if no fix is available,"
-            echo "add the advisory ID to KNOWN_ADVISORIES in .github/workflows/test.yml"
-            echo "with an inline comment explaining why."
+          npm run sync:pdf-worker
+          if ! git diff --exit-code public/lib/pdf.worker.min.mjs; then
+            echo "::error::public/lib/pdf.worker.min.mjs is out of sync with the installed pdfjs-dist."
+            echo "Run \`npm run sync:pdf-worker\` locally and commit the regenerated worker."
             exit 1
           fi
-          echo "No new high/critical vulnerabilities outside the allowlist."
 
   compile-matrix:
     # End-to-end LaTeX + DOCX compile harness. Three test files run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [Unreleased]
+
+### Changed
+
+- **One PDF viewer everywhere** — the desktop preview drops the browser's
+  iframe viewer and mobile drops its per-platform split; every surface renders
+  through a shared in-app viewer with zoom, page navigation, fullscreen, and
+  an open-in-tab escape hatch. Recompiles now swap in place: the old page
+  stays visible while the new one renders, then dissolves — no white flash,
+  no scroll jump.
+
+### Removed
+
+- `@react-pdf-viewer` (all five packages) and its CDN-hosted pdf.js 3.x
+  worker. This closes the 21 high-severity audit advisories
+  (CVE-2024-4367) that CI previously carried an explicit allowlist for —
+  `npm audit --audit-level=high` now gates with zero exceptions, and a new CI
+  check keeps the vendored pdf.js worker in lockstep with the installed
+  library.
+
 ## [1.2.0] — 2026-07-01
 
 The editor becomes a multi-document workspace. Existing data migrates in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,17 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
-## [Unreleased]
+## [1.2.1] — 2026-07-01
 
 ### Changed
 
 - **One PDF viewer everywhere** — the desktop preview drops the browser's
   iframe viewer and mobile drops its per-platform split; every surface renders
-  through a shared in-app viewer with zoom, page navigation, fullscreen, and
-  an open-in-tab escape hatch. Recompiles now swap in place: the old page
-  stays visible while the new one renders, then dissolves — no white flash,
-  no scroll jump.
+  through a shared in-app viewer with zoom, fit-width and fit-page modes,
+  page navigation with direct page entry, a collapsible thumbnail rail on
+  multi-page documents, fullscreen, and an open-in-tab escape hatch.
+  Recompiles swap in place: the old page stays visible while the new one
+  renders, then dissolves — no white flash, no scroll jump.
 
 ### Removed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.1.55",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.1.55",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -26,11 +26,6 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
-        "@react-pdf-viewer/core": "^3.12.0",
-        "@react-pdf-viewer/default-layout": "^3.12.0",
-        "@react-pdf-viewer/page-navigation": "^3.12.0",
-        "@react-pdf-viewer/thumbnail": "^3.12.0",
-        "@react-pdf-viewer/zoom": "^3.12.0",
         "@tiptap/extension-underline": "^3.14.0",
         "@tiptap/pm": "^3.14.0",
         "@tiptap/react": "^3.14.0",
@@ -2507,20 +2502,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2580,56 +2561,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
-      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
-      },
-      "bin": {
-        "node-pre-gyp": "bin/node-pre-gyp"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -4043,254 +3974,6 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
-    },
-    "node_modules/@react-pdf-viewer/attachment": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/attachment/-/attachment-3.12.0.tgz",
-      "integrity": "sha512-mhwrYJSIpCvHdERpLUotqhMgSjhtF+BTY1Yb9Fnzpcq3gLZP+Twp5Rynq21tCrVdDizPaVY7SKu400GkgdMfZw==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/bookmark": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/bookmark/-/bookmark-3.12.0.tgz",
-      "integrity": "sha512-i7nEit8vIFMAES8RFGwprZ9cXOOZb9ZStPW6E6yuObJEXcvBj/ctsbBJGZxqUZOGklM0JoB7sjHyxAriHfe92A==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/core": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/core/-/core-3.12.0.tgz",
-      "integrity": "sha512-8MsdlQJ4jaw3GT+zpCHS33nwnvzpY0ED6DEahZg9WngG++A5RMhk8LSlxdHelwaFFHFiXBjmOaj2Kpxh50VQRg==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "peerDependencies": {
-        "pdfjs-dist": "^2.16.105 || ^3.0.279",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/default-layout": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/default-layout/-/default-layout-3.12.0.tgz",
-      "integrity": "sha512-K2fS4+TJynHxxCBFuIDiFuAw3nqOh4bkBgtVZ/2pGvnFn9lLg46YGLMnTXCQqtyZzzXYh696jmlFViun3is4pA==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/attachment": "3.12.0",
-        "@react-pdf-viewer/bookmark": "3.12.0",
-        "@react-pdf-viewer/core": "3.12.0",
-        "@react-pdf-viewer/thumbnail": "3.12.0",
-        "@react-pdf-viewer/toolbar": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/full-screen": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/full-screen/-/full-screen-3.12.0.tgz",
-      "integrity": "sha512-hQouJ26QUaRBCXNMU1aI1zpJn4l4PJRvlHhuE2dZYtLl37ycjl7vBCQYZW1FwnuxMWztZsY47R43DKaZORg0pg==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/get-file": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/get-file/-/get-file-3.12.0.tgz",
-      "integrity": "sha512-Uhq45n2RWlZ7Ec/BtBJ0WQESRciaYIltveDXHNdWvXgFdOS8XsvB+mnTh/wzm7Cfl9hpPyzfeezifdU9AkQgQg==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/open": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/open/-/open-3.12.0.tgz",
-      "integrity": "sha512-vhiDEYsiQLxvZkIKT9VPYHZ1BOnv46x9eCEmRWxO1DJ8fa/GRDTA9ivXmq/ap0dGEJs6t+epleCkCEfllLR/Yw==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/page-navigation": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/page-navigation/-/page-navigation-3.12.0.tgz",
-      "integrity": "sha512-tVEJ48Dd5kajV1nKkrPWijglJRNBiKBTyYDKVexhiRdTHUP1f6QQXiSyDgCUb0IGSZeJzOJb1h7ApKHe8OTtuw==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/print": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/print/-/print-3.12.0.tgz",
-      "integrity": "sha512-xJn76CgbU/M2iNaN7wLHTg+sdOekkRMfCakFLwPrE+SR7qD6NUF4vQQKJBSVCCK5bUijzb6cWfKGfo8VA72o4Q==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/properties": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/properties/-/properties-3.12.0.tgz",
-      "integrity": "sha512-dYTCHtVwFNkpDo7QxL2qk/8zAKndLwdD1FFxBftl6jIlQbtvNdxkFfkv1HcQING9Ic+7DBryOiD7W0ze4IERYg==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/rotate": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/rotate/-/rotate-3.12.0.tgz",
-      "integrity": "sha512-yaxaMYPChvNOjR8+AxRmj0kvojyJKPq4XHEcIB2lJJgBY1Zra3mliDUP3Nlb4yV8BS9+yBqWn9U9mtnopQD+tw==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/scroll-mode": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/scroll-mode/-/scroll-mode-3.12.0.tgz",
-      "integrity": "sha512-okII7Xqhl6cMvl1izdEvlXNJ+vJVq/qdg53hJIDYVgBCWskLk/cpjUg/ZonBxseG9lIDP3w2VO1McT8Gn11OAg==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/search": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/search/-/search-3.12.0.tgz",
-      "integrity": "sha512-jAkLpis49fsDDY/HrbUZIOIhzF5vynONQNA4INQKI38r/MjveblrkNv7qbr9j5lQ/WFic5+gD1e+Mtpf1/7DiA==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/selection-mode": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/selection-mode/-/selection-mode-3.12.0.tgz",
-      "integrity": "sha512-yysWEu2aCtBvzSgbhgI9kT5cq2hf0FU6Z+3B7MMXz14Kxyc3y18wUqxtgbvpFEfWF0bNUUq16JtWRljtxvZ83w==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/theme": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/theme/-/theme-3.12.0.tgz",
-      "integrity": "sha512-cdBi+wR1VOZ6URCcO9plmAZQu4ZGFcd7HJdBe7VIFiGyrvl9I/Of74ONLycnDImSuONt8D3uNjPBLieeaShVeg==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/thumbnail": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/thumbnail/-/thumbnail-3.12.0.tgz",
-      "integrity": "sha512-Vc8j3bO6wumWZV4o6pAbktPWKDSC9tQAzOCJ3cof541u4i44C11ccYC4W9aNcsMMUSO3bNwAGWtP8OFthV5akQ==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/toolbar": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/toolbar/-/toolbar-3.12.0.tgz",
-      "integrity": "sha512-qACTU3qXHgtNK8J+T13EWio+0liilj86SJ87BdapqXynhl720OKPlSKOQqskUGqg3oTUJAhrse9XG6SFdHJx+g==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0",
-        "@react-pdf-viewer/full-screen": "3.12.0",
-        "@react-pdf-viewer/get-file": "3.12.0",
-        "@react-pdf-viewer/open": "3.12.0",
-        "@react-pdf-viewer/page-navigation": "3.12.0",
-        "@react-pdf-viewer/print": "3.12.0",
-        "@react-pdf-viewer/properties": "3.12.0",
-        "@react-pdf-viewer/rotate": "3.12.0",
-        "@react-pdf-viewer/scroll-mode": "3.12.0",
-        "@react-pdf-viewer/search": "3.12.0",
-        "@react-pdf-viewer/selection-mode": "3.12.0",
-        "@react-pdf-viewer/theme": "3.12.0",
-        "@react-pdf-viewer/zoom": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@react-pdf-viewer/zoom": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@react-pdf-viewer/zoom/-/zoom-3.12.0.tgz",
-      "integrity": "sha512-V0GUTyPM77+LzhoKX+T3XI10/HfGdqRTbgeP7ID60FCzcwu6kXWqJn5tzabjDKLTlFv8mJmn0aa/ppkIU97nfA==",
-      "license": "https://react-pdf-viewer.dev/license",
-      "dependencies": {
-        "@react-pdf-viewer/core": "3.12.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
@@ -6640,14 +6323,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -6669,20 +6344,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -6716,7 +6377,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6733,46 +6394,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/aproba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/argparse": {
@@ -7156,23 +6777,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/canvas": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
-      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.0",
-        "nan": "^2.17.0",
-        "simple-get": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -7202,17 +6806,6 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -7245,17 +6838,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/color-support": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -7275,22 +6857,6 @@
       "engines": {
         "node": ">=4.0.0"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -7425,7 +6991,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7437,20 +7003,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/deep-is": {
@@ -7506,14 +7058,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -7538,7 +7082,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -8366,14 +7910,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -8429,37 +7965,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/gauge": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gauge/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
@@ -8571,29 +8076,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -8605,40 +8087,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/globals": {
@@ -8790,14 +8238,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -8834,21 +8274,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/human-signals": {
       "version": "8.0.1",
@@ -8918,19 +8343,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -9113,17 +8525,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -10137,20 +9538,6 @@
         }
       }
     },
-    "node_modules/mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -10188,31 +9575,17 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mutation-server-protocol": {
@@ -10262,14 +9635,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/nan": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -10296,51 +9661,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nopt": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
@@ -10370,32 +9696,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-      "deprecated": "This package is no longer supported.",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -10452,17 +9752,6 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "wrappy": "1"
-      }
     },
     "node_modules/option": {
       "version": "0.2.4",
@@ -10585,7 +9874,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10633,17 +9922,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/path2d-polyfill": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path2d-polyfill/-/path2d-polyfill-2.0.1.tgz",
-      "integrity": "sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -10709,20 +9987,6 @@
       },
       "optionalDependencies": {
         "@napi-rs/canvas": "^0.1.80"
-      }
-    },
-    "node_modules/pdfjs-dist": {
-      "version": "3.11.174",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
-      "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "canvas": "^2.11.2",
-        "path2d-polyfill": "^2.0.1"
       }
     },
     "node_modules/picocolors": {
@@ -11347,24 +10611,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/rolldown": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
@@ -11566,7 +10812,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11584,14 +10830,6 @@
       "engines": {
         "node": ">=20.0.0"
       }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -11767,41 +11005,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/simple-get": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/smob": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
@@ -11896,30 +11099,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
@@ -12023,20 +11202,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
@@ -12128,35 +11293,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/temp-dir": {
@@ -12285,14 +11421,6 @@
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -12979,14 +12107,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -12995,18 +12115,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -13136,17 +12244,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/word-wrap": {
@@ -13446,14 +12543,6 @@
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "7.4.1"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true
     },
     "node_modules/ws": {
       "version": "8.21.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:coverage": "vitest run --coverage",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:cartesian": "vite-node --config vitest.integration.config.ts tests/cartesian/run.ts --",
-    "test:mutation": "stryker run"
+    "test:mutation": "stryker run",
+    "sync:pdf-worker": "node scripts/sync-pdf-worker.mjs"
   },
   "overrides": {
     "serialize-javascript": "^7.0.5",
@@ -37,11 +38,6 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
-    "@react-pdf-viewer/core": "^3.12.0",
-    "@react-pdf-viewer/default-layout": "^3.12.0",
-    "@react-pdf-viewer/page-navigation": "^3.12.0",
-    "@react-pdf-viewer/thumbnail": "^3.12.0",
-    "@react-pdf-viewer/zoom": "^3.12.0",
     "@tiptap/extension-underline": "^3.14.0",
     "@tiptap/pm": "^3.14.0",
     "@tiptap/react": "^3.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/sync-pdf-worker.mjs
+++ b/scripts/sync-pdf-worker.mjs
@@ -1,0 +1,36 @@
+/**
+ * Copy the pdf.js worker that matches the installed react-pdf into
+ * public/lib/pdf.worker.min.mjs.
+ *
+ * The app pins pdf.js's workerSrc to that vendored file
+ * (src/components/pdf/pdfConfig.ts). pdf.js hard-fails when the worker version
+ * differs from the API version, so any react-pdf/pdfjs-dist upgrade MUST
+ * re-vendor the worker — CI runs this script and asserts a clean diff
+ * (`pdf worker in sync` job), the same guard pattern as build-templates.mjs
+ * for the LaTeX bundle.
+ *
+ * Resolution deliberately goes THROUGH react-pdf: pdfjs-dist is nested under
+ * react-pdf's own node_modules (other packages pin different majors), and the
+ * nested copy is the one whose API the app actually runs.
+ *
+ * Usage: npm run sync:pdf-worker
+ */
+import { createRequire } from 'node:module';
+import { copyFileSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const requireFromRepo = createRequire(join(repoRoot, 'package.json'));
+const reactPdfPkgPath = requireFromRepo.resolve('react-pdf/package.json');
+const requireFromReactPdf = createRequire(reactPdfPkgPath);
+const pdfjsPkgPath = requireFromReactPdf.resolve('pdfjs-dist/package.json');
+
+const pdfjsDir = dirname(pdfjsPkgPath);
+const { version } = JSON.parse(readFileSync(pdfjsPkgPath, 'utf8'));
+const workerSrc = join(pdfjsDir, 'build', 'pdf.worker.min.mjs');
+const workerDest = join(repoRoot, 'public', 'lib', 'pdf.worker.min.mjs');
+
+copyFileSync(workerSrc, workerDest);
+console.log(`pdf.worker.min.mjs vendored from pdfjs-dist@${version} (via react-pdf)`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -547,9 +547,16 @@ function App() {
           pdfBytes = await enhancePreviewPdf(pdfBytes, currentStore);
         }
 
-        // Revoke old URL
+        // Revoke the old URL on a delay: the viewer double-buffers document
+        // swaps, so an in-flight load of the outgoing URL may still be reading
+        // it (the idle-enhance pass replaces the resting compile within the
+        // same second). Immediate revocation aborts that read — harmless (the
+        // swap machine abandons quietly) but it litters the console with
+        // pdf.js fetch warnings. A few seconds keeps every in-flight load
+        // alive; blobs are ~100 KB, so the deferred memory cost is trivial.
         if (pdfUrl) {
-          URL.revokeObjectURL(pdfUrl);
+          const stale = pdfUrl;
+          setTimeout(() => URL.revokeObjectURL(stale), 5000);
         }
 
         const blob = new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' });
@@ -575,7 +582,10 @@ function App() {
                   new Blob([new Uint8Array(enhanced)], { type: 'application/pdf' })
                 );
                 setPdfUrl((prev) => {
-                  if (prev) URL.revokeObjectURL(prev);
+                  // Deferred like the resting-compile revocation above: the
+                  // viewer may be mid-load on `prev` when the enhanced swap
+                  // lands.
+                  if (prev) setTimeout(() => URL.revokeObjectURL(prev), 5000);
                   return enhancedUrl;
                 });
                 setPreviewEnhanced(true);
@@ -729,10 +739,11 @@ function App() {
           const blob = new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' });
           const url = URL.createObjectURL(blob);
 
-          // Revoke old URL after creating new one
+          // Revoke old URL after creating new one (deferred — see the
+          // correspondence revocations above for why).
           setFormPdfUrl((prevUrl) => {
             if (prevUrl) {
-              URL.revokeObjectURL(prevUrl);
+              setTimeout(() => URL.revokeObjectURL(prevUrl), 5000);
             }
             return url;
           });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,9 +8,10 @@ import { PreviewPanel } from '@/components/layout/PreviewPanel';
 import { ResizableDivider } from '@/components/layout/ResizableDivider';
 import { ProfileModal } from '@/components/modals/ProfileModal';
 import { ReferenceLibraryModal } from '@/components/modals/ReferenceLibraryModal';
-// MobilePreviewModal pulls react-pdf + @react-pdf-viewer + pdf.js core
-// (~400 KB raw / ~120 KB gz) and only appears on mobile. Lazy-load it into
-// its own chunk; the mobilePreviewOpen gate below holds the fetch until the
+// MobilePreviewModal renders the shared in-app PdfViewer (react-pdf + pdf.js),
+// which Rollup emits as its own chunk because the desktop panel dynamically
+// imports the same component — one pdf.js copy for both surfaces. The modal
+// stays lazy too; the mobilePreviewOpen gate below holds the fetch until the
 // user taps "Preview PDF".
 const MobilePreviewModal = lazy(() =>
   import('@/components/modals/MobilePreviewModal').then((m) => ({

--- a/src/components/layout/PreviewPanel.tsx
+++ b/src/components/layout/PreviewPanel.tsx
@@ -1,8 +1,13 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { Loader2, AlertCircle, Eye, Paperclip } from 'lucide-react';
 import { useUIStore } from '@/stores/uiStore';
 import { useDocumentStore } from '@/stores/documentStore';
 import { ReadinessMeter } from './ReadinessMeter';
+
+// The in-app viewer (react-pdf + pdf.js) is its own chunk: the desktop shell
+// stays pdf.js-free until a preview actually exists. The warm-up effect below
+// starts fetching it during the first compile so it's ready before the PDF is.
+const PdfViewer = lazy(() => import('@/components/pdf/PdfViewer'));
 
 interface PreviewPanelProps {
   pdfUrl: string | null;
@@ -24,64 +29,14 @@ export function PreviewPanel({ pdfUrl, isCompiling, isWarmingUp = false, preview
   const setMobilePreviewOpen = useUIStore((s) => s.setMobilePreviewOpen);
   const fullQualityPreview = useUIStore((s) => s.fullQualityPreview);
   const enclosureCount = useDocumentStore((s) => s.enclosures.length);
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const savedScrollRef = useRef<{ scrollTop: number; scrollLeft: number } | null>(null);
-  const previousUrlRef = useRef<string | null>(null);
 
-  // Save scroll position before PDF URL changes
-  const saveScrollPosition = useCallback(() => {
-    try {
-      const iframe = iframeRef.current;
-      if (iframe?.contentWindow?.document?.scrollingElement) {
-        const scrollEl = iframe.contentWindow.document.scrollingElement;
-        savedScrollRef.current = {
-          scrollTop: scrollEl.scrollTop,
-          scrollLeft: scrollEl.scrollLeft,
-        };
-      }
-    } catch {
-      // Cross-origin restrictions may prevent access - silently ignore
-    }
-  }, []);
-
-  // Restore scroll position after PDF loads
-  const restoreScrollPosition = useCallback(() => {
-    const saved = savedScrollRef.current;
-    if (!saved) return;
-
-    // Try multiple times as PDF viewer may take time to initialize
-    const attempts = [100, 300, 600, 1000];
-    attempts.forEach((delay) => {
-      setTimeout(() => {
-        try {
-          const iframe = iframeRef.current;
-          if (iframe?.contentWindow?.document?.scrollingElement) {
-            const scrollEl = iframe.contentWindow.document.scrollingElement;
-            scrollEl.scrollTop = saved.scrollTop;
-            scrollEl.scrollLeft = saved.scrollLeft;
-          }
-        } catch {
-          // Cross-origin restrictions may prevent access - silently ignore
-        }
-      }, delay);
-    });
-  }, []);
-
-  // Handle PDF URL changes - save position before, restore after
+  // Prefetch the viewer chunk while the first compile runs, so the viewer is
+  // parsed and ready by the time a pdfUrl exists. (Scroll preservation across
+  // recompiles now lives inside PdfViewer's double-buffered swap — the old
+  // reach-into-the-iframe hack is gone with the iframe.)
   useEffect(() => {
-    if (pdfUrl && previousUrlRef.current && pdfUrl !== previousUrlRef.current) {
-      // URL is changing, save current scroll position
-      saveScrollPosition();
-    }
-    previousUrlRef.current = pdfUrl;
-  }, [pdfUrl, saveScrollPosition]);
-
-  // Handle iframe load event to restore scroll position
-  const handleIframeLoad = useCallback(() => {
-    if (savedScrollRef.current) {
-      restoreScrollPosition();
-    }
-  }, [restoreScrollPosition]);
+    if (isCompiling) void import('@/components/pdf/PdfViewer');
+  }, [isCompiling]);
 
   // Filter out engine reset message - it's not a user-facing error
   const displayError = error === 'ENGINE_RESET_NEEDED' ? null : error;
@@ -160,13 +115,11 @@ export function PreviewPanel({ pdfUrl, isCompiling, isWarmingUp = false, preview
         {/* Show PDF if available, with optional loading overlay */}
         {pdfUrl && (
           <>
-            <iframe
-              ref={iframeRef}
-              src={pdfUrl}
-              className="absolute inset-0 w-full h-full border-0"
-              title="Document preview"
-              onLoad={handleIframeLoad}
-            />
+            <Suspense fallback={null /* the mat behind is already painted */}>
+              <div className="absolute inset-0" title="Document preview">
+                <PdfViewer pdfUrl={pdfUrl} />
+              </div>
+            </Suspense>
             {/* While recompiling, the stale PDF stays visible and unobscured —
                 the header's compile sweep conveys the in-flight state instead of
                 a blocking overlay wash. */}

--- a/src/components/modals/MobilePreviewModal.tsx
+++ b/src/components/modals/MobilePreviewModal.tsx
@@ -1,161 +1,16 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
-import { Document, Page, pdfjs } from 'react-pdf';
 import { X, Loader2, AlertCircle, ScrollText, Download, FileText } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useUIStore } from '@/stores/uiStore';
 import { useLogStore } from '@/stores/logStore';
 import { downloadPdfBlob, preOpenWindowForIOS } from '@/utils/downloadPdf';
-import { useDeviceInfo } from '@/utils/device';
 import { debug } from '@/lib/debug';
-
-/**
- * PDF Preview Strategy:
- * 
- * iOS (iPhone AND iPad): Use react-pdf-viewer
- *   - react-pdf crashes on iOS due to canvas memory limits (384MB)
- *   - react-pdf-viewer has better memory management
- *   - Reference: https://github.com/wojtekmaj/react-pdf/issues/1601
- * 
- * Non-iOS (Android, Desktop): Use react-pdf
- *   - Works fine, simpler setup
- * 
- * NOTE: We tried using iframe for iPad but it showed black screen.
- * react-pdf-viewer works reliably on both iPhone and iPad.
- */
-
-// iOS viewer: react-pdf-viewer with full features (zoom, thumbnails, navigation)
-import { Worker, Viewer } from '@react-pdf-viewer/core';
-import { defaultLayoutPlugin } from '@react-pdf-viewer/default-layout';
-import type { ToolbarSlot } from '@react-pdf-viewer/default-layout';
-import '@react-pdf-viewer/core/lib/styles/index.css';
-import '@react-pdf-viewer/default-layout/lib/styles/index.css';
-
-// Custom CSS to theme react-pdf-viewer to match app theme
-const pdfViewerStyles = `
-  /* Theme react-pdf-viewer to match app */
-  .rpv-core__viewer {
-    --rpv-color-primary: var(--primary);
-    --rpv-color-primary-foreground: var(--primary-foreground);
-    background-color: var(--background);
-    color: var(--foreground);
-  }
-
-  /* Toolbar styling */
-  .rpv-default-layout__toolbar {
-    background-color: var(--card) !important;
-    border-bottom: 1px solid var(--border) !important;
-  }
-
-  .rpv-core__minimal-button {
-    color: var(--foreground) !important;
-  }
-
-  .rpv-core__minimal-button:hover {
-    background-color: var(--accent) !important;
-  }
-
-  /* Sidebar styling */
-  .rpv-default-layout__sidebar {
-    background-color: var(--card) !important;
-    border-right: 1px solid var(--border) !important;
-  }
-
-  .rpv-default-layout__sidebar-headers {
-    background-color: var(--muted) !important;
-  }
-
-  .rpv-default-layout__sidebar-tab {
-    color: var(--muted-foreground) !important;
-  }
-
-  .rpv-default-layout__sidebar-tab--selected {
-    color: var(--primary) !important;
-    border-color: var(--primary) !important;
-  }
-
-  /* Thumbnail styling */
-  .rpv-thumbnail__container {
-    background-color: var(--card) !important;
-  }
-
-  .rpv-thumbnail__item--selected .rpv-thumbnail__cover::after {
-    border-color: var(--primary) !important;
-  }
-
-  /* Body/main area styling */
-  .rpv-default-layout__body {
-    background-color: color-mix(in oklch, var(--muted) 30%, transparent) !important;
-  }
-
-  .rpv-core__inner-pages {
-    background-color: transparent !important;
-  }
-
-  /* Popover/dropdown styling */
-  .rpv-core__popover-body {
-    background-color: var(--popover) !important;
-    border: 1px solid var(--border) !important;
-    color: var(--popover-foreground) !important;
-  }
-
-  .rpv-core__menu-item:hover {
-    background-color: var(--accent) !important;
-  }
-
-  /* Scrollbar styling */
-  .rpv-core__inner-pages::-webkit-scrollbar-thumb {
-    background-color: color-mix(in oklch, var(--muted-foreground) 30%, transparent) !important;
-  }
-
-  /* Page number input */
-  .rpv-core__textbox {
-    background-color: var(--input) !important;
-    border-color: var(--border) !important;
-    color: var(--foreground) !important;
-  }
-
-  /* Zoom dropdown */
-  .rpv-zoom__popover-target-scale {
-    color: var(--foreground) !important;
-  }
-`;
-
-// Configure pdf.js worker for react-pdf (non-iOS)
-// react-pdf v10 uses pdfjs-dist v5 — worker copied to public/lib/
-pdfjs.GlobalWorkerOptions.workerSrc = `${import.meta.env.BASE_URL}lib/pdf.worker.min.mjs`;
-
-// Worker URL for react-pdf-viewer (iOS)
-const PDFJS_WORKER_URL = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js`;
-
-/**
- * Hardened pdf.js options. Both viewers below preview user-supplied PDFs
- * (compiled main + uploaded enclosures), so we force the safer code path.
- *
- * `isEvalSupported: false` mitigates CVE-2024-4367: PDF.js's eval-based
- * font glyph renderer can be coerced into executing arbitrary JavaScript
- * by a maliciously crafted PDF. Disabling it routes glyph rendering
- * through the slower-but-safe non-eval path. The desktop preview uses an
- * `<iframe>` and the browser's native PDF viewer, so it isn't affected;
- * this hardening is specifically for the mobile path which renders
- * pdf.js in our origin.
- *
- * `@react-pdf-viewer/core@3.12.0` pulls in the vulnerable
- * `pdfjs-dist@3.11.174` transitively (`react-pdf@10` is fine on 5.x);
- * upstream is dormant so a version bump isn't currently available. Until
- * we migrate `MobilePreviewModal` off `@react-pdf-viewer`, this option
- * closes the active exploit path.
- *
- * Note: defined at module scope so that `<Document options={...}>` gets
- * a referentially stable object — react-pdf reprocesses the document
- * when `options` changes by identity.
- */
-const HARDENED_PDF_OPTIONS = { isEvalSupported: false } as const;
-const transformPdfParamsHardened = (
-  options: Record<string, unknown>,
-): Record<string, unknown> => ({
-  ...options,
-  isEvalSupported: false,
-});
+// Static import on purpose: this modal is itself lazy-loaded from App, and the
+// desktop panel dynamically imports the same viewer — Rollup therefore emits
+// PdfViewer (react-pdf + pdf.js) as one shared chunk used by both surfaces.
+// The viewer replaced the previous per-platform split (react-pdf-viewer on
+// iOS, a bare react-pdf scroll on Android): its page virtualization and DPR
+// cap keep canvas memory inside iOS budgets, so one implementation serves all.
+import PdfViewer from '@/components/pdf/PdfViewer';
 
 interface MobilePreviewModalProps {
   pdfUrl: string | null;
@@ -165,169 +20,18 @@ interface MobilePreviewModalProps {
 }
 
 /**
- * iOS PDF Viewer Component using react-pdf-viewer
- * 
- * Used for BOTH iPhone and iPad because:
- * - react-pdf crashes on iOS due to canvas memory limits
- * - iframe shows black screen on iPad (tested and failed)
- * - react-pdf-viewer works reliably on all iOS devices
- * 
- * Features: zoom controls, page thumbnails sidebar, page navigation, search
+ * Full-screen mobile preview. The header keeps the download / logs / close
+ * actions; the body is the shared in-app viewer (same one the desktop panel
+ * renders), which brings zoom, page navigation, and the flicker-free
+ * recompile swap to mobile.
  */
-function IOSPdfViewer({ pdfUrl, onClose, onDownload, isPhone }: {
-  pdfUrl: string;
-  onClose: () => void;
-  onDownload: () => void;
-  isPhone: boolean;
-}) {
-  // Inject custom styles on mount
-  useEffect(() => {
-    const styleEl = document.createElement('style');
-    styleEl.textContent = pdfViewerStyles;
-    document.head.appendChild(styleEl);
-    return () => {
-      document.head.removeChild(styleEl);
-    };
-  }, []);
-
-  // Create the default layout plugin with all features
-  const defaultLayoutPluginInstance = defaultLayoutPlugin({
-    sidebarTabs: (defaultTabs) => [
-      // Only show thumbnails tab for cleaner mobile UI
-      defaultTabs[0], // Thumbnails
-    ],
-    renderToolbar: (Toolbar) => (
-      <Toolbar>
-        {(slots: ToolbarSlot) => {
-          const {
-            CurrentPageInput,
-            GoToNextPage,
-            GoToPreviousPage,
-            NumberOfPages,
-            ShowSearchPopover,
-            Zoom,
-            ZoomIn,
-            ZoomOut,
-            EnterFullScreen,
-          } = slots;
-          return (
-            <div className="rpv-toolbar" style={{
-              display: 'flex',
-              alignItems: 'center',
-              width: '100%',
-              padding: '4px 8px',
-              gap: '4px'
-            }}>
-              {/* Left: Navigation */}
-              <div style={{ display: 'flex', alignItems: 'center', gap: '2px' }}>
-                <GoToPreviousPage />
-                <CurrentPageInput /> / <NumberOfPages />
-                <GoToNextPage />
-              </div>
-
-              {/* Center: Zoom */}
-              <div style={{ display: 'flex', alignItems: 'center', gap: '2px', marginLeft: 'auto' }}>
-                <ZoomOut />
-                <Zoom />
-                <ZoomIn />
-              </div>
-
-              {/* Right: Actions */}
-              <div style={{ display: 'flex', alignItems: 'center', gap: '2px', marginLeft: 'auto' }}>
-                <ShowSearchPopover />
-                <EnterFullScreen />
-              </div>
-            </div>
-          );
-        }}
-      </Toolbar>
-    ),
-  });
-
-  return (
-    <div className="flex flex-col h-full">
-      {/* Modal Header with Download and Close */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-card shrink-0">
-        <span className="font-semibold text-sm">PDF Preview</span>
-        <div className="flex items-center gap-1">
-          <Button
-            variant="default"
-            size="sm"
-            onClick={onDownload}
-            className="h-8 px-3"
-          >
-            <Download className="h-4 w-4 mr-1.5" />
-            Download
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            onClick={onClose}
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
-
-      {/* PDF Viewer */}
-      <div className="flex-1 overflow-hidden">
-        <Worker workerUrl={PDFJS_WORKER_URL}>
-          <div style={{ height: 'calc(100vh - 52px)' }}>
-            <Viewer
-              fileUrl={pdfUrl}
-              plugins={[defaultLayoutPluginInstance]}
-              defaultScale={isPhone ? 0.5 : 1}
-              transformGetDocumentParams={transformPdfParamsHardened}
-            />
-          </div>
-        </Worker>
-      </div>
-    </div>
-  );
-}
-
 export function MobilePreviewModal({ pdfUrl, isCompiling, error }: MobilePreviewModalProps) {
   // Individual selectors — modal only re-renders on its own flag changing.
   const mobilePreviewOpen = useUIStore((s) => s.mobilePreviewOpen);
   const setMobilePreviewOpen = useUIStore((s) => s.setMobilePreviewOpen);
   const { setOpen: setLogViewerOpen, setEnabled: setLogEnabled } = useLogStore();
-  const [numPages, setNumPages] = useState<number>(0);
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  const [viewportWidth, setViewportWidth] = useState<number>(window.innerWidth);
-  const pageRefs = useRef<Map<number, HTMLDivElement>>(new Map());
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
 
-  // Track viewport width reactively for device rotation
-  useEffect(() => {
-    const handleResize = () => setViewportWidth(window.innerWidth);
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  // Use centralized device detection
-  const deviceInfo = useDeviceInfo();
-
-  useEffect(() => {
-    if (deviceInfo.isIOS) {
-      debug.log('MobilePreview', 'iOS detected - using react-pdf-viewer');
-      debug.log('MobilePreview', 'Device:', { isIOS: deviceInfo.isIOS, isIPad: deviceInfo.isIPad, isIPhone: deviceInfo.isIPhone });
-    }
-  }, [deviceInfo]);
-
-  // Reset to page 1 when the modal opens or the PDF source changes.
-  // currentPage is also mutated by user scrolling/page navigation, so
-  // it can't be purely derived from the open/url inputs -- it has to
-  // be state. Reset-on-input-change pattern (analogous to FindReplaceModal
-  // resetting currentMatchIndex on search-input change).
-  useEffect(() => {
-    if (mobilePreviewOpen && pdfUrl) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setCurrentPage(1);
-    }
-  }, [mobilePreviewOpen, pdfUrl]);
-
-  // Filter out engine reset message
+  // Filter out engine reset message — it's not a user-facing error.
   const displayError = error === 'ENGINE_RESET_NEEDED' ? null : error;
 
   const handleOpenLogs = () => {
@@ -335,50 +39,11 @@ export function MobilePreviewModal({ pdfUrl, isCompiling, error }: MobilePreview
     setLogViewerOpen(true);
   };
 
-  const onDocumentLoadSuccess = useCallback(({ numPages }: { numPages: number }) => {
-    setNumPages(numPages);
-    setCurrentPage(1);
-  }, []);
-
-  const onDocumentLoadError = useCallback((err: Error) => {
-    debug.error('MobilePreview', 'PDF load error:', err?.message || err);
-  }, []);
-
-  // Track visible page via IntersectionObserver
-  useEffect(() => {
-    if (!mobilePreviewOpen || numPages === 0) return;
-
-    // Defer observer setup to ensure page refs are populated after async render
-    const rafId = requestAnimationFrame(() => {
-      const observer = new IntersectionObserver(
-        (entries) => {
-          for (const entry of entries) {
-            if (entry.isIntersecting) {
-              const pageNum = Number(entry.target.getAttribute('data-page'));
-              if (pageNum) setCurrentPage(pageNum);
-            }
-          }
-        },
-        { root: scrollContainerRef.current, threshold: 0.5 }
-      );
-
-      pageRefs.current.forEach((el) => observer.observe(el));
-      observerRef.current = observer;
-    });
-
-    const observerRef = { current: null as IntersectionObserver | null };
-    return () => {
-      cancelAnimationFrame(rafId);
-      observerRef.current?.disconnect();
-    };
-  }, [mobilePreviewOpen, numPages]);
-
-  // Download handler using centralized download utility
+  // Download via the centralized platform-aware utility (iOS needs a window
+  // pre-opened inside the user gesture).
   const handleDownload = async () => {
     if (!pdfUrl) return;
-
     const preOpenedWindow = preOpenWindowForIOS();
-
     try {
       const response = await fetch(pdfUrl);
       const blob = await response.blob();
@@ -395,25 +60,6 @@ export function MobilePreviewModal({ pdfUrl, isCompiling, error }: MobilePreview
 
   if (!mobilePreviewOpen) return null;
 
-  // iOS (iPhone AND iPad): Use react-pdf-viewer
-  // This is the ONLY viewer that works reliably on iOS
-  // - react-pdf crashes due to canvas memory limits
-  // - iframe shows black screen on iPad
-  if (deviceInfo.isIOS && pdfUrl && !isCompiling && !displayError) {
-    const isPhone = !deviceInfo.isIPad; // iPhone/iPod = phone, iPad = tablet
-    return (
-      <div className="fixed inset-0 z-50 bg-background flex flex-col">
-        <IOSPdfViewer
-          pdfUrl={pdfUrl}
-          onClose={() => setMobilePreviewOpen(false)}
-          onDownload={handleDownload}
-          isPhone={isPhone}
-        />
-      </div>
-    );
-  }
-
-  // Non-iOS fallback: Standard modal with react-pdf
   return (
     <div className="fixed inset-0 z-50 bg-background flex flex-col">
       {/* Header */}
@@ -421,22 +67,12 @@ export function MobilePreviewModal({ pdfUrl, isCompiling, error }: MobilePreview
         <span className="font-semibold text-sm">PDF Preview</span>
         <div className="flex items-center gap-1">
           {pdfUrl && !isCompiling && (
-            <Button
-              variant="default"
-              size="sm"
-              onClick={handleDownload}
-              className="h-8 px-3"
-            >
+            <Button variant="default" size="sm" onClick={handleDownload} className="h-8 px-3">
               <Download className="h-4 w-4 mr-1.5" />
               Download
             </Button>
           )}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            onClick={handleOpenLogs}
-          >
+          <Button variant="ghost" size="icon" className="h-8 w-8" onClick={handleOpenLogs}>
             <ScrollText className="h-4 w-4" />
           </Button>
           <Button
@@ -450,9 +86,8 @@ export function MobilePreviewModal({ pdfUrl, isCompiling, error }: MobilePreview
         </div>
       </div>
 
-      {/* PDF Content */}
-      <div className="flex-1 overflow-auto bg-muted/30">
-        {/* Loading State */}
+      {/* Content */}
+      <div className="flex-1 min-h-0">
         {isCompiling && (
           <div className="flex flex-col items-center justify-center h-full gap-4">
             <div className="relative">
@@ -466,7 +101,6 @@ export function MobilePreviewModal({ pdfUrl, isCompiling, error }: MobilePreview
           </div>
         )}
 
-        {/* Compilation Error State */}
         {displayError && !pdfUrl && !isCompiling && (
           <div className="flex flex-col items-center justify-center h-full gap-4 p-4">
             <AlertCircle className="h-16 w-16 text-destructive/70" />
@@ -481,84 +115,21 @@ export function MobilePreviewModal({ pdfUrl, isCompiling, error }: MobilePreview
           </div>
         )}
 
-        {/* PDF Viewer - non-iOS: react-pdf scrollable all-pages view */}
-        {/* Note: iframe doesn't work on mobile — browsers can't render blob URLs inline */}
-        {pdfUrl && !isCompiling && (
-          <div
-            ref={scrollContainerRef}
-            className="flex flex-col items-center p-2 gap-4 min-h-full overflow-auto"
-            style={{ touchAction: 'pan-y pinch-zoom' }}
-          >
-            <Document
-              file={pdfUrl}
-              options={HARDENED_PDF_OPTIONS}
-              onLoadSuccess={onDocumentLoadSuccess}
-              onLoadError={onDocumentLoadError}
-              loading={
-                <div className="flex items-center justify-center py-12">
-                  <Loader2 className="h-8 w-8 animate-spin text-primary" />
-                </div>
-              }
-              className="flex flex-col items-center gap-4"
-              error={
-                <div className="flex flex-col items-center justify-center py-12 gap-4">
-                  <AlertCircle className="h-12 w-12 text-destructive/70" />
-                  <p className="text-sm text-muted-foreground">Failed to render PDF</p>
-                  <Button variant="outline" onClick={handleDownload}>
-                    <Download className="h-4 w-4 mr-2" />
-                    Download Instead
-                  </Button>
-                </div>
-              }
-            >
-              {Array.from(new Array(numPages), (_, index) => (
-                <div
-                  key={index}
-                  ref={(el) => { if (el) pageRefs.current.set(index + 1, el); }}
-                  data-page={index + 1}
-                >
-                  <Page
-                    pageNumber={index + 1}
-                    width={Math.min(viewportWidth - 16, 960)}
-                    className="shadow-lg"
-                    renderTextLayer={false}
-                    renderAnnotationLayer={false}
-                    loading={
-                      <div className="flex items-center justify-center py-12">
-                        <Loader2 className="h-6 w-6 animate-spin text-primary" />
-                      </div>
-                    }
-                    error={
-                      <div className="flex items-center justify-center py-12">
-                        <p className="text-sm text-muted-foreground">Error rendering page {index + 1}</p>
-                      </div>
-                    }
-                  />
-                </div>
-              ))}
-            </Document>
+        {/* The modal is already full-screen — hide the redundant fullscreen control. */}
+        {pdfUrl && !isCompiling && <PdfViewer pdfUrl={pdfUrl} showFullscreen={false} />}
 
-            {/* Floating page indicator */}
-            {numPages > 1 && (
-              <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-card/90 backdrop-blur-sm border border-border rounded-full px-3 py-1 text-xs font-medium shadow-lg">
-                Page {currentPage} of {numPages}
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Initial State */}
         {!pdfUrl && !displayError && !isCompiling && (
           <div className="flex flex-col items-center justify-center h-full gap-4">
             <FileText className="h-16 w-16 text-muted-foreground/30" />
             <div className="text-center">
               <p className="font-medium">No Preview Available</p>
-              <p className="text-sm text-muted-foreground mt-1">Edit your document to generate a preview</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                Edit your document to generate a preview
+              </p>
             </div>
           </div>
         )}
       </div>
-
     </div>
   );
 }

--- a/src/components/pdf/PdfPageLayer.tsx
+++ b/src/components/pdf/PdfPageLayer.tsx
@@ -173,8 +173,7 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
       ref={containerRef}
       onScroll={handleScroll}
       aria-hidden={!visible || undefined}
-      // @ts-expect-error — `inert` is a valid DOM attribute; React's types lag.
-      inert={!visible ? '' : undefined}
+      inert={!visible}
       className={cn(
         'absolute inset-0 overflow-auto overscroll-contain',
         // Hidden pre-render layer: invisible, inert. Fading layer: same, but

--- a/src/components/pdf/PdfPageLayer.tsx
+++ b/src/components/pdf/PdfPageLayer.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { Document, Page } from 'react-pdf';
 import { cn } from '@/lib/utils';
 import { HARDENED_PDF_OPTIONS } from './pdfConfig';
@@ -43,6 +44,12 @@ interface PdfPageLayerProps {
   initialScrollTop?: number;
   /** Fade the layer out (promotion crossfade). */
   fadingOut?: boolean;
+  /** Where the thumbnail rail lives (a sibling column). Thumbnails portal out
+   *  of this layer's <Document> so they share the parsed document — no second
+   *  parse, and they follow document swaps for free. Active layer only. */
+  thumbPortalTarget?: HTMLElement | null;
+  /** 1-based page highlighted in the rail. */
+  currentPage?: number;
   onDocMeta?: (gen: number, meta: { numPages: number; baseWidth: number; baseAspect: number }) => void;
   onPageInView?: (page: number) => void;
   /** Hidden layer only: document parsed (numPages known). */
@@ -59,7 +66,7 @@ interface PdfPageLayerProps {
  * the viewer inside iOS's canvas memory budget.
  */
 export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(function PdfPageLayer(
-  { url, gen, pageWidth, dprCap, visible, initialScrollTop = 0, fadingOut = false, onDocMeta, onPageInView, onLoaded, onReady, onFailed },
+  { url, gen, pageWidth, dprCap, visible, initialScrollTop = 0, fadingOut = false, thumbPortalTarget, currentPage, onDocMeta, onPageInView, onLoaded, onReady, onFailed },
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -116,6 +123,16 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, layout.length]);
 
+  const scrollToPage = useCallback(
+    (index: number, smooth: boolean) => {
+      const el = containerRef.current;
+      const target = layout[index];
+      if (!el || !target) return;
+      el.scrollTo({ top: Math.max(0, target.top - PAGE_GAP), behavior: smooth ? 'smooth' : 'auto' });
+    },
+    [layout]
+  );
+
   useImperativeHandle(
     ref,
     () => ({
@@ -125,14 +142,9 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
         if (!el) return;
         el.scrollTop = clampScrollTop(v, el.scrollHeight, el.clientHeight);
       },
-      scrollToPage: (index: number, smooth: boolean) => {
-        const el = containerRef.current;
-        const target = layout[index];
-        if (!el || !target) return;
-        el.scrollTo({ top: Math.max(0, target.top - PAGE_GAP), behavior: smooth ? 'smooth' : 'auto' });
-      },
+      scrollToPage,
     }),
-    [layout]
+    [scrollToPage]
   );
 
   const handleScroll = useCallback(() => {
@@ -258,6 +270,51 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
             );
           })}
         </div>
+        {/* Thumbnail rail: portaled to the sibling column but rendered INSIDE
+            this <Document>, so the thumbs draw from the same parsed document
+            (react-pdf's context crosses the portal). Tiny canvases at dpr 1 —
+            even a 50-page merged doc costs single-digit MB. */}
+        {visible &&
+          thumbPortalTarget &&
+          numPages > 0 &&
+          createPortal(
+            <div className="flex flex-col gap-2 p-2">
+              {Array.from({ length: numPages }, (_, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => scrollToPage(i, true)}
+                  aria-label={`Go to page ${i + 1}`}
+                  aria-current={currentPage === i + 1 ? 'page' : undefined}
+                  className={cn(
+                    'shrink-0 rounded-sm outline-none transition-shadow focus-visible:ring-2 focus-visible:ring-ring/60',
+                    currentPage === i + 1
+                      ? 'ring-2 ring-primary'
+                      : 'ring-1 ring-black/10 hover:ring-ring/60 dark:ring-white/10'
+                  )}
+                >
+                  <Page
+                    pageNumber={i + 1}
+                    width={72}
+                    devicePixelRatio={1}
+                    renderTextLayer={false}
+                    renderAnnotationLayer={false}
+                    loading={
+                      <div
+                        className="bg-white/70"
+                        style={{ width: 72, height: 72 / (aspects[i] ?? DEFAULT_PAGE_ASPECT) }}
+                      />
+                    }
+                    error={null}
+                  />
+                  <span className="tnum block py-0.5 text-center text-[10px] text-muted-foreground">
+                    {i + 1}
+                  </span>
+                </button>
+              ))}
+            </div>,
+            thumbPortalTarget
+          )}
       </Document>
     </div>
   );

--- a/src/components/pdf/PdfPageLayer.tsx
+++ b/src/components/pdf/PdfPageLayer.tsx
@@ -77,7 +77,18 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
     return computePageLayout(filled, pageWidth, PAGE_GAP, LAYER_PAD);
   }, [numPages, aspects, pageWidth]);
 
-  const viewportHeight = containerRef.current?.clientHeight ?? 800;
+  // Viewport height is measured state (refs must not be read during render);
+  // 800 is a safe pre-measure default — it only widens the first window.
+  const [viewportHeight, setViewportHeight] = useState(800);
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    setViewportHeight(el.clientHeight);
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => setViewportHeight(el.clientHeight));
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   // Render window: the visible layer follows its own scroll; the hidden layer
   // pre-renders around the scroll position it will be promoted at.
@@ -86,6 +97,24 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
     () => visibleRange(anchor, viewportHeight, layout, visible ? viewportHeight : 0),
     [anchor, viewportHeight, layout, visible]
   );
+
+  // Hidden-layer readiness bookkeeping: once the layout exists, record which
+  // restore-window pages must paint before this layer reports ready. Runs in
+  // an effect (never during render) and at most once per layer instance —
+  // onRenderSuccess drains the set as pages paint.
+  useEffect(() => {
+    if (visible || !onReady || layout.length === 0 || pendingRenderRef.current !== null) return;
+    const pending = new Set<number>();
+    for (let i = first; i <= last; i++) pending.add(i);
+    if (pending.size === 0) {
+      onReady(gen);
+      return;
+    }
+    pendingRenderRef.current = pending;
+    // The window is captured at first-layout on purpose; later window shifts
+    // belong to the promoted (visible) phase.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, layout.length]);
 
   useImperativeHandle(
     ref,
@@ -226,44 +255,8 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
           })}
         </div>
       </Document>
-      {/* Hidden-layer readiness bookkeeping: once the layout is known, record
-          which restore-window pages must paint before promotion. */}
-      {!visible && layout.length > 0 && pendingRenderRef.current === null && onReady && (
-        <TrackPending firstIndex={first} lastIndex={last} pendingRef={pendingRenderRef} onEmpty={() => onReady(gen)} />
-      )}
     </div>
   );
 });
-
-/** Initializes the pending-render set exactly once per (hidden) layer. Rendered
- *  as a null component so the initialization participates in the same commit
- *  as the first windowed <Page> mount. */
-function TrackPending({
-  firstIndex,
-  lastIndex,
-  pendingRef,
-  onEmpty,
-}: {
-  firstIndex: number;
-  lastIndex: number;
-  pendingRef: React.MutableRefObject<Set<number> | null>;
-  onEmpty: () => void;
-}) {
-  useEffect(() => {
-    if (pendingRef.current !== null) return;
-    const pending = new Set<number>();
-    for (let i = firstIndex; i <= lastIndex; i++) pending.add(i);
-    if (pending.size === 0) {
-      onEmpty();
-      return;
-    }
-    pendingRef.current = pending;
-    // Pages already painted before this effect ran can't call back — but
-    // onRenderSuccess always fires after mount, and this effect runs in the
-    // same commit as the first windowed Page mount, so no callback is missed.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  return null;
-}
 
 export default PdfPageLayer;

--- a/src/components/pdf/PdfPageLayer.tsx
+++ b/src/components/pdf/PdfPageLayer.tsx
@@ -43,7 +43,7 @@ interface PdfPageLayerProps {
   initialScrollTop?: number;
   /** Fade the layer out (promotion crossfade). */
   fadingOut?: boolean;
-  onDocMeta?: (gen: number, meta: { numPages: number; baseWidth: number }) => void;
+  onDocMeta?: (gen: number, meta: { numPages: number; baseWidth: number; baseAspect: number }) => void;
   onPageInView?: (page: number) => void;
   /** Hidden layer only: document parsed (numPages known). */
   onLoaded?: (gen: number) => void;
@@ -208,8 +208,13 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
           ).then((resolved) => setAspects(resolved));
           void doc
             .getPage(1)
-            .then((p) => onDocMeta?.(gen, { numPages: doc.numPages, baseWidth: p.getViewport({ scale: 1 }).width }))
-            .catch(() => onDocMeta?.(gen, { numPages: doc.numPages, baseWidth: pageWidth }));
+            .then((p) => {
+              const vp = p.getViewport({ scale: 1 });
+              onDocMeta?.(gen, { numPages: doc.numPages, baseWidth: vp.width, baseAspect: vp.width / vp.height });
+            })
+            .catch(() =>
+              onDocMeta?.(gen, { numPages: doc.numPages, baseWidth: pageWidth, baseAspect: DEFAULT_PAGE_ASPECT })
+            );
           if (visible) onPageInView?.(1);
         }}
         onLoadError={() => onFailed?.(gen)}

--- a/src/components/pdf/PdfPageLayer.tsx
+++ b/src/components/pdf/PdfPageLayer.tsx
@@ -278,7 +278,11 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
           thumbPortalTarget &&
           numPages > 0 &&
           createPortal(
-            <div className="flex flex-col gap-2 p-2">
+            // Mirrors the retired plugin's thumbnail anatomy: items centered in
+            // the rail, the selection ring drawn TIGHT on the page image (a
+            // stretched frame reads as broken page margins), and the page
+            // number below the frame rather than inside it.
+            <div className="flex flex-col items-center gap-3 p-2">
               {Array.from({ length: numPages }, (_, i) => (
                 <button
                   key={i}
@@ -286,28 +290,37 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
                   onClick={() => scrollToPage(i, true)}
                   aria-label={`Go to page ${i + 1}`}
                   aria-current={currentPage === i + 1 ? 'page' : undefined}
-                  className={cn(
-                    'shrink-0 rounded-sm outline-none transition-shadow focus-visible:ring-2 focus-visible:ring-ring/60',
-                    currentPage === i + 1
-                      ? 'ring-2 ring-primary'
-                      : 'ring-1 ring-black/10 hover:ring-ring/60 dark:ring-white/10'
-                  )}
+                  className="group flex w-fit shrink-0 flex-col items-center gap-1 outline-none"
                 >
-                  <Page
-                    pageNumber={i + 1}
-                    width={72}
-                    devicePixelRatio={1}
-                    renderTextLayer={false}
-                    renderAnnotationLayer={false}
-                    loading={
-                      <div
-                        className="bg-white/70"
-                        style={{ width: 72, height: 72 / (aspects[i] ?? DEFAULT_PAGE_ASPECT) }}
-                      />
-                    }
-                    error={null}
-                  />
-                  <span className="tnum block py-0.5 text-center text-[10px] text-muted-foreground">
+                  <div
+                    className={cn(
+                      'overflow-hidden rounded-[3px] bg-white transition-shadow',
+                      currentPage === i + 1
+                        ? 'ring-2 ring-primary'
+                        : 'ring-1 ring-black/10 group-hover:ring-ring/60 group-focus-visible:ring-2 group-focus-visible:ring-ring/60 dark:ring-white/10'
+                    )}
+                  >
+                    <Page
+                      pageNumber={i + 1}
+                      width={72}
+                      devicePixelRatio={dprCap}
+                      renderTextLayer={false}
+                      renderAnnotationLayer={false}
+                      loading={
+                        <div
+                          className="bg-white/70"
+                          style={{ width: 72, height: 72 / (aspects[i] ?? DEFAULT_PAGE_ASPECT) }}
+                        />
+                      }
+                      error={null}
+                    />
+                  </div>
+                  <span
+                    className={cn(
+                      'tnum text-[10px]',
+                      currentPage === i + 1 ? 'font-medium text-foreground' : 'text-muted-foreground'
+                    )}
+                  >
                     {i + 1}
                   </span>
                 </button>

--- a/src/components/pdf/PdfPageLayer.tsx
+++ b/src/components/pdf/PdfPageLayer.tsx
@@ -1,0 +1,269 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Document, Page } from 'react-pdf';
+import { cn } from '@/lib/utils';
+import { HARDENED_PDF_OPTIONS } from './pdfConfig';
+import {
+  computePageLayout,
+  contentHeight,
+  visibleRange,
+  currentPage as currentPageAt,
+  clampScrollTop,
+  DEFAULT_PAGE_ASPECT,
+  type PageLayout,
+} from './pdfMath';
+
+/** Vertical gap between pages and mat padding, in CSS px. */
+export const PAGE_GAP = 16;
+export const LAYER_PAD = 24;
+
+export interface PdfPageLayerHandle {
+  getScrollTop: () => number;
+  setScrollTop: (v: number) => void;
+  scrollToPage: (index: number, smooth: boolean) => void;
+}
+
+interface PdfPageLayerProps {
+  url: string;
+  gen: number;
+  pageWidth: number;
+  dprCap: number;
+  /** Visible (active) layer: owns scrolling and reports page metadata.
+   *  Hidden (incoming) layer: pre-renders the restore window only. */
+  visible: boolean;
+  /** For the hidden layer: the active layer's scrollTop, so the pages the user
+   *  is looking at are the ones pre-rendered before promotion. */
+  initialScrollTop?: number;
+  /** Fade the layer out (promotion crossfade). */
+  fadingOut?: boolean;
+  onDocMeta?: (gen: number, meta: { numPages: number; baseWidth: number }) => void;
+  onPageInView?: (page: number) => void;
+  /** Hidden layer only: document parsed (numPages known). */
+  onLoaded?: (gen: number) => void;
+  /** Hidden layer only: restore-window pages painted. */
+  onReady?: (gen: number) => void;
+  onFailed?: (gen: number) => void;
+}
+
+/**
+ * One pdf.js document with a virtualized page stack in its own scroll
+ * container. Pages outside the render window are fixed-size placeholders —
+ * their canvases unmount and free their backing stores, which is what keeps
+ * the viewer inside iOS's canvas memory budget.
+ */
+export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(function PdfPageLayer(
+  { url, gen, pageWidth, dprCap, visible, initialScrollTop = 0, fadingOut = false, onDocMeta, onPageInView, onLoaded, onReady, onFailed },
+  ref
+) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [numPages, setNumPages] = useState(0);
+  const [aspects, setAspects] = useState<number[]>([]);
+  const [scrollTop, setScrollTop] = useState(initialScrollTop);
+  const rafRef = useRef<number | null>(null);
+  // Restore-window pages that still need to paint before this (hidden) layer
+  // reports ready. Mutated as onRenderSuccess fires; null = not tracking.
+  const pendingRenderRef = useRef<Set<number> | null>(null);
+
+  const layout: PageLayout[] = useMemo(() => {
+    if (numPages === 0) return [];
+    const filled = Array.from({ length: numPages }, (_, i) => aspects[i] ?? DEFAULT_PAGE_ASPECT);
+    return computePageLayout(filled, pageWidth, PAGE_GAP, LAYER_PAD);
+  }, [numPages, aspects, pageWidth]);
+
+  const viewportHeight = containerRef.current?.clientHeight ?? 800;
+
+  // Render window: the visible layer follows its own scroll; the hidden layer
+  // pre-renders around the scroll position it will be promoted at.
+  const anchor = visible ? scrollTop : initialScrollTop;
+  const [first, last] = useMemo(
+    () => visibleRange(anchor, viewportHeight, layout, visible ? viewportHeight : 0),
+    [anchor, viewportHeight, layout, visible]
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getScrollTop: () => containerRef.current?.scrollTop ?? 0,
+      setScrollTop: (v: number) => {
+        const el = containerRef.current;
+        if (!el) return;
+        el.scrollTop = clampScrollTop(v, el.scrollHeight, el.clientHeight);
+      },
+      scrollToPage: (index: number, smooth: boolean) => {
+        const el = containerRef.current;
+        const target = layout[index];
+        if (!el || !target) return;
+        el.scrollTo({ top: Math.max(0, target.top - PAGE_GAP), behavior: smooth ? 'smooth' : 'auto' });
+      },
+    }),
+    [layout]
+  );
+
+  const handleScroll = useCallback(() => {
+    if (!visible) return;
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const el = containerRef.current;
+      if (!el) return;
+      setScrollTop(el.scrollTop);
+      onPageInView?.(currentPageAt(el.scrollTop, el.clientHeight, layout));
+    });
+  }, [visible, layout, onPageInView]);
+
+  useEffect(
+    () => () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    },
+    []
+  );
+
+  // Promotion: this layer was pre-rendering hidden and just became the active
+  // one. Its DOM scrollTop was set imperatively during the hand-off — sync the
+  // internal state so the render window and page indicator anchor correctly
+  // before the first real scroll event.
+  useEffect(() => {
+    if (!visible) return;
+    const el = containerRef.current;
+    if (!el) return;
+    setScrollTop(el.scrollTop);
+    onPageInView?.(currentPageAt(el.scrollTop, el.clientHeight, layout));
+    // Only on the visibility flip — layout/callback identity churn must not re-run this.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
+
+  return (
+    <div
+      ref={containerRef}
+      onScroll={handleScroll}
+      aria-hidden={!visible || undefined}
+      // @ts-expect-error — `inert` is a valid DOM attribute; React's types lag.
+      inert={!visible ? '' : undefined}
+      className={cn(
+        'absolute inset-0 overflow-auto overscroll-contain',
+        // Hidden pre-render layer: invisible, inert. Fading layer: same, but
+        // with a transition so it dissolves over the promoted one (the global
+        // prefers-reduced-motion rule collapses the duration; the fade is also
+        // skipped entirely at the call site under reduced motion).
+        !visible && 'pointer-events-none opacity-0',
+        fadingOut && 'transition-opacity duration-150'
+      )}
+      data-pdf-layer={visible ? 'active' : 'incoming'}
+    >
+      <Document
+        file={url}
+        options={HARDENED_PDF_OPTIONS}
+        loading={null}
+        error={null}
+        onLoadSuccess={(doc) => {
+          setNumPages(doc.numPages);
+          onLoaded?.(gen);
+          // Resolve real aspect ratios (fast post-parse); placeholders use the
+          // US-Letter default meanwhile, which is exact for this app's output.
+          void Promise.all(
+            Array.from({ length: doc.numPages }, (_, i) =>
+              doc
+                .getPage(i + 1)
+                .then((p) => {
+                  const vp = p.getViewport({ scale: 1 });
+                  return vp.width / vp.height;
+                })
+                .catch(() => DEFAULT_PAGE_ASPECT)
+            )
+          ).then((resolved) => setAspects(resolved));
+          void doc
+            .getPage(1)
+            .then((p) => onDocMeta?.(gen, { numPages: doc.numPages, baseWidth: p.getViewport({ scale: 1 }).width }))
+            .catch(() => onDocMeta?.(gen, { numPages: doc.numPages, baseWidth: pageWidth }));
+          if (visible) onPageInView?.(1);
+        }}
+        onLoadError={() => onFailed?.(gen)}
+        onSourceError={() => onFailed?.(gen)}
+      >
+        <div className="relative" style={{ height: contentHeight(layout, LAYER_PAD) }}>
+          {layout.map((p, i) => {
+            const inWindow = i >= first && i <= last;
+            return (
+              <div
+                key={i}
+                className="absolute inset-x-0 flex justify-center"
+                style={{ top: p.top }}
+              >
+                <div
+                  className="bg-white shadow-md ring-1 ring-black/5 dark:ring-white/10"
+                  style={{ width: pageWidth, height: p.height }}
+                >
+                  {inWindow && (
+                    <Page
+                      pageNumber={i + 1}
+                      width={pageWidth}
+                      devicePixelRatio={dprCap}
+                      renderTextLayer={false}
+                      renderAnnotationLayer={false}
+                      loading={null}
+                      error={null}
+                      onRenderSuccess={() => {
+                        const pending = pendingRenderRef.current;
+                        if (!pending) return;
+                        pending.delete(i);
+                        if (pending.size === 0) {
+                          pendingRenderRef.current = null;
+                          onReady?.(gen);
+                        }
+                      }}
+                    />
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </Document>
+      {/* Hidden-layer readiness bookkeeping: once the layout is known, record
+          which restore-window pages must paint before promotion. */}
+      {!visible && layout.length > 0 && pendingRenderRef.current === null && onReady && (
+        <TrackPending firstIndex={first} lastIndex={last} pendingRef={pendingRenderRef} onEmpty={() => onReady(gen)} />
+      )}
+    </div>
+  );
+});
+
+/** Initializes the pending-render set exactly once per (hidden) layer. Rendered
+ *  as a null component so the initialization participates in the same commit
+ *  as the first windowed <Page> mount. */
+function TrackPending({
+  firstIndex,
+  lastIndex,
+  pendingRef,
+  onEmpty,
+}: {
+  firstIndex: number;
+  lastIndex: number;
+  pendingRef: React.MutableRefObject<Set<number> | null>;
+  onEmpty: () => void;
+}) {
+  useEffect(() => {
+    if (pendingRef.current !== null) return;
+    const pending = new Set<number>();
+    for (let i = firstIndex; i <= lastIndex; i++) pending.add(i);
+    if (pending.size === 0) {
+      onEmpty();
+      return;
+    }
+    pendingRef.current = pending;
+    // Pages already painted before this effect ran can't call back — but
+    // onRenderSuccess always fires after mount, and this effect runs in the
+    // same commit as the first windowed Page mount, so no callback is missed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return null;
+}
+
+export default PdfPageLayer;

--- a/src/components/pdf/PdfViewer.tsx
+++ b/src/components/pdf/PdfViewer.tsx
@@ -50,6 +50,10 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
   const [docMeta, setDocMeta] = useState<{ numPages: number; baseWidth: number } | null>(null);
   const [pageInView, setPageInView] = useState(1);
   const [loadFailed, setLoadFailed] = useState(false);
+  // The active layer's scroll position at the moment an incoming document was
+  // staged — the hidden layer pre-renders around it. Captured in an effect
+  // (refs are off-limits during render).
+  const [stagedScrollTop, setStagedScrollTop] = useState(0);
   // The just-replaced layer, kept mounted briefly (same key → same instance)
   // so it can fade out over the promoted one.
   const [fadingSlot, setFadingSlot] = useState<DocSlot | null>(null);
@@ -83,6 +87,13 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
     },
     []
   );
+
+  const incomingGen = state.incoming?.gen ?? null;
+  useEffect(() => {
+    if (incomingGen !== null) {
+      setStagedScrollTop(activeLayerRef.current?.getScrollTop() ?? 0);
+    }
+  }, [incomingGen]);
 
   // Meta comes from whichever layer loaded most recently (the incoming layer
   // reports during pre-render, so a page-count change is reflected by the time
@@ -166,7 +177,7 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
             pageWidth={pageWidth}
             dprCap={dprCap}
             visible={false}
-            initialScrollTop={activeLayerRef.current?.getScrollTop() ?? 0}
+            initialScrollTop={stagedScrollTop}
             onDocMeta={handleDocMeta}
             onLoaded={onIncomingLoaded}
             onReady={handleIncomingReady}

--- a/src/components/pdf/PdfViewer.tsx
+++ b/src/components/pdf/PdfViewer.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AlertCircle, ExternalLink } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+import { useDeviceInfo } from '@/utils/device';
+import { cn } from '@/lib/utils';
+// Side effect: sets the single pdf.js workerSrc for the whole app.
+import { getDprCap } from './pdfConfig';
+import { usePdfDocumentSwap, type DocSlot } from './usePdfDocumentSwap';
+import { usePdfZoom } from './usePdfZoom';
+import { useFullscreen } from './useFullscreen';
+import { PdfPageLayer, type PdfPageLayerHandle } from './PdfPageLayer';
+import { PdfViewerToolbar } from './PdfViewerToolbar';
+
+export interface PdfViewerProps {
+  pdfUrl: string;
+  className?: string;
+  /** Hide the fullscreen control (the mobile modal is already fullscreen). */
+  showFullscreen?: boolean;
+}
+
+/**
+ * The unified in-app PDF viewer — one component for the desktop preview panel
+ * and the mobile preview modal. Pages render as paper floating on the app's
+ * mat with a slim design-language toolbar, and recompiled documents swap in
+ * place: the outgoing document stays visible while the incoming one
+ * pre-renders in a hidden layer at the same geometry, then the old layer
+ * crossfades away on top of the new one. No white flash, no scroll jump.
+ *
+ * Layer lifecycle on a recompile (URL change):
+ *   1. active layer (gen N) keeps rendering; a hidden layer (gen N+1) mounts,
+ *      loads the new blob, and paints the pages around the current scrollTop.
+ *   2. on ready (or a 1.2s safety timeout) the active scrollTop is copied to
+ *      the hidden layer, the swap machine promotes gen N+1, and — because both
+ *      layers are keyed by generation — React preserves the freshly painted
+ *      instance as the new active layer.
+ *   3. the old gen N layer sticks around ~180ms with a fade-out class (skipped
+ *      under prefers-reduced-motion), then unmounts.
+ */
+export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: PdfViewerProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const activeLayerRef = useRef<PdfPageLayerHandle>(null);
+  const incomingLayerRef = useRef<PdfPageLayerHandle>(null);
+  const reducedMotion = useReducedMotion();
+  const deviceInfo = useDeviceInfo();
+  const dprCap = getDprCap(deviceInfo.isIOS);
+
+  const { state, onIncomingLoaded, onIncomingReady, onIncomingFailed } = usePdfDocumentSwap(pdfUrl);
+
+  const [docMeta, setDocMeta] = useState<{ numPages: number; baseWidth: number } | null>(null);
+  const [pageInView, setPageInView] = useState(1);
+  const [loadFailed, setLoadFailed] = useState(false);
+  // The just-replaced layer, kept mounted briefly (same key → same instance)
+  // so it can fade out over the promoted one.
+  const [fadingSlot, setFadingSlot] = useState<DocSlot | null>(null);
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const { mode, pageWidth, effectiveScale, zoomStep, zoomFit } = usePdfZoom(
+    rootRef,
+    docMeta?.baseWidth ?? null
+  );
+  const fullscreen = useFullscreen(rootRef);
+
+  // Promotion hand-off: copy the active layer's scroll position onto the
+  // incoming layer, start the old layer's fade, THEN promote.
+  const handleIncomingReady = useCallback(
+    (gen: number) => {
+      const scrollTop = activeLayerRef.current?.getScrollTop() ?? 0;
+      incomingLayerRef.current?.setScrollTop(scrollTop);
+      if (!reducedMotion && state.active) {
+        setFadingSlot(state.active);
+        if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+        fadeTimerRef.current = setTimeout(() => setFadingSlot(null), 180);
+      }
+      onIncomingReady(gen);
+    },
+    [onIncomingReady, reducedMotion, state.active]
+  );
+
+  useEffect(
+    () => () => {
+      if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+    },
+    []
+  );
+
+  // Meta comes from whichever layer loaded most recently (the incoming layer
+  // reports during pre-render, so a page-count change is reflected by the time
+  // it's promoted).
+  const handleDocMeta = useCallback((_gen: number, meta: { numPages: number; baseWidth: number }) => {
+    setDocMeta(meta);
+    setLoadFailed(false);
+  }, []);
+
+  const handleActiveFailed = useCallback(() => setLoadFailed(true), []);
+
+  const openInTab = useCallback(() => {
+    window.open(pdfUrl, '_blank', 'noopener');
+  }, [pdfUrl]);
+
+  const goToPage = useCallback(
+    (delta: 1 | -1) => {
+      activeLayerRef.current?.scrollToPage(pageInView - 1 + delta, !reducedMotion);
+    },
+    [pageInView, reducedMotion]
+  );
+
+  if (loadFailed) {
+    return (
+      <div className={cn('flex h-full flex-col items-center justify-center gap-3 p-6', className)}>
+        <AlertCircle className="h-8 w-8 text-muted-foreground" />
+        <p className="max-w-[22rem] text-center text-sm text-muted-foreground">
+          The preview couldn&apos;t be rendered here.
+        </p>
+        <Button type="button" variant="outline" size="sm" onClick={openInTab}>
+          <ExternalLink className="mr-1.5 h-3.5 w-3.5" /> Open in browser tab
+        </Button>
+      </div>
+    );
+  }
+
+  const showFading = fadingSlot && fadingSlot.gen !== (state.active?.gen ?? -1);
+
+  return (
+    <div
+      ref={rootRef}
+      className={cn(
+        'flex h-full flex-col bg-[color-mix(in_oklab,var(--muted)_60%,var(--background))]',
+        className
+      )}
+    >
+      <PdfViewerToolbar
+        page={pageInView}
+        pageCount={docMeta?.numPages ?? 0}
+        zoomPercent={Math.round(effectiveScale * 100)}
+        isFitWidth={mode.kind === 'fit-width'}
+        onPrevPage={() => goToPage(-1)}
+        onNextPage={() => goToPage(1)}
+        onZoomIn={() => zoomStep(1)}
+        onZoomOut={() => zoomStep(-1)}
+        onZoomFit={zoomFit}
+        onOpenInTab={openInTab}
+        fullscreen={showFullscreen && fullscreen.available ? fullscreen : null}
+      />
+      <div className="relative min-h-0 flex-1">
+        {state.active && (
+          <PdfPageLayer
+            key={state.active.gen}
+            ref={activeLayerRef}
+            url={state.active.url}
+            gen={state.active.gen}
+            pageWidth={pageWidth}
+            dprCap={dprCap}
+            visible
+            onDocMeta={handleDocMeta}
+            onPageInView={setPageInView}
+            onFailed={handleActiveFailed}
+          />
+        )}
+        {state.incoming && (
+          <PdfPageLayer
+            key={state.incoming.gen}
+            ref={incomingLayerRef}
+            url={state.incoming.url}
+            gen={state.incoming.gen}
+            pageWidth={pageWidth}
+            dprCap={dprCap}
+            visible={false}
+            initialScrollTop={activeLayerRef.current?.getScrollTop() ?? 0}
+            onDocMeta={handleDocMeta}
+            onLoaded={onIncomingLoaded}
+            onReady={handleIncomingReady}
+            onFailed={onIncomingFailed}
+          />
+        )}
+        {showFading && (
+          <PdfPageLayer
+            key={fadingSlot.gen}
+            url={fadingSlot.url}
+            gen={fadingSlot.gen}
+            pageWidth={pageWidth}
+            dprCap={dprCap}
+            visible={false}
+            fadingOut
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/pdf/PdfViewer.tsx
+++ b/src/components/pdf/PdfViewer.tsx
@@ -154,47 +154,56 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
         fullscreen={showFullscreen && fullscreen.available ? fullscreen : null}
       />
       <div className="relative min-h-0 flex-1">
-        {state.active && (
-          <PdfPageLayer
-            key={state.active.gen}
-            ref={activeLayerRef}
-            url={state.active.url}
-            gen={state.active.gen}
-            pageWidth={pageWidth}
-            dprCap={dprCap}
-            visible
-            onDocMeta={handleDocMeta}
-            onPageInView={setPageInView}
-            onFailed={handleActiveFailed}
-          />
-        )}
-        {state.incoming && (
-          <PdfPageLayer
-            key={state.incoming.gen}
-            ref={incomingLayerRef}
-            url={state.incoming.url}
-            gen={state.incoming.gen}
-            pageWidth={pageWidth}
-            dprCap={dprCap}
-            visible={false}
-            initialScrollTop={stagedScrollTop}
-            onDocMeta={handleDocMeta}
-            onLoaded={onIncomingLoaded}
-            onReady={handleIncomingReady}
-            onFailed={onIncomingFailed}
-          />
-        )}
-        {showFading && (
-          <PdfPageLayer
-            key={fadingSlot.gen}
-            url={fadingSlot.url}
-            gen={fadingSlot.gen}
-            pageWidth={pageWidth}
-            dprCap={dprCap}
-            visible={false}
-            fadingOut
-          />
-        )}
+        {/* ONE keyed array on purpose: React only reconciles keys across a
+            single children array, not across separate JSX expression slots.
+            On promotion the incoming element becomes the active one and the
+            old active becomes the fading one — as array siblings their
+            instances (and painted canvases) are preserved; as positional
+            slots they would remount, refetching a revoked blob URL. The
+            fading layer is last so it paints on top while it dissolves. */}
+        {[
+          state.active && (
+            <PdfPageLayer
+              key={state.active.gen}
+              ref={activeLayerRef}
+              url={state.active.url}
+              gen={state.active.gen}
+              pageWidth={pageWidth}
+              dprCap={dprCap}
+              visible
+              onDocMeta={handleDocMeta}
+              onPageInView={setPageInView}
+              onFailed={handleActiveFailed}
+            />
+          ),
+          state.incoming && (
+            <PdfPageLayer
+              key={state.incoming.gen}
+              ref={incomingLayerRef}
+              url={state.incoming.url}
+              gen={state.incoming.gen}
+              pageWidth={pageWidth}
+              dprCap={dprCap}
+              visible={false}
+              initialScrollTop={stagedScrollTop}
+              onDocMeta={handleDocMeta}
+              onLoaded={onIncomingLoaded}
+              onReady={handleIncomingReady}
+              onFailed={onIncomingFailed}
+            />
+          ),
+          showFading && (
+            <PdfPageLayer
+              key={fadingSlot.gen}
+              url={fadingSlot.url}
+              gen={fadingSlot.gen}
+              pageWidth={pageWidth}
+              dprCap={dprCap}
+              visible={false}
+              fadingOut
+            />
+          ),
+        ].filter(Boolean)}
       </div>
     </div>
   );

--- a/src/components/pdf/PdfViewer.tsx
+++ b/src/components/pdf/PdfViewer.tsx
@@ -47,7 +47,7 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
 
   const { state, onIncomingLoaded, onIncomingReady, onIncomingFailed } = usePdfDocumentSwap(pdfUrl);
 
-  const [docMeta, setDocMeta] = useState<{ numPages: number; baseWidth: number } | null>(null);
+  const [docMeta, setDocMeta] = useState<{ numPages: number; baseWidth: number; baseAspect: number } | null>(null);
   const [pageInView, setPageInView] = useState(1);
   const [loadFailed, setLoadFailed] = useState(false);
   // The active layer's scroll position at the moment an incoming document was
@@ -59,9 +59,10 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
   const [fadingSlot, setFadingSlot] = useState<DocSlot | null>(null);
   const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const { mode, pageWidth, effectiveScale, zoomStep, zoomFit } = usePdfZoom(
+  const { mode, pageWidth, effectiveScale, zoomStep, zoomFitWidth, zoomFitPage } = usePdfZoom(
     rootRef,
-    docMeta?.baseWidth ?? null
+    docMeta?.baseWidth ?? null,
+    docMeta?.baseAspect ?? null
   );
   const fullscreen = useFullscreen(rootRef);
 
@@ -98,10 +99,13 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
   // Meta comes from whichever layer loaded most recently (the incoming layer
   // reports during pre-render, so a page-count change is reflected by the time
   // it's promoted).
-  const handleDocMeta = useCallback((_gen: number, meta: { numPages: number; baseWidth: number }) => {
-    setDocMeta(meta);
-    setLoadFailed(false);
-  }, []);
+  const handleDocMeta = useCallback(
+    (_gen: number, meta: { numPages: number; baseWidth: number; baseAspect: number }) => {
+      setDocMeta(meta);
+      setLoadFailed(false);
+    },
+    []
+  );
 
   const handleActiveFailed = useCallback(() => setLoadFailed(true), []);
 
@@ -114,6 +118,14 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
       activeLayerRef.current?.scrollToPage(pageInView - 1 + delta, !reducedMotion);
     },
     [pageInView, reducedMotion]
+  );
+
+  // Direct entry from the toolbar's page input (1-based, pre-clamped there).
+  const goToPageNumber = useCallback(
+    (n: number) => {
+      activeLayerRef.current?.scrollToPage(n - 1, !reducedMotion);
+    },
+    [reducedMotion]
   );
 
   if (loadFailed) {
@@ -144,12 +156,14 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
         page={pageInView}
         pageCount={docMeta?.numPages ?? 0}
         zoomPercent={Math.round(effectiveScale * 100)}
-        isFitWidth={mode.kind === 'fit-width'}
+        fitMode={mode.kind === 'fit-width' ? 'width' : mode.kind === 'fit-page' ? 'page' : null}
+        onGoToPage={goToPageNumber}
         onPrevPage={() => goToPage(-1)}
         onNextPage={() => goToPage(1)}
         onZoomIn={() => zoomStep(1)}
         onZoomOut={() => zoomStep(-1)}
-        onZoomFit={zoomFit}
+        onZoomFitWidth={zoomFitWidth}
+        onZoomFitPage={zoomFitPage}
         onOpenInTab={openInTab}
         fullscreen={showFullscreen && fullscreen.available ? fullscreen : null}
       />

--- a/src/components/pdf/PdfViewer.tsx
+++ b/src/components/pdf/PdfViewer.tsx
@@ -40,6 +40,9 @@ export interface PdfViewerProps {
  */
 export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: PdfViewerProps) {
   const rootRef = useRef<HTMLDivElement>(null);
+  // The column the pages actually live in — this is what fit modes must track
+  // (it shrinks when the thumbnail rail opens; the root does not).
+  const contentRef = useRef<HTMLDivElement>(null);
   const activeLayerRef = useRef<PdfPageLayerHandle>(null);
   const incomingLayerRef = useRef<PdfPageLayerHandle>(null);
   const reducedMotion = useReducedMotion();
@@ -67,7 +70,7 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
   const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { mode, pageWidth, effectiveScale, zoomStep, zoomFitWidth, zoomFitPage } = usePdfZoom(
-    rootRef,
+    contentRef,
     docMeta?.baseWidth ?? null,
     docMeta?.baseAspect ?? null
   );
@@ -187,7 +190,7 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
             aria-label="Page thumbnails"
           />
         )}
-        <div className="relative min-h-0 flex-1">
+        <div ref={contentRef} className="relative min-h-0 flex-1">
         {/* ONE keyed array on purpose: React only reconciles keys across a
             single children array, not across separate JSX expression slots.
             On promotion the incoming element becomes the active one and the

--- a/src/components/pdf/PdfViewer.tsx
+++ b/src/components/pdf/PdfViewer.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
 import { useDeviceInfo } from '@/utils/device';
+import { useUIStore } from '@/stores/uiStore';
 import { cn } from '@/lib/utils';
 // Side effect: sets the single pdf.js workerSrc for the whole app.
 import { getDprCap } from './pdfConfig';
@@ -54,6 +55,12 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
   // staged — the hidden layer pre-renders around it. Captured in an effect
   // (refs are off-limits during render).
   const [stagedScrollTop, setStagedScrollTop] = useState(0);
+  // Thumbnail rail: preference persists; the toggle only exists on 2+ page
+  // documents, so a single-page letter never shows (or pays for) the rail.
+  const thumbsOpen = useUIStore((s) => s.pdfThumbnailsOpen);
+  const setThumbsOpen = useUIStore((s) => s.setPdfThumbnailsOpen);
+  // Callback-ref state so the portal target re-renders the layer when it mounts.
+  const [thumbTarget, setThumbTarget] = useState<HTMLDivElement | null>(null);
   // The just-replaced layer, kept mounted briefly (same key → same instance)
   // so it can fade out over the promoted one.
   const [fadingSlot, setFadingSlot] = useState<DocSlot | null>(null);
@@ -157,6 +164,11 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
         pageCount={docMeta?.numPages ?? 0}
         zoomPercent={Math.round(effectiveScale * 100)}
         fitMode={mode.kind === 'fit-width' ? 'width' : mode.kind === 'fit-page' ? 'page' : null}
+        thumbnails={
+          (docMeta?.numPages ?? 0) >= 2
+            ? { open: thumbsOpen, toggle: () => setThumbsOpen(!thumbsOpen) }
+            : null
+        }
         onGoToPage={goToPageNumber}
         onPrevPage={() => goToPage(-1)}
         onNextPage={() => goToPage(1)}
@@ -167,7 +179,15 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
         onOpenInTab={openInTab}
         fullscreen={showFullscreen && fullscreen.available ? fullscreen : null}
       />
-      <div className="relative min-h-0 flex-1">
+      <div className="flex min-h-0 flex-1">
+        {thumbsOpen && (docMeta?.numPages ?? 0) >= 2 && (
+          <div
+            ref={setThumbTarget}
+            className="w-[104px] shrink-0 overflow-y-auto border-r border-border bg-card/50"
+            aria-label="Page thumbnails"
+          />
+        )}
+        <div className="relative min-h-0 flex-1">
         {/* ONE keyed array on purpose: React only reconciles keys across a
             single children array, not across separate JSX expression slots.
             On promotion the incoming element becomes the active one and the
@@ -185,6 +205,8 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
               pageWidth={pageWidth}
               dprCap={dprCap}
               visible
+              thumbPortalTarget={thumbTarget}
+              currentPage={pageInView}
               onDocMeta={handleDocMeta}
               onPageInView={setPageInView}
               onFailed={handleActiveFailed}
@@ -218,6 +240,7 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
             />
           ),
         ].filter(Boolean)}
+        </div>
       </div>
     </div>
   );

--- a/src/components/pdf/PdfViewerToolbar.tsx
+++ b/src/components/pdf/PdfViewerToolbar.tsx
@@ -99,9 +99,12 @@ export function PdfViewerToolbar({
   };
 
   return (
+    // @container: in narrow panels (rail open, divider dragged tight) the
+    // text readouts yield before any button clips — page entry and every
+    // control stay reachable at the panel's minimum width.
     <div
       className={cn(
-        'flex h-9 shrink-0 items-center gap-1 border-b border-border bg-card px-2',
+        '@container flex h-9 shrink-0 items-center gap-1 overflow-hidden border-b border-border bg-card px-2',
         className
       )}
     >
@@ -135,7 +138,9 @@ export function PdfViewerToolbar({
           onBlur={(e) => commitPage(e.currentTarget)}
           onFocus={(e) => e.currentTarget.select()}
         />
-        <span className="tnum whitespace-nowrap">of {pageCount > 0 ? pageCount : '—'}</span>
+        <span className="tnum hidden whitespace-nowrap @[360px]:inline">
+          of {pageCount > 0 ? pageCount : '—'}
+        </span>
       </span>
 
       <div className="flex-1" />
@@ -143,7 +148,7 @@ export function PdfViewerToolbar({
       <ToolButton label="Zoom out" onClick={onZoomOut}>
         <ZoomOut className="h-4 w-4" />
       </ToolButton>
-      <span className="tnum min-w-[3rem] text-center text-xs text-muted-foreground">
+      <span className="tnum hidden min-w-[3rem] text-center text-xs text-muted-foreground @[420px]:block">
         {zoomPercent}%
       </span>
       <ToolButton label="Zoom in" onClick={onZoomIn}>
@@ -156,7 +161,7 @@ export function PdfViewerToolbar({
         <RectangleVertical className={cn('h-4 w-4', fitMode === 'page' && 'text-primary')} />
       </ToolButton>
 
-      <div className="mx-1 h-4 w-px bg-border" />
+      <div className="mx-1 hidden h-4 w-px bg-border @[420px]:block" />
 
       {fullscreen && (
         <ToolButton

--- a/src/components/pdf/PdfViewerToolbar.tsx
+++ b/src/components/pdf/PdfViewerToolbar.tsx
@@ -5,6 +5,7 @@ import {
   Maximize2,
   Minimize2,
   MoveHorizontal,
+  PanelLeft,
   RectangleVertical,
   ZoomIn,
   ZoomOut,
@@ -18,6 +19,8 @@ interface PdfViewerToolbarProps {
   pageCount: number;
   zoomPercent: number;
   fitMode: 'width' | 'page' | null;
+  /** Thumbnail-rail control; null hides the toggle (single-page documents). */
+  thumbnails: { open: boolean; toggle: () => void } | null;
   onGoToPage: (page: number) => void;
   onPrevPage: () => void;
   onNextPage: () => void;
@@ -71,6 +74,7 @@ export function PdfViewerToolbar({
   pageCount,
   zoomPercent,
   fitMode,
+  thumbnails,
   onGoToPage,
   onPrevPage,
   onNextPage,
@@ -101,6 +105,15 @@ export function PdfViewerToolbar({
         className
       )}
     >
+      {thumbnails && (
+        <ToolButton
+          label={thumbnails.open ? 'Hide page thumbnails' : 'Show page thumbnails'}
+          onClick={thumbnails.toggle}
+          pressed={thumbnails.open}
+        >
+          <PanelLeft className={cn('h-4 w-4', thumbnails.open && 'text-primary')} />
+        </ToolButton>
+      )}
       <ToolButton label="Previous page" onClick={onPrevPage} disabled={page <= 1}>
         <ChevronUp className="h-4 w-4" />
       </ToolButton>

--- a/src/components/pdf/PdfViewerToolbar.tsx
+++ b/src/components/pdf/PdfViewerToolbar.tsx
@@ -1,0 +1,115 @@
+import { ChevronDown, ChevronUp, ExternalLink, Maximize2, Minimize2, Scan, ZoomIn, ZoomOut } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+interface PdfViewerToolbarProps {
+  page: number;
+  pageCount: number;
+  zoomPercent: number;
+  isFitWidth: boolean;
+  onPrevPage: () => void;
+  onNextPage: () => void;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onZoomFit: () => void;
+  onOpenInTab: () => void;
+  fullscreen?: { isFullscreen: boolean; toggle: () => void } | null;
+  className?: string;
+}
+
+function ToolButton({
+  label,
+  onClick,
+  disabled,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          aria-label={label}
+          onClick={onClick}
+          disabled={disabled}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+/** Slim viewer chrome in the app's design language — quiet card bar, tabular
+ *  figures for the page/zoom readouts, unified tooltips. */
+export function PdfViewerToolbar({
+  page,
+  pageCount,
+  zoomPercent,
+  isFitWidth,
+  onPrevPage,
+  onNextPage,
+  onZoomIn,
+  onZoomOut,
+  onZoomFit,
+  onOpenInTab,
+  fullscreen,
+  className,
+}: PdfViewerToolbarProps) {
+  return (
+    <div
+      className={cn(
+        'flex h-9 shrink-0 items-center gap-1 border-b border-border bg-card px-2',
+        className
+      )}
+    >
+      <ToolButton label="Previous page" onClick={onPrevPage} disabled={page <= 1}>
+        <ChevronUp className="h-4 w-4" />
+      </ToolButton>
+      <ToolButton label="Next page" onClick={onNextPage} disabled={page >= pageCount}>
+        <ChevronDown className="h-4 w-4" />
+      </ToolButton>
+      <span className="tnum min-w-[4.5rem] px-1 text-center text-xs text-muted-foreground" aria-live="polite">
+        {pageCount > 0 ? `${page} of ${pageCount}` : '—'}
+      </span>
+
+      <div className="flex-1" />
+
+      <ToolButton label="Zoom out" onClick={onZoomOut}>
+        <ZoomOut className="h-4 w-4" />
+      </ToolButton>
+      <span className="tnum min-w-[3rem] text-center text-xs text-muted-foreground">
+        {zoomPercent}%
+      </span>
+      <ToolButton label="Zoom in" onClick={onZoomIn}>
+        <ZoomIn className="h-4 w-4" />
+      </ToolButton>
+      <ToolButton label={isFitWidth ? 'Fit width (on)' : 'Fit width'} onClick={onZoomFit}>
+        <Scan className={cn('h-4 w-4', isFitWidth && 'text-primary')} />
+      </ToolButton>
+
+      <div className="mx-1 h-4 w-px bg-border" />
+
+      {fullscreen && (
+        <ToolButton
+          label={fullscreen.isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+          onClick={fullscreen.toggle}
+        >
+          {fullscreen.isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+        </ToolButton>
+      )}
+      <ToolButton label="Open in browser tab" onClick={onOpenInTab}>
+        <ExternalLink className="h-4 w-4" />
+      </ToolButton>
+    </div>
+  );
+}

--- a/src/components/pdf/PdfViewerToolbar.tsx
+++ b/src/components/pdf/PdfViewerToolbar.tsx
@@ -1,4 +1,14 @@
-import { ChevronDown, ChevronUp, ExternalLink, Maximize2, Minimize2, Scan, ZoomIn, ZoomOut } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronUp,
+  ExternalLink,
+  Maximize2,
+  Minimize2,
+  MoveHorizontal,
+  RectangleVertical,
+  ZoomIn,
+  ZoomOut,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
@@ -7,12 +17,14 @@ interface PdfViewerToolbarProps {
   page: number;
   pageCount: number;
   zoomPercent: number;
-  isFitWidth: boolean;
+  fitMode: 'width' | 'page' | null;
+  onGoToPage: (page: number) => void;
   onPrevPage: () => void;
   onNextPage: () => void;
   onZoomIn: () => void;
   onZoomOut: () => void;
-  onZoomFit: () => void;
+  onZoomFitWidth: () => void;
+  onZoomFitPage: () => void;
   onOpenInTab: () => void;
   fullscreen?: { isFullscreen: boolean; toggle: () => void } | null;
   className?: string;
@@ -22,11 +34,13 @@ function ToolButton({
   label,
   onClick,
   disabled,
+  pressed,
   children,
 }: {
   label: string;
   onClick: () => void;
   disabled?: boolean;
+  pressed?: boolean;
   children: React.ReactNode;
 }) {
   return (
@@ -38,6 +52,7 @@ function ToolButton({
           size="icon"
           className="h-7 w-7"
           aria-label={label}
+          aria-pressed={pressed}
           onClick={onClick}
           disabled={disabled}
         >
@@ -55,16 +70,30 @@ export function PdfViewerToolbar({
   page,
   pageCount,
   zoomPercent,
-  isFitWidth,
+  fitMode,
+  onGoToPage,
   onPrevPage,
   onNextPage,
   onZoomIn,
   onZoomOut,
-  onZoomFit,
+  onZoomFitWidth,
+  onZoomFitPage,
   onOpenInTab,
   fullscreen,
   className,
 }: PdfViewerToolbarProps) {
+  // Uncontrolled input keyed by the current page: it remounts (and re-seeds)
+  // whenever the page changes from scrolling/buttons, while typing stays local
+  // until Enter/blur commits — no set-state-in-effect syncing needed.
+  const commitPage = (el: HTMLInputElement) => {
+    const n = Math.round(Number(el.value));
+    if (Number.isFinite(n) && n >= 1 && n <= pageCount && n !== page) {
+      onGoToPage(n);
+    } else {
+      el.value = String(page); // invalid or unchanged — restore the readout
+    }
+  };
+
   return (
     <div
       className={cn(
@@ -78,8 +107,22 @@ export function PdfViewerToolbar({
       <ToolButton label="Next page" onClick={onNextPage} disabled={page >= pageCount}>
         <ChevronDown className="h-4 w-4" />
       </ToolButton>
-      <span className="tnum min-w-[4.5rem] px-1 text-center text-xs text-muted-foreground" aria-live="polite">
-        {pageCount > 0 ? `${page} of ${pageCount}` : '—'}
+      <span className="flex items-center gap-1 px-1 text-xs text-muted-foreground">
+        <input
+          key={page}
+          defaultValue={pageCount > 0 ? page : ''}
+          disabled={pageCount === 0}
+          inputMode="numeric"
+          aria-label="Page number"
+          className="tnum h-6 w-9 rounded border border-border bg-background text-center text-xs text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commitPage(e.currentTarget);
+            if (e.key === 'Escape') e.currentTarget.value = String(page);
+          }}
+          onBlur={(e) => commitPage(e.currentTarget)}
+          onFocus={(e) => e.currentTarget.select()}
+        />
+        <span className="tnum whitespace-nowrap">of {pageCount > 0 ? pageCount : '—'}</span>
       </span>
 
       <div className="flex-1" />
@@ -93,8 +136,11 @@ export function PdfViewerToolbar({
       <ToolButton label="Zoom in" onClick={onZoomIn}>
         <ZoomIn className="h-4 w-4" />
       </ToolButton>
-      <ToolButton label={isFitWidth ? 'Fit width (on)' : 'Fit width'} onClick={onZoomFit}>
-        <Scan className={cn('h-4 w-4', isFitWidth && 'text-primary')} />
+      <ToolButton label="Fit width" onClick={onZoomFitWidth} pressed={fitMode === 'width'}>
+        <MoveHorizontal className={cn('h-4 w-4', fitMode === 'width' && 'text-primary')} />
+      </ToolButton>
+      <ToolButton label="Fit page" onClick={onZoomFitPage} pressed={fitMode === 'page'}>
+        <RectangleVertical className={cn('h-4 w-4', fitMode === 'page' && 'text-primary')} />
       </ToolButton>
 
       <div className="mx-1 h-4 w-px bg-border" />

--- a/src/components/pdf/pdfConfig.ts
+++ b/src/components/pdf/pdfConfig.ts
@@ -1,0 +1,38 @@
+import { pdfjs } from 'react-pdf';
+
+/**
+ * Single source of pdf.js configuration for every preview surface (desktop
+ * panel and mobile modal). The worker file is vendored at
+ * public/lib/pdf.worker.min.mjs and kept in lockstep with react-pdf's nested
+ * pdfjs-dist by scripts/sync-pdf-worker.mjs (CI verifies the copy is current).
+ *
+ * The `?v=` parameter matters: the service worker runtime-caches /lib/* files
+ * CacheFirst for 90 days (engine-core-cache-v1), and runtime cache keys
+ * include the query string. Without the version stamp, upgrading pdfjs would
+ * serve returning users a stale worker against a newer API — the classic
+ * "worker version does not match the API" failure.
+ */
+pdfjs.GlobalWorkerOptions.workerSrc = `${import.meta.env.BASE_URL}lib/pdf.worker.min.mjs?v=${pdfjs.version}`;
+
+/**
+ * CVE-2024-4367 hardening: pdf.js's optional eval-based font glyph renderer
+ * could be coerced into arbitrary JavaScript by a malicious PDF. Our PDFs are
+ * self-generated, but enclosures are user-supplied files that get merged into
+ * the full-quality preview — so the safe, slightly slower non-eval glyph path
+ * is forced everywhere. Defined at module scope so <Document options={...}>
+ * receives a referentially stable object (react-pdf reloads the document when
+ * `options` changes identity).
+ */
+export const HARDENED_PDF_OPTIONS = { isEvalSupported: false } as const;
+
+/**
+ * Canvas backing-store cap. Retina rendering at full devicePixelRatio is the
+ * main memory driver (bytes ~ width² × dpr²); iOS Safari enforces a hard
+ * canvas memory budget (~384 MB) that killed the previous naive all-pages
+ * renderer there. Capping dpr — lower on iOS — plus page virtualization keeps
+ * the mounted-canvas total to a few tens of MB worst case.
+ */
+export function getDprCap(isIOS: boolean): number {
+  const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+  return Math.min(dpr, isIOS ? 1.5 : 2);
+}

--- a/src/components/pdf/pdfMath.ts
+++ b/src/components/pdf/pdfMath.ts
@@ -1,0 +1,144 @@
+/**
+ * Pure layout/zoom math for the PDF viewer. No DOM, no pdf.js — everything
+ * here is deterministic and unit-tested (tests/unit/pdfViewerMath.test.ts).
+ * The viewer deliberately derives its render window and page indicator from
+ * scroll arithmetic instead of IntersectionObserver: one rAF-throttled scroll
+ * handler, no observer lifecycle, and it runs under happy-dom.
+ */
+
+/** One page's vertical band inside the scroll content, in CSS px. */
+export interface PageLayout {
+  /** Top edge of the page (its gap is above it). */
+  top: number;
+  /** Page height only (no gap). */
+  height: number;
+}
+
+/** US Letter width/height — the right placeholder aspect for this app. */
+export const DEFAULT_PAGE_ASPECT = 8.5 / 11;
+
+/** Discrete zoom stops; fit-width snaps into these when the user steps. */
+export const ZOOM_STEPS = [0.5, 0.67, 0.8, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0] as const;
+
+/**
+ * Stack pages vertically: each page is pageWidth wide, height from its
+ * width/height aspect ratio, `gap` between pages, `pad` above the first and
+ * below the last.
+ */
+export function computePageLayout(
+  aspects: readonly number[],
+  pageWidth: number,
+  gap: number,
+  pad: number
+): PageLayout[] {
+  const layout: PageLayout[] = [];
+  let top = pad;
+  for (const aspect of aspects) {
+    const height = pageWidth / (aspect > 0 ? aspect : DEFAULT_PAGE_ASPECT);
+    layout.push({ top, height });
+    top += height + gap;
+  }
+  return layout;
+}
+
+/** Total scrollable content height for a layout produced above (gaps are
+ *  already baked into the layout's top offsets). */
+export function contentHeight(layout: readonly PageLayout[], pad: number): number {
+  if (layout.length === 0) return pad * 2;
+  const last = layout[layout.length - 1];
+  return last.top + last.height + pad;
+}
+
+/**
+ * The inclusive [first, last] page-index range intersecting the viewport
+ * extended by `overscanPx` in both directions. Pages outside this window are
+ * rendered as fixed-size placeholders (their canvases unmount → memory freed).
+ */
+export function visibleRange(
+  scrollTop: number,
+  viewportHeight: number,
+  layout: readonly PageLayout[],
+  overscanPx: number
+): [number, number] {
+  if (layout.length === 0) return [0, -1];
+  const windowTop = scrollTop - overscanPx;
+  const windowBottom = scrollTop + viewportHeight + overscanPx;
+  let first = layout.length - 1;
+  let last = 0;
+  for (let i = 0; i < layout.length; i++) {
+    const p = layout[i];
+    if (p.top + p.height >= windowTop && p.top <= windowBottom) {
+      if (i < first) first = i;
+      if (i > last) last = i;
+    }
+  }
+  // Nothing intersects (scrolled past all content): clamp to the nearest page.
+  if (first > last) {
+    const nearest = scrollTop <= layout[0].top ? 0 : layout.length - 1;
+    return [nearest, nearest];
+  }
+  return [first, last];
+}
+
+/**
+ * 1-based page number whose band covers the viewport's vertical center —
+ * drives the "N of M" indicator.
+ */
+export function currentPage(
+  scrollTop: number,
+  viewportHeight: number,
+  layout: readonly PageLayout[]
+): number {
+  if (layout.length === 0) return 1;
+  const center = scrollTop + viewportHeight / 2;
+  for (let i = 0; i < layout.length; i++) {
+    const p = layout[i];
+    // A page "owns" the band from its top to the next page's top (the gap
+    // below it counts as its territory, so the indicator never flickers to
+    // "no page" between pages).
+    const bandEnd = i + 1 < layout.length ? layout[i + 1].top : Infinity;
+    if (center >= p.top && center < bandEnd) return i + 1;
+  }
+  return center < layout[0].top ? 1 : layout.length;
+}
+
+/**
+ * The next discrete zoom stop from an arbitrary effective scale (fit-width
+ * produces non-step scales). Stepping up from a value between stops snaps to
+ * the next stop above it; stepping down snaps below. Clamped at the ends.
+ */
+export function nextZoomStep(effectiveScale: number, dir: 1 | -1): number {
+  if (dir === 1) {
+    for (const step of ZOOM_STEPS) {
+      if (step > effectiveScale + 1e-6) return step;
+    }
+    return ZOOM_STEPS[ZOOM_STEPS.length - 1];
+  }
+  for (let i = ZOOM_STEPS.length - 1; i >= 0; i--) {
+    if (ZOOM_STEPS[i] < effectiveScale - 1e-6) return ZOOM_STEPS[i];
+  }
+  return ZOOM_STEPS[0];
+}
+
+/** Clamp a saved scrollTop into a container's valid scroll range. */
+export function clampScrollTop(saved: number, scrollHeight: number, clientHeight: number): number {
+  const max = Math.max(0, scrollHeight - clientHeight);
+  return Math.min(Math.max(0, saved), max);
+}
+
+/**
+ * Re-anchor scrollTop after the content height changes (zoom / fit-width
+ * resize): keep the point at the viewport's center at the center.
+ */
+export function rescaleScrollTop(
+  scrollTop: number,
+  viewportHeight: number,
+  oldContentHeight: number,
+  newContentHeight: number
+): number {
+  if (oldContentHeight <= 0) return 0;
+  const center = scrollTop + viewportHeight / 2;
+  const ratio = center / oldContentHeight;
+  const newCenter = ratio * newContentHeight;
+  return Math.max(0, newCenter - viewportHeight / 2);
+}

--- a/src/components/pdf/useFullscreen.ts
+++ b/src/components/pdf/useFullscreen.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Fullscreen for the viewer root. `available` is false where the Fullscreen
+ * API is missing (iPhone Safari) so the toolbar can hide the control instead
+ * of offering a dead button.
+ */
+export function useFullscreen(ref: React.RefObject<HTMLElement | null>) {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const available = typeof document !== 'undefined' && !!document.fullscreenEnabled;
+
+  useEffect(() => {
+    if (!available) return;
+    const onChange = () => setIsFullscreen(document.fullscreenElement === ref.current);
+    document.addEventListener('fullscreenchange', onChange);
+    return () => document.removeEventListener('fullscreenchange', onChange);
+  }, [available, ref]);
+
+  const toggle = useCallback(() => {
+    if (!available || !ref.current) return;
+    if (document.fullscreenElement === ref.current) {
+      void document.exitFullscreen().catch(() => {});
+    } else {
+      void ref.current.requestFullscreen().catch(() => {});
+    }
+  }, [available, ref]);
+
+  return { available, isFullscreen, toggle };
+}

--- a/src/components/pdf/usePdfDocumentSwap.ts
+++ b/src/components/pdf/usePdfDocumentSwap.ts
@@ -1,0 +1,112 @@
+import { useEffect, useReducer, useRef } from 'react';
+
+/**
+ * Double-buffered document swap — the machinery behind the flicker-free
+ * recompile. The active document stays fully rendered while the incoming one
+ * loads and pre-renders in a hidden layer; only once the pages the user is
+ * looking at have actually painted does the new layer get promoted (a short
+ * crossfade in the component). The compile loop re-emits a new blob URL every
+ * ~1.5s while the user types, so the machine coalesces: a newer URL simply
+ * replaces the in-flight incoming document (newest wins), and a load failure
+ * abandons the incoming quietly — App revokes old blob URLs eagerly, so a
+ * mid-flight revocation is expected and a fresher URL always follows.
+ *
+ * The reducer is pure and exported for unit tests
+ * (tests/unit/pdfSwapMachine.test.ts).
+ */
+
+export interface DocSlot {
+  url: string;
+  /** Monotonic generation — stale async events (loads/renders/timeouts from a
+   *  superseded document) are ignored by comparing generations. */
+  gen: number;
+}
+
+export interface SwapState {
+  active: DocSlot | null;
+  incoming: DocSlot | null;
+  /** Generation counter (last issued). */
+  gen: number;
+}
+
+export type SwapEvent =
+  | { type: 'URL_CHANGED'; url: string }
+  | { type: 'INCOMING_LOADED'; gen: number }
+  | { type: 'INCOMING_READY'; gen: number }
+  | { type: 'READY_TIMEOUT'; gen: number }
+  | { type: 'INCOMING_FAILED'; gen: number };
+
+export const initialSwapState: SwapState = { active: null, incoming: null, gen: 0 };
+
+export function swapReducer(state: SwapState, event: SwapEvent): SwapState {
+  switch (event.type) {
+    case 'URL_CHANGED': {
+      const gen = state.gen + 1;
+      const slot = { url: event.url, gen };
+      // First document: no old content to protect — activate directly and let
+      // the layer render with the surface's normal loading state.
+      if (!state.active) return { active: slot, incoming: null, gen };
+      // Same URL re-emitted (e.g. parent re-render): nothing to do.
+      if (state.active.url === event.url && !state.incoming) return state;
+      // Replace any in-flight incoming — newest wins.
+      return { ...state, incoming: slot, gen };
+    }
+    case 'INCOMING_READY':
+    case 'READY_TIMEOUT': {
+      // Promote the incoming document once its restore-window pages have
+      // painted (or the safety timeout fires so a slow render can't wedge the
+      // preview on stale content forever).
+      if (!state.incoming || state.incoming.gen !== event.gen) return state;
+      return { active: state.incoming, incoming: null, gen: state.gen };
+    }
+    case 'INCOMING_FAILED': {
+      // Blob revoked mid-load or parse failure: keep showing the active
+      // document. The next compile emits a fresh URL within the debounce.
+      if (!state.incoming || state.incoming.gen !== event.gen) return state;
+      return { ...state, incoming: null };
+    }
+    case 'INCOMING_LOADED':
+      // Structural no-op in the reducer (the layer drives pre-rendering), but
+      // kept as an event so the hook can arm the READY_TIMEOUT from it.
+      return state;
+    default:
+      return state;
+  }
+}
+
+/** How long after load we wait for the restore-window pages to paint before
+ *  promoting anyway — keeps a pathological render from pinning stale content. */
+export const READY_TIMEOUT_MS = 1200;
+
+export function usePdfDocumentSwap(pdfUrl: string) {
+  const [state, dispatch] = useReducer(swapReducer, initialSwapState);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    dispatch({ type: 'URL_CHANGED', url: pdfUrl });
+  }, [pdfUrl]);
+
+  // Arm the promote-anyway timeout when an incoming document finishes loading.
+  const onIncomingLoaded = (gen: number) => {
+    dispatch({ type: 'INCOMING_LOADED', gen });
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => dispatch({ type: 'READY_TIMEOUT', gen }), READY_TIMEOUT_MS);
+  };
+  const onIncomingReady = (gen: number) => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    dispatch({ type: 'INCOMING_READY', gen });
+  };
+  const onIncomingFailed = (gen: number) => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    dispatch({ type: 'INCOMING_FAILED', gen });
+  };
+
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    },
+    []
+  );
+
+  return { state, onIncomingLoaded, onIncomingReady, onIncomingFailed };
+}

--- a/src/components/pdf/usePdfZoom.ts
+++ b/src/components/pdf/usePdfZoom.ts
@@ -1,64 +1,88 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { nextZoomStep } from './pdfMath';
+import { nextZoomStep, DEFAULT_PAGE_ASPECT } from './pdfMath';
 
 /**
  * Zoom state for the viewer. Fit-width is the resting mode: the page tracks
  * the container (ResizeObserver, rAF-coalesced) up to a hard cap so a wide
- * desktop panel doesn't blow a letter page up to poster size. Stepping the
- * zoom converts the current *effective* scale into the nearest discrete stop
- * and switches to manual; "fit" returns to tracking.
+ * desktop panel doesn't blow a letter page up to poster size. Fit-page sizes
+ * the page so the whole sheet is visible — the "judge the composition" view.
+ * Stepping the zoom converts the current *effective* scale into the nearest
+ * discrete stop and switches to manual; either fit button returns to tracking.
  */
 
-export type ZoomMode = { kind: 'fit-width' } | { kind: 'manual'; scale: number };
+export type ZoomMode = { kind: 'fit-width' } | { kind: 'fit-page' } | { kind: 'manual'; scale: number };
 
 /** Horizontal padding of the mat around the page, per side. */
 export const MAT_PAD = 24;
-/** Fit-width never renders wider than this (matches the old mobile cap). */
+/** Fit modes never render wider than this (matches the old mobile cap). */
 export const MAX_FIT_WIDTH = 960;
+/** The toolbar's height — subtracted from the root box for fit-page. */
+export const TOOLBAR_HEIGHT = 36;
 
-export function usePdfZoom(rootRef: React.RefObject<HTMLElement | null>, basePageCssWidth: number | null) {
+export function usePdfZoom(
+  rootRef: React.RefObject<HTMLElement | null>,
+  basePageCssWidth: number | null,
+  basePageAspect: number | null
+) {
   const [mode, setMode] = useState<ZoomMode>({ kind: 'fit-width' });
-  const [containerWidth, setContainerWidth] = useState(0);
+  const [box, setBox] = useState({ width: 0, height: 0 });
   const rafRef = useRef<number | null>(null);
 
   useEffect(() => {
     const el = rootRef.current;
     if (!el || typeof ResizeObserver === 'undefined') return;
     const ro = new ResizeObserver((entries) => {
-      const width = entries[entries.length - 1]?.contentRect.width ?? 0;
+      const rect = entries[entries.length - 1]?.contentRect;
+      if (!rect) return;
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
-      rafRef.current = requestAnimationFrame(() => setContainerWidth(width));
+      rafRef.current = requestAnimationFrame(() => setBox({ width: rect.width, height: rect.height }));
     });
     ro.observe(el);
-    setContainerWidth(el.clientWidth);
+    setBox({ width: el.clientWidth, height: el.clientHeight });
     return () => {
       ro.disconnect();
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
     };
   }, [rootRef]);
 
-  const fitWidth = Math.min(Math.max(containerWidth - MAT_PAD * 2, 120), MAX_FIT_WIDTH);
-  const pageWidth =
-    mode.kind === 'fit-width'
-      ? fitWidth
-      : Math.round((basePageCssWidth ?? fitWidth) * mode.scale);
+  const aspect = basePageAspect ?? DEFAULT_PAGE_ASPECT;
+  const clampWidth = (w: number) => Math.min(Math.max(w, 120), MAX_FIT_WIDTH);
+  const fitWidth = clampWidth(box.width - MAT_PAD * 2);
+  // Whole page visible: constrained by BOTH dimensions — the height available
+  // under the toolbar sets the ceiling, but a narrow panel still wins (a
+  // height-only fit would exceed the container and force horizontal scroll,
+  // defeating the point of the mode).
+  const fitPageWidth = clampWidth(
+    Math.min((box.height - TOOLBAR_HEIGHT - MAT_PAD * 2) * aspect, box.width - MAT_PAD * 2)
+  );
 
-  // The scale the current pageWidth corresponds to, for the % readout and as
-  // the starting point when stepping out of fit-width.
+  const widthFor = useCallback(
+    (m: ZoomMode): number => {
+      if (m.kind === 'fit-width') return fitWidth;
+      if (m.kind === 'fit-page') return fitPageWidth;
+      return Math.round((basePageCssWidth ?? fitWidth) * m.scale);
+    },
+    [fitWidth, fitPageWidth, basePageCssWidth]
+  );
+
+  const pageWidth = widthFor(mode);
+  // The scale the current pageWidth corresponds to — the % readout, and the
+  // starting point when stepping out of either fit mode.
   const effectiveScale = basePageCssWidth ? pageWidth / basePageCssWidth : 1;
 
   const zoomStep = useCallback(
     (dir: 1 | -1) => {
       setMode((prev) => {
         const base = basePageCssWidth ?? fitWidth;
-        const current = prev.kind === 'manual' ? prev.scale : fitWidth / base;
+        const current = widthFor(prev) / base;
         return { kind: 'manual', scale: nextZoomStep(current, dir) };
       });
     },
-    [basePageCssWidth, fitWidth]
+    [basePageCssWidth, fitWidth, widthFor]
   );
 
-  const zoomFit = useCallback(() => setMode({ kind: 'fit-width' }), []);
+  const zoomFitWidth = useCallback(() => setMode({ kind: 'fit-width' }), []);
+  const zoomFitPage = useCallback(() => setMode({ kind: 'fit-page' }), []);
 
-  return { mode, pageWidth, effectiveScale, zoomStep, zoomFit };
+  return { mode, pageWidth, effectiveScale, zoomStep, zoomFitWidth, zoomFitPage };
 }

--- a/src/components/pdf/usePdfZoom.ts
+++ b/src/components/pdf/usePdfZoom.ts
@@ -16,11 +16,15 @@ export type ZoomMode = { kind: 'fit-width' } | { kind: 'fit-page' } | { kind: 'm
 export const MAT_PAD = 24;
 /** Fit modes never render wider than this (matches the old mobile cap). */
 export const MAX_FIT_WIDTH = 960;
-/** The toolbar's height — subtracted from the root box for fit-page. */
-export const TOOLBAR_HEIGHT = 36;
 
+/**
+ * `contentRef` must be the element that actually holds the pages — the layer
+ * column, NOT the viewer root. The root doesn't shrink when the thumbnail
+ * rail opens, so observing it renders pages wider than the space they live in
+ * (negative margins + horizontal scroll — caught in the live geometry scan).
+ */
 export function usePdfZoom(
-  rootRef: React.RefObject<HTMLElement | null>,
+  contentRef: React.RefObject<HTMLElement | null>,
   basePageCssWidth: number | null,
   basePageAspect: number | null
 ) {
@@ -29,7 +33,7 @@ export function usePdfZoom(
   const rafRef = useRef<number | null>(null);
 
   useEffect(() => {
-    const el = rootRef.current;
+    const el = contentRef.current;
     if (!el || typeof ResizeObserver === 'undefined') return;
     const ro = new ResizeObserver((entries) => {
       const rect = entries[entries.length - 1]?.contentRect;
@@ -43,17 +47,17 @@ export function usePdfZoom(
       ro.disconnect();
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
     };
-  }, [rootRef]);
+  }, [contentRef]);
 
   const aspect = basePageAspect ?? DEFAULT_PAGE_ASPECT;
   const clampWidth = (w: number) => Math.min(Math.max(w, 120), MAX_FIT_WIDTH);
   const fitWidth = clampWidth(box.width - MAT_PAD * 2);
-  // Whole page visible: constrained by BOTH dimensions — the height available
-  // under the toolbar sets the ceiling, but a narrow panel still wins (a
-  // height-only fit would exceed the container and force horizontal scroll,
-  // defeating the point of the mode).
+  // Whole page visible: constrained by BOTH dimensions — the content column's
+  // height (it already excludes the toolbar) sets the ceiling, but a narrow
+  // column still wins (a height-only fit would exceed the container and force
+  // horizontal scroll, defeating the point of the mode).
   const fitPageWidth = clampWidth(
-    Math.min((box.height - TOOLBAR_HEIGHT - MAT_PAD * 2) * aspect, box.width - MAT_PAD * 2)
+    Math.min((box.height - MAT_PAD * 2) * aspect, box.width - MAT_PAD * 2)
   );
 
   const widthFor = useCallback(

--- a/src/components/pdf/usePdfZoom.ts
+++ b/src/components/pdf/usePdfZoom.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { nextZoomStep } from './pdfMath';
+
+/**
+ * Zoom state for the viewer. Fit-width is the resting mode: the page tracks
+ * the container (ResizeObserver, rAF-coalesced) up to a hard cap so a wide
+ * desktop panel doesn't blow a letter page up to poster size. Stepping the
+ * zoom converts the current *effective* scale into the nearest discrete stop
+ * and switches to manual; "fit" returns to tracking.
+ */
+
+export type ZoomMode = { kind: 'fit-width' } | { kind: 'manual'; scale: number };
+
+/** Horizontal padding of the mat around the page, per side. */
+export const MAT_PAD = 24;
+/** Fit-width never renders wider than this (matches the old mobile cap). */
+export const MAX_FIT_WIDTH = 960;
+
+export function usePdfZoom(rootRef: React.RefObject<HTMLElement | null>, basePageCssWidth: number | null) {
+  const [mode, setMode] = useState<ZoomMode>({ kind: 'fit-width' });
+  const [containerWidth, setContainerWidth] = useState(0);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver((entries) => {
+      const width = entries[entries.length - 1]?.contentRect.width ?? 0;
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => setContainerWidth(width));
+    });
+    ro.observe(el);
+    setContainerWidth(el.clientWidth);
+    return () => {
+      ro.disconnect();
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [rootRef]);
+
+  const fitWidth = Math.min(Math.max(containerWidth - MAT_PAD * 2, 120), MAX_FIT_WIDTH);
+  const pageWidth =
+    mode.kind === 'fit-width'
+      ? fitWidth
+      : Math.round((basePageCssWidth ?? fitWidth) * mode.scale);
+
+  // The scale the current pageWidth corresponds to, for the % readout and as
+  // the starting point when stepping out of fit-width.
+  const effectiveScale = basePageCssWidth ? pageWidth / basePageCssWidth : 1;
+
+  const zoomStep = useCallback(
+    (dir: 1 | -1) => {
+      setMode((prev) => {
+        const base = basePageCssWidth ?? fitWidth;
+        const current = prev.kind === 'manual' ? prev.scale : fitWidth / base;
+        return { kind: 'manual', scale: nextZoomStep(current, dir) };
+      });
+    },
+    [basePageCssWidth, fitWidth]
+  );
+
+  const zoomFit = useCallback(() => setMode({ kind: 'fit-width' }), []);
+
+  return { mode, pageWidth, effectiveScale, zoomStep, zoomFit };
+}

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -34,6 +34,9 @@ interface UIState {
   togglePreview: () => void;
   setPreviewVisible: (visible: boolean) => void;
   setPreviewWidth: (width: number) => void;
+  /** PDF viewer thumbnail rail (only offered on 2+ page documents). */
+  pdfThumbnailsOpen: boolean;
+  setPdfThumbnailsOpen: (open: boolean) => void;
 
   // Modals
   profileModalOpen: boolean;
@@ -142,6 +145,8 @@ export const useUIStore = create<UIState>()(
       togglePreview: () => set((state) => ({ previewVisible: !state.previewVisible })),
       setPreviewVisible: (visible) => set({ previewVisible: visible }),
       setPreviewWidth: (width) => set({ previewWidth: Math.max(20, Math.min(80, width)) }),
+      pdfThumbnailsOpen: false,
+      setPdfThumbnailsOpen: (open) => set({ pdfThumbnailsOpen: open }),
 
       // Modals
       profileModalOpen: false,
@@ -237,6 +242,7 @@ export const useUIStore = create<UIState>()(
         density: state.density,
         previewVisible: state.previewVisible,
         previewWidth: state.previewWidth,
+        pdfThumbnailsOpen: state.pdfThumbnailsOpen,
         fullQualityPreview: state.fullQualityPreview,
         sidebarCollapsed: state.sidebarCollapsed,
         storageNoticeDismissed: state.storageNoticeDismissed,

--- a/src/utils/device/strategies.ts
+++ b/src/utils/device/strategies.ts
@@ -30,18 +30,14 @@
  *    is more reliable.
  * 
  * PDF PREVIEW:
- * 
- * 1. Desktop: Native iframe works perfectly - browsers have built-in
- *    PDF viewers.
- * 
- * 2. iPad: Native iframe also works great - Safari has excellent PDF
- *    viewing with zoom, scroll, etc.
- * 
- * 3. iPhone/Android phones: Screen is small, native viewer is awkward.
- *    Use react-pdf-viewer for custom UI with zoom controls.
+ *
+ * All platforms render through the shared in-app viewer
+ * (src/components/pdf/PdfViewer.tsx) — page virtualization plus a capped
+ * devicePixelRatio keep canvas memory inside iOS budgets, so no per-device
+ * viewer split remains. Only DOWNLOAD strategy varies by device.
  */
 
-import type { DeviceInfo, DeviceStrategy, PdfDownloadStrategy, PdfPreviewStrategy } from './types';
+import type { DeviceInfo, DeviceStrategy, PdfDownloadStrategy } from './types';
 import { getDeviceInfo } from './detectors';
 
 /**
@@ -85,42 +81,16 @@ export function getPdfDownloadStrategy(device?: DeviceInfo): PdfDownloadStrategy
 }
 
 /**
- * Get the recommended PDF preview strategy for the current device
- * 
- * NOTE: We use react-pdf-viewer for ALL iOS devices (iPhone AND iPad) because:
- * - react-pdf crashes on iOS due to canvas memory limits (384MB)
- * - iframe shows black screen on iPad (tested and failed)
- * - react-pdf-viewer works reliably on all iOS devices
- */
-export function getPdfPreviewStrategy(device?: DeviceInfo): PdfPreviewStrategy {
-  const info = device || getDeviceInfo();
-  
-  // iOS (iPhone AND iPad): Use react-pdf-viewer
-  // This is the ONLY viewer that works reliably on iOS
-  if (info.isIOS) {
-    return 'react-pdf-viewer';
-  }
-  
-  // Desktop: Use native iframe, browser has built-in PDF viewer
-  if (info.isDesktop) {
-    return 'iframe';
-  }
-  
-  // Android phones/tablets: Use react-pdf-viewer for custom UI
-  return 'react-pdf-viewer';
-}
-
-/**
- * Get complete strategy recommendations with reasoning
+ * Get complete strategy recommendations with reasoning. Preview no longer
+ * varies by device (one in-app viewer everywhere); only downloads do.
  */
 export function getDeviceStrategy(device?: DeviceInfo): DeviceStrategy {
   const info = device || getDeviceInfo();
   const download = getPdfDownloadStrategy(info);
-  const preview = getPdfPreviewStrategy(info);
-  
+
   // Generate human-readable reasoning
   let reasoning: string;
-  
+
   if (info.isIOS && info.isInAppBrowser) {
     const appName = info.isGoogleApp ? 'Google App' :
                     info.isFacebookApp ? 'Facebook' :
@@ -129,20 +99,18 @@ export function getDeviceStrategy(device?: DeviceInfo): DeviceStrategy {
                     info.isLinkedInApp ? 'LinkedIn' : 'in-app browser';
     reasoning = `${appName} in-app browser detected. WKWebView doesn't support blob URL downloads (WebKit bug #216918). User must open in Safari.`;
   } else if (info.isIOS && info.isChromeIOS) {
-    reasoning = 'Chrome iOS detected. Blob URLs broken, using FileReader + data URL + window.open. Preview uses react-pdf-viewer for phone-optimized UI.';
+    reasoning = 'Chrome iOS detected. Blob URLs broken, using FileReader + data URL + window.open.';
   } else if (info.isIOS && info.isFirefoxIOS) {
     reasoning = 'Firefox iOS detected. Same WebKit limitations as Chrome iOS. Using data URL approach.';
-  } else if (info.isIOS && info.isRealSafari && info.isIPad) {
-    reasoning = 'iPad Safari detected. Native iframe for preview (excellent built-in PDF viewer). Standard blob download with octet-stream MIME type.';
   } else if (info.isIOS && info.isRealSafari) {
-    reasoning = 'iPhone Safari detected. react-pdf-viewer for phone-optimized preview. Standard blob download with octet-stream MIME type.';
+    reasoning = 'iOS Safari detected. Standard blob download with octet-stream MIME type.';
   } else if (info.isAndroid) {
-    reasoning = 'Android detected. Data URL download is more reliable than blob URLs. react-pdf-viewer for phone-optimized preview.';
+    reasoning = 'Android detected. Data URL download is more reliable than blob URLs.';
   } else {
-    reasoning = 'Desktop browser detected. Native iframe for preview, standard blob URL for download.';
+    reasoning = 'Desktop browser detected. Standard blob URL for download.';
   }
-  
-  return { download, preview, reasoning };
+
+  return { download, reasoning };
 }
 
 /**

--- a/src/utils/device/types.ts
+++ b/src/utils/device/types.ts
@@ -94,21 +94,13 @@ export type PdfDownloadStrategy =
   ;
 
 /**
- * PDF preview strategy recommendation
- */
-export type PdfPreviewStrategy =
-  | 'iframe'           // Native browser PDF viewer in iframe
-  | 'react-pdf-viewer' // react-pdf-viewer library (good for phones)
-  | 'react-pdf'        // react-pdf library (good for tablets)
-  ;
-
-/**
- * Combined strategy recommendations for a device
+ * Combined strategy recommendations for a device. Preview is not part of the
+ * strategy anymore: every platform renders through the shared in-app viewer
+ * (src/components/pdf/PdfViewer.tsx).
  */
 export interface DeviceStrategy {
   download: PdfDownloadStrategy;
-  preview: PdfPreviewStrategy;
-  
+
   /** Human-readable explanation of why this strategy was chosen */
   reasoning: string;
 }

--- a/tests/component/PdfViewer.test.tsx
+++ b/tests/component/PdfViewer.test.tsx
@@ -122,6 +122,26 @@ describe('PdfViewer', () => {
     expect(input.value).toBe('1'); // out of range for a 2-page doc → restored
   });
 
+  it('thumbnail rail: toggle appears on multi-page docs, opens a clickable rail', async () => {
+    const { container } = renderViewer('blob:test/5');
+    await waitFor(() => expect(screen.getByText('of 2')).toBeTruthy());
+
+    const toggle = screen.getByLabelText('Show page thumbnails');
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(toggle);
+
+    // Rail mounts and the portal fills it with one thumbnail button per page,
+    // drawn from the SAME document (no second doc:testid appears).
+    await waitFor(() => expect(screen.getByLabelText('Go to page 2')).toBeTruthy());
+    expect(container.querySelectorAll('[data-testid="doc:blob:test/5"]')).toHaveLength(1);
+    expect(screen.getByLabelText('Go to page 1').getAttribute('aria-current')).toBe('page');
+    expect(screen.getByLabelText('Hide page thumbnails').getAttribute('aria-pressed')).toBe('true');
+
+    // Close restores the clean single-column layout.
+    fireEvent.click(screen.getByLabelText('Hide page thumbnails'));
+    await waitFor(() => expect(screen.queryByLabelText('Go to page 2')).toBeNull());
+  });
+
   it('zoom buttons change the rendered page width', async () => {
     const { container } = renderViewer('blob:test/3');
     await waitFor(() => expect(container.querySelector('[data-testid="page:1"]')).toBeTruthy());

--- a/tests/component/PdfViewer.test.tsx
+++ b/tests/component/PdfViewer.test.tsx
@@ -6,8 +6,8 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 // proxy; Page renders a probe div and fires onRenderSuccess after mount. This
 // exercises the real swap machine, zoom math, and layer lifecycle without a
 // canvas or worker (happy-dom has neither).
-vi.mock('react-pdf', () => {
-  const React = require('react');
+vi.mock('react-pdf', async () => {
+  const React = await import('react');
   const PAGE_ASPECT = 8.5 / 11;
   const makeDoc = (numPages: number) => ({
     numPages,
@@ -25,6 +25,9 @@ vi.mock('react-pdf', () => {
       return () => {
         alive = false;
       };
+      // Keyed on file alone on purpose: callbacks are inline in the layer and
+      // change identity per render; re-firing would double-load documents.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [file]);
     return React.createElement('div', { 'data-testid': `doc:${file}` }, children);
   }
@@ -32,6 +35,7 @@ vi.mock('react-pdf', () => {
     React.useEffect(() => {
       const t = setTimeout(() => onRenderSuccess?.(), 0);
       return () => clearTimeout(t);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
     return React.createElement('div', { 'data-testid': `page:${pageNumber}`, 'data-width': width });
   }
@@ -120,6 +124,16 @@ describe('PdfViewer', () => {
     input.value = '99';
     fireEvent.blur(input);
     expect(input.value).toBe('1'); // out of range for a 2-page doc → restored
+
+    // A valid entry actually scrolls the active layer to that page's band.
+    const scrollCalls: Array<{ top?: number }> = [];
+    (Element.prototype as { scrollTo: (o: { top?: number }) => void }).scrollTo = function (o) {
+      scrollCalls.push(o);
+    };
+    input.value = '2';
+    fireEvent.keyDown(input, { key: 'Enter', target: input });
+    expect(scrollCalls.length).toBeGreaterThan(0);
+    expect(scrollCalls[scrollCalls.length - 1].top).toBeGreaterThan(0); // page 2 sits below page 1
   });
 
   it('thumbnail rail: toggle appears on multi-page docs, opens a clickable rail', async () => {

--- a/tests/component/PdfViewer.test.tsx
+++ b/tests/component/PdfViewer.test.tsx
@@ -66,7 +66,8 @@ beforeAll(() => {
 describe('PdfViewer', () => {
   it('renders the toolbar with a tabular page indicator once the doc loads', async () => {
     renderViewer('blob:test/1');
-    await waitFor(() => expect(screen.getByText('1 of 2')).toBeTruthy());
+    await waitFor(() => expect(screen.getByText('of 2')).toBeTruthy());
+    expect((screen.getByLabelText('Page number') as HTMLInputElement).value).toBe('1');
     expect(screen.getByLabelText('Zoom in')).toBeTruthy();
     expect(screen.getByLabelText('Open in browser tab')).toBeTruthy();
   });
@@ -97,6 +98,28 @@ describe('PdfViewer', () => {
       () => expect(container.querySelector('[data-testid="doc:blob:test/1"]')).toBeNull(),
       { timeout: 3000 }
     );
+  });
+
+  it('offers both fit modes and a direct page-number input', async () => {
+    const { container } = renderViewer('blob:test/4');
+    await waitFor(() => expect(container.querySelector('[data-testid="page:1"]')).toBeTruthy());
+
+    // Two explicit fit buttons; fit-width is the resting default.
+    const fitWidth = screen.getByLabelText('Fit width');
+    const fitPage = screen.getByLabelText('Fit page');
+    expect(fitWidth.getAttribute('aria-pressed')).toBe('true');
+    expect(fitPage.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(fitPage);
+    await waitFor(() => expect(fitPage.getAttribute('aria-pressed')).toBe('true'));
+    expect(fitWidth.getAttribute('aria-pressed')).toBe('false');
+
+    // Page input seeds from the current page and clamps invalid entries back.
+    const input = screen.getByLabelText('Page number') as HTMLInputElement;
+    expect(input.value).toBe('1');
+    fireEvent.keyDown(input, { key: 'Enter', target: input }); // unchanged → no-op
+    input.value = '99';
+    fireEvent.blur(input);
+    expect(input.value).toBe('1'); // out of range for a 2-page doc → restored
   });
 
   it('zoom buttons change the rendered page width', async () => {

--- a/tests/component/PdfViewer.test.tsx
+++ b/tests/component/PdfViewer.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+// react-pdf stub: Document invokes onLoadSuccess asynchronously with a doc
+// proxy; Page renders a probe div and fires onRenderSuccess after mount. This
+// exercises the real swap machine, zoom math, and layer lifecycle without a
+// canvas or worker (happy-dom has neither).
+vi.mock('react-pdf', () => {
+  const React = require('react');
+  const PAGE_ASPECT = 8.5 / 11;
+  const makeDoc = (numPages: number) => ({
+    numPages,
+    getPage: (n: number) =>
+      Promise.resolve({
+        getViewport: ({ scale }: { scale: number }) => ({ width: 612 * scale, height: (612 / PAGE_ASPECT) * scale }),
+        void: n,
+      }),
+  });
+  function Document({ file, onLoadSuccess, children }: never) {
+    React.useEffect(() => {
+      let alive = true;
+      // Two pages for every doc; async like the real parser.
+      void Promise.resolve().then(() => alive && onLoadSuccess?.(makeDoc(2)));
+      return () => {
+        alive = false;
+      };
+    }, [file]);
+    return React.createElement('div', { 'data-testid': `doc:${file}` }, children);
+  }
+  function Page({ pageNumber, width, onRenderSuccess }: never) {
+    React.useEffect(() => {
+      const t = setTimeout(() => onRenderSuccess?.(), 0);
+      return () => clearTimeout(t);
+    }, []);
+    return React.createElement('div', { 'data-testid': `page:${pageNumber}`, 'data-width': width });
+  }
+  return {
+    Document,
+    Page,
+    pdfjs: { GlobalWorkerOptions: {}, version: 'test' },
+  };
+});
+
+import PdfViewer from '@/components/pdf/PdfViewer';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+// The viewer always lives under the app-level TooltipProvider; mirror that.
+function renderViewer(url: string) {
+  return render(
+    <TooltipProvider>
+      <PdfViewer pdfUrl={url} />
+    </TooltipProvider>
+  );
+}
+
+beforeAll(() => {
+  // happy-dom lacks ResizeObserver; the zoom hook degrades to its initial width.
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as never;
+});
+
+describe('PdfViewer', () => {
+  it('renders the toolbar with a tabular page indicator once the doc loads', async () => {
+    renderViewer('blob:test/1');
+    await waitFor(() => expect(screen.getByText('1 of 2')).toBeTruthy());
+    expect(screen.getByLabelText('Zoom in')).toBeTruthy();
+    expect(screen.getByLabelText('Open in browser tab')).toBeTruthy();
+  });
+
+  it('keeps the old document mounted until the incoming one is ready, then swaps', async () => {
+    const { rerender, container } = renderViewer('blob:test/1');
+    await waitFor(() => expect(container.querySelector('[data-testid="doc:blob:test/1"]')).toBeTruthy());
+
+    rerender(
+      <TooltipProvider>
+        <PdfViewer pdfUrl="blob:test/2" />
+      </TooltipProvider>
+    );
+    // Both documents exist during the staged swap (old visible, new hidden).
+    await waitFor(() => expect(container.querySelector('[data-testid="doc:blob:test/2"]')).toBeTruthy());
+    expect(container.querySelector('[data-testid="doc:blob:test/1"]')).toBeTruthy();
+
+    // After the stub pages paint, the machine promotes and the old doc leaves
+    // (fade window included).
+    await waitFor(
+      () => {
+        const active = container.querySelector('[data-pdf-layer="active"] [data-testid="doc:blob:test/2"]');
+        expect(active).toBeTruthy();
+      },
+      { timeout: 3000 }
+    );
+    await waitFor(
+      () => expect(container.querySelector('[data-testid="doc:blob:test/1"]')).toBeNull(),
+      { timeout: 3000 }
+    );
+  });
+
+  it('zoom buttons change the rendered page width', async () => {
+    const { container } = renderViewer('blob:test/3');
+    await waitFor(() => expect(container.querySelector('[data-testid="page:1"]')).toBeTruthy());
+    const before = Number(container.querySelector('[data-testid="page:1"]')!.getAttribute('data-width'));
+
+    fireEvent.click(screen.getByLabelText('Zoom in'));
+    await waitFor(() => {
+      const after = Number(container.querySelector('[data-testid="page:1"]')!.getAttribute('data-width'));
+      expect(after).toBeGreaterThan(before);
+    });
+  });
+});

--- a/tests/component/PreviewPanel.test.tsx
+++ b/tests/component/PreviewPanel.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// Same react-pdf stub as PdfViewer.test — the panel lazy-loads the viewer.
+vi.mock('react-pdf', () => {
+  const React = require('react');
+  const makeDoc = (numPages: number) => ({
+    numPages,
+    getPage: () =>
+      Promise.resolve({ getViewport: ({ scale }: { scale: number }) => ({ width: 612 * scale, height: 792 * scale }) }),
+  });
+  function Document({ file, onLoadSuccess, children }: never) {
+    React.useEffect(() => {
+      let alive = true;
+      void Promise.resolve().then(() => alive && onLoadSuccess?.(makeDoc(1)));
+      return () => {
+        alive = false;
+      };
+    }, [file]);
+    return React.createElement('div', { 'data-testid': `doc:${file}` }, children);
+  }
+  function Page({ pageNumber, onRenderSuccess }: never) {
+    React.useEffect(() => {
+      const t = setTimeout(() => onRenderSuccess?.(), 0);
+      return () => clearTimeout(t);
+    }, []);
+    return React.createElement('div', { 'data-testid': `page:${pageNumber}` });
+  }
+  return { Document, Page, pdfjs: { GlobalWorkerOptions: {}, version: 'test' } };
+});
+
+import { PreviewPanel } from '@/components/layout/PreviewPanel';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { useUIStore } from '@/stores/uiStore';
+
+function renderPanel(props: Partial<React.ComponentProps<typeof PreviewPanel>>) {
+  return render(
+    <TooltipProvider>
+      <PreviewPanel pdfUrl={null} isCompiling={false} error={null} {...props} />
+    </TooltipProvider>
+  );
+}
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as never;
+});
+
+beforeEach(() => {
+  // Desktop panel path, preview open.
+  useUIStore.setState({ isMobile: false, previewVisible: true });
+});
+
+describe('PreviewPanel — compile-error reporting', () => {
+  it('a failure AFTER a successful compile banners over the stale document', async () => {
+    renderPanel({ pdfUrl: 'blob:test/ok', error: 'Undefined control sequence \\badmacro' });
+
+    // The banner announces the failure (role=alert reaches screen readers)…
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('Compile failed — preview is out of date');
+    expect(alert.textContent).toContain('Undefined control sequence');
+
+    // …while the last good document stays visible underneath, not blanked.
+    await waitFor(() => expect(screen.getByTestId('doc:blob:test/ok')).toBeTruthy());
+  });
+
+  it('a failure with NO document yet shows the centered error state', () => {
+    renderPanel({ pdfUrl: null, error: 'Emergency stop: LaTeX exited abnormally' });
+    expect(screen.getByText('Emergency stop: LaTeX exited abnormally')).toBeTruthy();
+    expect(screen.queryByRole('alert')).toBeNull(); // no stale doc → no overlay banner
+  });
+
+  it('the internal ENGINE_RESET_NEEDED signal is never shown to the user', () => {
+    renderPanel({ pdfUrl: null, error: 'ENGINE_RESET_NEEDED' });
+    expect(screen.queryByText(/ENGINE_RESET_NEEDED/)).toBeNull();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('no error, no banner — the viewer renders clean', async () => {
+    renderPanel({ pdfUrl: 'blob:test/clean' });
+    await waitFor(() => expect(screen.getByTestId('doc:blob:test/clean')).toBeTruthy());
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/tests/component/PreviewPanel.test.tsx
+++ b/tests/component/PreviewPanel.test.tsx
@@ -3,8 +3,8 @@ import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 
 // Same react-pdf stub as PdfViewer.test — the panel lazy-loads the viewer.
-vi.mock('react-pdf', () => {
-  const React = require('react');
+vi.mock('react-pdf', async () => {
+  const React = await import('react');
   const makeDoc = (numPages: number) => ({
     numPages,
     getPage: () =>
@@ -17,6 +17,8 @@ vi.mock('react-pdf', () => {
       return () => {
         alive = false;
       };
+      // Keyed on file alone on purpose — see PdfViewer.test.tsx.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [file]);
     return React.createElement('div', { 'data-testid': `doc:${file}` }, children);
   }
@@ -24,6 +26,7 @@ vi.mock('react-pdf', () => {
     React.useEffect(() => {
       const t = setTimeout(() => onRenderSuccess?.(), 0);
       return () => clearTimeout(t);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
     return React.createElement('div', { 'data-testid': `page:${pageNumber}` });
   }

--- a/tests/integration/pdf-viewer-real-pdf.test.ts
+++ b/tests/integration/pdf-viewer-real-pdf.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The in-app PDF viewer against REAL compiled output.
+ *
+ * Every other viewer test mocks react-pdf; this one closes the loop the mocks
+ * can't: it compiles an actual letter with pdflatex, then parses the bytes
+ * with the EXACT pdf.js react-pdf ships (resolved through react-pdf's nested
+ * pdfjs-dist — the same resolution scripts/sync-pdf-worker.mjs vendors the
+ * worker from), under the viewer's own hardened options. It then feeds the
+ * real page geometry into the viewer's layout math.
+ *
+ * What this proves that the mocked tests can't:
+ *  - the generator's PDFs open in the shipped pdf.js (no version/format skew),
+ *  - CVE hardening (isEvalSupported: false) doesn't break real documents,
+ *  - the viewer's US-Letter placeholder aspect matches real output exactly,
+ *  - virtualization math holds on real multi-page geometry, not synthetic.
+ *
+ * Skipped when pdflatex is absent (same guard as the rest of the harness);
+ * the compile-matrix CI job provides it.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { compileFixture } from '../_helpers/compileLatex';
+import { buildBaseline } from '../_helpers/compileMatrix';
+import {
+  computePageLayout,
+  visibleRange,
+  currentPage,
+  DEFAULT_PAGE_ASPECT,
+} from '@/components/pdf/pdfMath';
+import { HARDENED_PDF_OPTIONS } from '@/components/pdf/pdfConfig';
+
+const pdflatexAvailable =
+  spawnSync('pdflatex', ['--version'], { encoding: 'utf-8' }).status === 0;
+
+// Resolve the pdfjs-dist copy react-pdf actually runs (nested under its own
+// node_modules — other packages pin different majors), and load its Node entry.
+const req = createRequire(import.meta.url);
+const reactPdfPkg = req.resolve('react-pdf/package.json');
+const reqFromReactPdf = createRequire(reactPdfPkg);
+const pdfjsPkgPath = reqFromReactPdf.resolve('pdfjs-dist/package.json');
+const pdfjsDir = dirname(pdfjsPkgPath);
+const pdfjsVersion: string = JSON.parse(readFileSync(pdfjsPkgPath, 'utf8')).version;
+
+async function loadViewerPdfjs() {
+  return import(pathToFileURL(join(pdfjsDir, 'legacy', 'build', 'pdf.mjs')).href);
+}
+
+async function parseWithViewerPdfjs(pdfBytes: Uint8Array) {
+  const pdfjs = await loadViewerPdfjs();
+  return pdfjs.getDocument({
+    // compileFixture returns a Node Buffer; pdf.js 5 rejects Buffer subclasses.
+    data: new Uint8Array(pdfBytes),
+    // The viewer's hardening + node-friendly font handling.
+    ...HARDENED_PDF_OPTIONS,
+    disableFontFace: true,
+    useSystemFonts: false,
+  }).promise;
+}
+
+describe('PDF viewer × real compiled documents', () => {
+  it.skipIf(!pdflatexAvailable)(
+    'a real naval letter opens in the shipped pdf.js with the geometry the viewer assumes',
+    async () => {
+      const result = await compileFixture(buildBaseline('naval_letter'));
+      expect(result.ok, result.errors.join('\n') || result.logTail).toBe(true);
+
+      const doc = await parseWithViewerPdfjs(result.pdfBytes!);
+      expect(doc.numPages).toBeGreaterThanOrEqual(1);
+
+      // US Letter at 72dpi — and exactly the placeholder aspect the viewer
+      // sizes unresolved pages with (612/792 === 8.5/11).
+      const page = await doc.getPage(1);
+      const vp = page.getViewport({ scale: 1 });
+      expect(vp.width).toBeCloseTo(612, 0);
+      expect(vp.height).toBeCloseTo(792, 0);
+      expect(vp.width / vp.height).toBeCloseTo(DEFAULT_PAGE_ASPECT, 10);
+
+      // The subject the fixture set is really in the rendered text layer —
+      // the same data the preview draws.
+      const text = (await page.getTextContent()).items
+        .map((i: { str?: string }) => i.str ?? '')
+        .join(' ');
+      expect(text).toContain('OPERATIONAL READINESS REPORT');
+
+      await doc.destroy();
+    },
+    30_000
+  );
+
+  it.skipIf(!pdflatexAvailable)(
+    'multi-page output drives the virtualization math correctly',
+    async () => {
+      const store = buildBaseline('naval_letter');
+      store.paragraphs = Array.from({ length: 18 }, (_, i) => ({
+        text:
+          `Paragraph ${i + 1}. ` +
+          'All personnel shall comply with the provisions of this correspondence in every particular and report completion through the chain of command. '.repeat(
+            4
+          ),
+        level: 0,
+      }));
+      const result = await compileFixture(store);
+      expect(result.ok, result.errors.join('\n') || result.logTail).toBe(true);
+
+      const doc = await parseWithViewerPdfjs(result.pdfBytes!);
+      expect(doc.numPages).toBeGreaterThanOrEqual(2);
+
+      // Real per-page aspects → the viewer's layout, exactly as PdfPageLayer
+      // computes it after onLoadSuccess.
+      const aspects: number[] = [];
+      for (let i = 1; i <= doc.numPages; i++) {
+        const vp = (await doc.getPage(i)).getViewport({ scale: 1 });
+        aspects.push(vp.width / vp.height);
+      }
+      const pageWidth = 600;
+      const layout = computePageLayout(aspects, pageWidth, 16, 24);
+      expect(layout).toHaveLength(doc.numPages);
+      // Pages stack strictly downward with positive heights.
+      for (let i = 0; i < layout.length; i++) {
+        expect(layout[i].height).toBeGreaterThan(0);
+        if (i > 0) expect(layout[i].top).toBeGreaterThan(layout[i - 1].top + layout[i - 1].height - 1);
+      }
+      // At the top of the scroll, page 1 is in view; centered on the last
+      // page's band, the indicator reports the last page.
+      expect(visibleRange(0, 800, layout, 0)[0]).toBe(0);
+      const last = layout[layout.length - 1];
+      expect(currentPage(last.top + 10, 100, layout)).toBe(doc.numPages);
+
+      await doc.destroy();
+    },
+    30_000
+  );
+
+  it('the shipped pdf.js version matches the vendored worker exactly', () => {
+    // pdf.js hard-fails at runtime on worker/API version skew. The CI job
+    // re-vendors and diffs the worker file; this assertion pins the OTHER
+    // half — the version the viewer stamps into its workerSrc ?v= parameter
+    // resolves from the same nested package this test just exercised.
+    const workerBytes = readFileSync(join(pdfjsDir, 'build', 'pdf.worker.min.mjs'));
+    const vendored = readFileSync(
+      join(dirname(req.resolve('react-pdf/package.json')), '..', '..', 'public', 'lib', 'pdf.worker.min.mjs')
+    );
+    expect(pdfjsVersion).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(vendored.equals(workerBytes)).toBe(true);
+  });
+});

--- a/tests/unit/pdfSwapMachine.test.ts
+++ b/tests/unit/pdfSwapMachine.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { swapReducer, initialSwapState, type SwapState } from '@/components/pdf/usePdfDocumentSwap';
+
+const url = (n: number) => `blob:test/${n}`;
+
+function run(events: Parameters<typeof swapReducer>[1][], from: SwapState = initialSwapState): SwapState {
+  return events.reduce(swapReducer, from);
+}
+
+describe('pdf document swap machine', () => {
+  it('first URL activates directly — nothing to double-buffer', () => {
+    const s = run([{ type: 'URL_CHANGED', url: url(1) }]);
+    expect(s.active?.url).toBe(url(1));
+    expect(s.incoming).toBeNull();
+  });
+
+  it('a recompile stages the new document as incoming, keeping the active one', () => {
+    const s = run([
+      { type: 'URL_CHANGED', url: url(1) },
+      { type: 'URL_CHANGED', url: url(2) },
+    ]);
+    expect(s.active?.url).toBe(url(1)); // still showing the old doc
+    expect(s.incoming?.url).toBe(url(2));
+  });
+
+  it('newest wins: rapid recompiles replace the in-flight incoming', () => {
+    const s = run([
+      { type: 'URL_CHANGED', url: url(1) },
+      { type: 'URL_CHANGED', url: url(2) },
+      { type: 'URL_CHANGED', url: url(3) },
+    ]);
+    expect(s.active?.url).toBe(url(1));
+    expect(s.incoming?.url).toBe(url(3)); // url(2) was coalesced away
+  });
+
+  it('READY promotes the incoming document', () => {
+    let s = run([
+      { type: 'URL_CHANGED', url: url(1) },
+      { type: 'URL_CHANGED', url: url(2) },
+    ]);
+    s = swapReducer(s, { type: 'INCOMING_READY', gen: s.incoming!.gen });
+    expect(s.active?.url).toBe(url(2));
+    expect(s.incoming).toBeNull();
+  });
+
+  it('the safety timeout promotes exactly like READY', () => {
+    let s = run([
+      { type: 'URL_CHANGED', url: url(1) },
+      { type: 'URL_CHANGED', url: url(2) },
+    ]);
+    s = swapReducer(s, { type: 'READY_TIMEOUT', gen: s.incoming!.gen });
+    expect(s.active?.url).toBe(url(2));
+  });
+
+  it('stale-generation events are ignored (a coalesced doc cannot promote)', () => {
+    let s = run([
+      { type: 'URL_CHANGED', url: url(1) },
+      { type: 'URL_CHANGED', url: url(2) },
+    ]);
+    const staleGen = s.incoming!.gen;
+    s = swapReducer(s, { type: 'URL_CHANGED', url: url(3) }); // supersedes url(2)
+    s = swapReducer(s, { type: 'INCOMING_READY', gen: staleGen });
+    expect(s.active?.url).toBe(url(1)); // stale ready did nothing
+    expect(s.incoming?.url).toBe(url(3));
+    s = swapReducer(s, { type: 'INCOMING_READY', gen: s.incoming!.gen });
+    expect(s.active?.url).toBe(url(3));
+  });
+
+  it('a failed incoming load keeps the active document (revoked-blob race)', () => {
+    let s = run([
+      { type: 'URL_CHANGED', url: url(1) },
+      { type: 'URL_CHANGED', url: url(2) },
+    ]);
+    s = swapReducer(s, { type: 'INCOMING_FAILED', gen: s.incoming!.gen });
+    expect(s.active?.url).toBe(url(1));
+    expect(s.incoming).toBeNull();
+  });
+
+  it('re-emitting the active URL with no incoming is a no-op', () => {
+    const s1 = run([{ type: 'URL_CHANGED', url: url(1) }]);
+    const s2 = swapReducer(s1, { type: 'URL_CHANGED', url: url(1) });
+    expect(s2).toBe(s1);
+  });
+});

--- a/tests/unit/pdfViewerMath.test.ts
+++ b/tests/unit/pdfViewerMath.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import {
+  computePageLayout,
+  contentHeight,
+  visibleRange,
+  currentPage,
+  nextZoomStep,
+  clampScrollTop,
+  rescaleScrollTop,
+  ZOOM_STEPS,
+  DEFAULT_PAGE_ASPECT,
+} from '@/components/pdf/pdfMath';
+
+// A three-page US-Letter stack at 600px wide, 16px gaps, 24px padding:
+// heights ≈ 776.47, tops at 24, 816.47, 1608.94.
+const LETTER = DEFAULT_PAGE_ASPECT;
+const layout3 = computePageLayout([LETTER, LETTER, LETTER], 600, 16, 24);
+
+describe('computePageLayout / contentHeight', () => {
+  it('stacks pages with gaps and padding', () => {
+    expect(layout3).toHaveLength(3);
+    expect(layout3[0].top).toBe(24);
+    expect(layout3[0].height).toBeCloseTo(600 / LETTER, 5);
+    expect(layout3[1].top).toBeCloseTo(24 + layout3[0].height + 16, 5);
+    expect(contentHeight(layout3, 24)).toBeCloseTo(layout3[2].top + layout3[2].height + 24, 5);
+  });
+
+  it('guards a zero/negative aspect with the US-Letter default', () => {
+    const [broken] = computePageLayout([0], 600, 16, 24);
+    expect(broken.height).toBeCloseTo(600 / DEFAULT_PAGE_ASPECT, 5);
+  });
+
+  it('empty layout still reports the padding as content height', () => {
+    expect(contentHeight([], 24)).toBe(48);
+  });
+});
+
+describe('visibleRange', () => {
+  it('returns only the first page when the viewport sits at the top with no overscan', () => {
+    expect(visibleRange(0, 400, layout3, 0)).toEqual([0, 0]);
+  });
+
+  it('overscan pulls in the neighbor page', () => {
+    // Viewport bottom at 400; page 2 starts ~816 — a full-viewport overscan reaches it.
+    expect(visibleRange(0, 400, layout3, 500)).toEqual([0, 1]);
+  });
+
+  it('clamps to the nearest page when scrolled past all content', () => {
+    expect(visibleRange(99_999, 400, layout3, 0)).toEqual([2, 2]);
+  });
+
+  it('property: range is always within bounds and ordered', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 50_000 }),
+        fc.integer({ min: 100, max: 2000 }),
+        fc.integer({ min: 0, max: 2000 }),
+        fc.array(fc.double({ min: 0.3, max: 3, noNaN: true }), { minLength: 1, maxLength: 30 }),
+        (scrollTop, viewportH, overscan, aspects) => {
+          const layout = computePageLayout(aspects, 600, 16, 24);
+          const [first, last] = visibleRange(scrollTop, viewportH, layout, overscan);
+          return first >= 0 && last < layout.length && first <= last;
+        }
+      )
+    );
+  });
+});
+
+describe('currentPage', () => {
+  it('reports the page covering the viewport center, owning its trailing gap', () => {
+    expect(currentPage(0, 400, layout3)).toBe(1);
+    // Center inside the gap right after page 1 still reads as page 1.
+    const gapCenterScroll = layout3[0].height + 24 + 8 - 200; // center ≈ in the gap
+    expect(currentPage(gapCenterScroll, 400, layout3)).toBe(1);
+    expect(currentPage(layout3[2].top, 400, layout3)).toBe(3);
+  });
+
+  it('property: monotonically non-decreasing in scrollTop', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.double({ min: 0.3, max: 3, noNaN: true }), { minLength: 1, maxLength: 20 }),
+        fc.integer({ min: 100, max: 1500 }),
+        fc.array(fc.integer({ min: 0, max: 30_000 }), { minLength: 2, maxLength: 10 }),
+        (aspects, viewportH, scrolls) => {
+          const layout = computePageLayout(aspects, 600, 16, 24);
+          const sorted = [...scrolls].sort((a, b) => a - b);
+          const pages = sorted.map((s) => currentPage(s, viewportH, layout));
+          return pages.every((p, i) => i === 0 || p >= pages[i - 1]);
+        }
+      )
+    );
+  });
+});
+
+describe('nextZoomStep', () => {
+  it('steps up and down through the discrete stops', () => {
+    expect(nextZoomStep(1.0, 1)).toBe(1.1);
+    expect(nextZoomStep(1.0, -1)).toBe(0.9);
+  });
+
+  it('snaps a non-step fit-width scale into the ladder', () => {
+    expect(nextZoomStep(0.93, 1)).toBe(1.0);
+    expect(nextZoomStep(0.93, -1)).toBe(0.9);
+  });
+
+  it('clamps at both ends', () => {
+    expect(nextZoomStep(ZOOM_STEPS[ZOOM_STEPS.length - 1], 1)).toBe(ZOOM_STEPS[ZOOM_STEPS.length - 1]);
+    expect(nextZoomStep(ZOOM_STEPS[0], -1)).toBe(ZOOM_STEPS[0]);
+  });
+
+  it('property: up-then-down from any step returns to it (round-trip)', () => {
+    for (let i = 1; i < ZOOM_STEPS.length - 1; i++) {
+      const up = nextZoomStep(ZOOM_STEPS[i], 1);
+      expect(nextZoomStep(up, -1)).toBe(ZOOM_STEPS[i]);
+    }
+  });
+});
+
+describe('clampScrollTop / rescaleScrollTop', () => {
+  it('clamps into the valid scroll range', () => {
+    expect(clampScrollTop(-10, 2000, 400)).toBe(0);
+    expect(clampScrollTop(5000, 2000, 400)).toBe(1600);
+    expect(clampScrollTop(800, 2000, 400)).toBe(800);
+  });
+
+  it('content shorter than the viewport clamps to zero', () => {
+    expect(clampScrollTop(300, 200, 400)).toBe(0);
+  });
+
+  it('keeps the viewport center anchored across a content-height change', () => {
+    // Center at 1000 of 2000 (ratio .5) → new center 2000 of 4000.
+    expect(rescaleScrollTop(800, 400, 2000, 4000)).toBeCloseTo(1800, 5);
+    // Shrinking maps back symmetrically.
+    expect(rescaleScrollTop(1800, 400, 4000, 2000)).toBeCloseTo(800, 5);
+  });
+
+  it('degenerate old height rescales to the top', () => {
+    expect(rescaleScrollTop(500, 400, 0, 2000)).toBe(0);
+  });
+});


### PR DESCRIPTION
One PDF viewer for desktop and mobile, replacing the browser iframe and @react-pdf-viewer.

- Zoom, fit width / fit page, page navigation with direct entry, thumbnail rail on multi-page docs, fullscreen, open-in-tab
- Recompiles swap in place — no flash, no scroll jump
- Removes @react-pdf-viewer and its 21 high-severity audit advisories; `npm audit` gate now has zero exceptions
- New CI check keeps the vendored pdf.js worker in sync
- Bundle ~0.5 MB smaller; 1414 tests passing

Version bumped to 1.2.1. Real-device iOS check pending before merge.