### PR TITLE
chore(deps): override qs to 6.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.2] — 2026-07-01
+
+### Security
+
+- Overrode the transitive `qs` dependency to 6.15.3
+  (GHSA-q8mj-m7cp-5q26, moderate DoS). The vulnerable copy lived only in a
+  dev-tool chain (`@stryker-mutator/core` → `typed-rest-client`) and never
+  shipped in the app; the repository now has zero open advisories of any
+  severity.
+
 ## [1.2.1] — 2026-07-01
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.0",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -10275,13 +10275,14 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -10910,15 +10911,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -18,7 +18,8 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.5",
-    "tar": "^7.5.13"
+    "tar": "^7.5.13",
+    "qs": "^6.15.3"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Resolves the last open Dependabot alert (GHSA-q8mj-m7cp-5q26, moderate DoS in `qs`). typed-rest-client pins qs exactly, so this uses the existing `overrides` pattern. Dev-tool chain only (`@stryker-mutator/core` → `typed-rest-client`) — never shipped in the bundle.

`npm audit`: zero vulnerabilities of any severity. Version bumped to 1.2.2.