### PR TITLE
fix(mf): Memorandum For gets its addressee field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.3] — 2026-07-01
+
+### Fixed
+
+- Memorandum For (mf) documents can finally address someone: the editor
+  gains a required "Memorandum For" field (with unit lookup) that fills the
+  `MEMORANDUM FOR [addressee]` title line, which previously always rendered
+  blank because no field wrote it. Guarded by an integration test that
+  compiles a real document and checks the line in the output.
+
 ## [1.2.2] — 2026-07-01
 
 ### Security

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,6 +2,20 @@
 
 ## Resolved
 
+### Memorandum For (mf): No Addressee Field in the Editor
+
+**Resolved:** July 2026 (1.2.3)
+
+The generators emit the `MEMORANDUM FOR [addressee]` line only when `data.to`
+is set, but no editor field wrote `to` for the `mf` doc type (`fromTo: false`,
+no recipient-address block) — so the defining line of every Memorandum For
+rendered blank. Fixed with a dedicated required "Memorandum For" field (with
+unit lookup) in the addressing section; the section-completeness rule now
+requires it, and an integration test compiles a real `mf` document and asserts
+the addressee appears in the output text.
+
+**Files:** `src/components/editor/AddressingSection.tsx`, `src/components/layout/editorSections.tsx`, `tests/integration/mf-addressee.test.ts`
+
 ### SwiftLaTeX Dollar Sign (`$`) Rendering
 
 **Resolved:** February 2026
@@ -29,19 +43,6 @@ Pandoc ignores `\fancyfoot[R]{\thepage}`, so page number position is determined 
 **Potential fix:** Post-process `word/footer1.xml` to position the page number field code.
 
 **Files:** `src/services/latex/flat-generator.ts`, `public/lib/pandoc/dondocs.lua`
-
-### Memorandum For (mf): No Addressee Field in the Editor
-
-The generators emit the `MEMORANDUM FOR [addressee]` line only when `data.to`
-is set, but the `mf` document type's config has `fromTo: false` and no
-recipient-address block, so no editor field ever writes `data.to`. The
-defining line of the document is always empty in the output.
-
-**Potential fix:** Render a dedicated addressee input for `docType === 'mf'`
-(or reuse the executive-memo `MEMORANDUM FOR` input) and keep the existing
-generator gating.
-
-**Files:** `src/components/editor/AddressingSection.tsx`, `src/types/document.ts`, `src/services/latex/flat-generator.ts`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/editor/AddressingSection.tsx
+++ b/src/components/editor/AddressingSection.tsx
@@ -312,6 +312,43 @@ export function AddressingSection({ config }: AddressingSectionProps) {
               </>
             )}
 
+            {/* Memorandum For (mf): the addressee is embedded in the title line
+                ("MEMORANDUM FOR [addressee]"), so this doc type has no From/To
+                block — but the generators still read the addressee from `to`.
+                Without this field the defining line of the document rendered
+                blank (docs/KNOWN_ISSUES.md, now resolved). */}
+            {docType === 'mf' && (
+              <div className="space-y-2">
+                <Label htmlFor="to">
+                  Memorandum For <span className="text-destructive">*</span>
+                </Label>
+                <div className="flex gap-1">
+                  <div className="flex-1">
+                    <InputWithVariables
+                      id="to"
+                      value={formData.to || ''}
+                      onValueChange={(v) => setField('to', v)}
+                      aria-invalid={validationVisible && unfilled(formData.to) ? true : undefined}
+                      placeholder="Distribution List, or the receiving office/official"
+                    />
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={() => setUnitLookup('to')}
+                    title="Look up a unit"
+                    className="shrink-0"
+                  >
+                    <Building2 className="h-4 w-4" />
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Completes the title line: MEMORANDUM FOR [addressee] (SECNAV M-5216.5 Ch 10).
+                </p>
+              </div>
+            )}
+
             {/* Recipient Address - for business letters (multi-line address block) */}
             {config.recipientAddress && (
               <div className="space-y-2">

--- a/src/components/layout/editorSections.tsx
+++ b/src/components/layout/editorSections.tsx
@@ -191,7 +191,12 @@ export function getSectionError(
       // unclearable error dot on the Heading section; business letters (no From)
       // got the same on the From check.
       const fromError = config.fromTo ? unfilled(formData.from) : false;
-      const toError = config.fromTo || config.recipientAddress ? unfilled(formData.to) : false;
+      // "To" also carries the Memorandum For addressee — the doc type renders a
+      // dedicated required field for its "MEMORANDUM FOR [addressee]" title line.
+      const toError =
+        config.fromTo || config.recipientAddress || config.memoTitle === 'MEMORANDUM FOR'
+          ? unfilled(formData.to)
+          : false;
       return fromError || toError || unfilled(formData.subject);
     }
     case 'body':

--- a/tests/integration/mf-addressee.test.ts
+++ b/tests/integration/mf-addressee.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Memorandum For (mf): the addressee must reach the compiled output.
+ *
+ * The bug this pins: the generators have always gated the title line on
+ * `data.to` ("MEMORANDUM FOR [addressee]"), but the editor exposed no field
+ * that wrote `to` for this doc type — so the defining line of every
+ * Memorandum For rendered blank. The editor field now exists; this test
+ * guards the generator half with a real compile, so the line can never
+ * silently vanish again.
+ *
+ * Skipped when pdflatex is absent (same guard as the rest of the harness).
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { compileFixture } from '../_helpers/compileLatex';
+import { buildBaseline } from '../_helpers/compileMatrix';
+import { PDFParse } from 'pdf-parse';
+
+const pdflatexAvailable =
+  spawnSync('pdflatex', ['--version'], { encoding: 'utf-8' }).status === 0;
+
+async function extractPdfText(pdfBytes: Uint8Array): Promise<string> {
+  const parser = new PDFParse({ data: new Uint8Array(pdfBytes) });
+  try {
+    const result = await parser.getText();
+    return result.text ?? '';
+  } finally {
+    await parser.destroy();
+  }
+}
+
+describe('Memorandum For — addressee in real compiled output', () => {
+  it.skipIf(!pdflatexAvailable)(
+    'the MEMORANDUM FOR line carries the addressee from `to`',
+    async () => {
+      const store = buildBaseline('mf');
+      store.formData.to = 'Distribution List';
+
+      const result = await compileFixture(store);
+      expect(result.ok, result.errors.join('\n') || result.logTail).toBe(true);
+
+      const text = await extractPdfText(result.pdfBytes!);
+      // Whitespace-normalize: LaTeX may break the line internally.
+      const flat = text.replace(/\s+/g, ' ');
+      expect(flat).toContain('MEMORANDUM FOR Distribution List');
+    },
+    30_000
+  );
+});

--- a/tests/unit/editorSections.test.ts
+++ b/tests/unit/editorSections.test.ts
@@ -109,6 +109,16 @@ describe('getSectionError — addressing only flags fields the doc type exposes'
     expect(getSectionError('addressing', { from: '', to: '', subject: 'X' }, noParas, DOC_TYPE_CONFIG.business_letter)).toBe(true);
     expect(getSectionError('addressing', { from: '', to: 'Acme Corp', subject: 'X' }, noParas, DOC_TYPE_CONFIG.business_letter)).toBe(false);
   });
+
+  it('flags the Memorandum For addressee (mf writes the MEMORANDUM FOR line from `to`)', () => {
+    expect(DOC_TYPE_CONFIG.mf.fromTo).toBe(false);
+    expect(DOC_TYPE_CONFIG.mf.memoTitle).toBe('MEMORANDUM FOR');
+    // The addressee field is required — a blank (or placeholder) To errors...
+    expect(getSectionError('addressing', { from: '', to: '', subject: 'X' }, noParas, DOC_TYPE_CONFIG.mf)).toBe(true);
+    expect(getSectionError('addressing', { from: '', to: '[RECIPIENT]', subject: 'X' }, noParas, DOC_TYPE_CONFIG.mf)).toBe(true);
+    // ...and a real addressee clears it (From stays unfillable, so blank From is fine).
+    expect(getSectionError('addressing', { from: '', to: 'Distribution List', subject: 'X' }, noParas, DOC_TYPE_CONFIG.mf)).toBe(false);
+  });
 });
 
 describe('getSectionError — executive/joint-memo heading sections validate their Subject', () => {


### PR DESCRIPTION
The `MEMORANDUM FOR [addressee]` title line always rendered blank: the generators read it from `data.to`, but the editor exposed no field that wrote it for this doc type. Adds a required Memorandum For field (with unit lookup) and the completeness-rule check.

Verified with a real compile — an integration test builds an actual `mf` PDF and asserts the addressee in the output text. Version bumped to 1.2.3.