### PR TITLE
feat(backup): surface when synced backup is paused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.4] — 2026-07-01
+
+### Fixed
+
+- Synced backup now says when it's paused. Browsers revoke a file's write
+  permission every time the app fully closes, so auto-backup silently
+  stopped after each restart until you reopened the Save menu — a returning
+  user had no way to know their backup wasn't current. A dismissible strip
+  now appears when the backup needs reconnecting (or a write failed), with a
+  one-click Reconnect (or Choose file) action.
+
 ## [1.2.3] — 2026-07-01
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.3",
+  "version": "1.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import {
 import { parseShareUrl } from '@/lib/shareCrypto';
 import { BrowserCompatibilityNotice } from '@/components/BrowserCompatibilityNotice';
 import { StorageNotice } from '@/components/StorageNotice';
+import { BackupNotice } from '@/components/BackupNotice';
 import { probeStorageHealth } from '@/lib/documentsDb';
 const marineCodersLogo = `${import.meta.env.BASE_URL}attachments/marine-coders-logo.svg`;
 import { useUIStore } from '@/stores/uiStore';
@@ -1812,6 +1813,7 @@ ${texFiles['body.tex'] || '% No body content'}
       />
 
       <StorageNotice />
+      <BackupNotice />
 
       <div className="flex flex-1 overflow-hidden">
         {/* Document workspace (desktop). Sits beside the main editor so the

--- a/src/components/BackupNotice.tsx
+++ b/src/components/BackupNotice.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+import { useBackupStore, type BackupStatus } from '@/stores/backupStore';
+
+/**
+ * Slim, dismissible strip shown when the synced backup file has stopped
+ * updating — either the browser dropped write permission on restart
+ * ('needs-permission', which happens on EVERY relaunch by design: browsers
+ * revoke file-write grants when the app fully closes and require a fresh user
+ * gesture) or a write failed ('error', e.g. the file was moved/deleted). The
+ * status otherwise lived only inside the Save menu, so a returning user had no
+ * way to know their backup had quietly paused. One click here re-arms it.
+ */
+export function BackupNotice() {
+  const status = useBackupStore((s) => s.status);
+  const fileName = useBackupStore((s) => s.fileName);
+  const reconnect = useBackupStore((s) => s.reconnect);
+  const setupBackup = useBackupStore((s) => s.setupBackup);
+  // Per-status dismissal: hiding the "needs-permission" strip shouldn't also
+  // suppress a later, different "error" — mirrors StorageNotice's per-level rule.
+  const [dismissedStatus, setDismissedStatus] = useState<BackupStatus | null>(null);
+
+  const degraded = status === 'needs-permission' || status === 'error';
+  if (!degraded || status === dismissedStatus) return null;
+
+  const needsPermission = status === 'needs-permission';
+  const message = needsPermission
+    ? 'Auto-backup is paused — reconnect to keep your synced backup current.'
+    : "Auto-backup couldn't write to your file, so your backup may be out of date.";
+  // A permission drop is fixed by re-granting; a write fault usually means the
+  // file is gone/unwritable, so re-picking one is the honest recovery.
+  const actionLabel = needsPermission ? 'Reconnect' : 'Choose file';
+  const onAction = needsPermission ? reconnect : setupBackup;
+
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-2 border-b border-amber-500/25 bg-amber-500/10 px-4 py-1 text-xs text-foreground"
+    >
+      <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+      <p className="min-w-0 flex-1">
+        {message}
+        {fileName ? <span className="text-muted-foreground"> ({fileName})</span> : null}
+      </p>
+      <button
+        type="button"
+        onClick={() => void onAction()}
+        className="shrink-0 rounded px-2 py-0.5 font-medium text-amber-700 underline-offset-2 outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring/50 dark:text-amber-300"
+      >
+        {actionLabel}
+      </button>
+      <button
+        type="button"
+        onClick={() => setDismissedStatus(status)}
+        aria-label="Dismiss backup notice"
+        className="shrink-0 rounded p-0.5 text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/tests/component/BackupNotice.test.tsx
+++ b/tests/component/BackupNotice.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BackupNotice } from '@/components/BackupNotice';
+import { useBackupStore, type BackupStatus } from '@/stores/backupStore';
+
+function setStatus(status: BackupStatus, fileName: string | null = 'dondocs-library.json') {
+  useBackupStore.setState({ status, fileName });
+}
+
+beforeEach(() => {
+  useBackupStore.setState({
+    status: 'off',
+    fileName: null,
+    reconnect: vi.fn(async () => {}),
+    setupBackup: vi.fn(async () => {}),
+  });
+});
+
+describe('BackupNotice', () => {
+  it('is silent when backup is healthy or was never set up', () => {
+    for (const s of ['off', 'connected', 'unsupported'] as BackupStatus[]) {
+      setStatus(s);
+      const { container, unmount } = render(<BackupNotice />);
+      expect(container.firstChild).toBeNull();
+      unmount();
+    }
+  });
+
+  it('shows a Reconnect strip when permission was dropped on restart', () => {
+    setStatus('needs-permission');
+    render(<BackupNotice />);
+    expect(screen.getByRole('status').textContent).toContain('Auto-backup is paused');
+    expect(screen.getByText('(dondocs-library.json)')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Reconnect' }));
+    expect(useBackupStore.getState().reconnect).toHaveBeenCalledOnce();
+  });
+
+  it('shows a write-failure strip that offers to re-pick the file', () => {
+    setStatus('error');
+    render(<BackupNotice />);
+    expect(screen.getByRole('status').textContent).toContain("couldn't write");
+    fireEvent.click(screen.getByRole('button', { name: 'Choose file' }));
+    expect(useBackupStore.getState().setupBackup).toHaveBeenCalledOnce();
+  });
+
+  it('dismissal is per-status: hiding needs-permission still lets a later error surface', () => {
+    setStatus('needs-permission');
+    const { rerender, container } = render(<BackupNotice />);
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss backup notice' }));
+    rerender(<BackupNotice />);
+    expect(container.firstChild).toBeNull(); // dismissed for this status
+
+    setStatus('error');
+    rerender(<BackupNotice />);
+    expect(screen.getByRole('status').textContent).toContain("couldn't write"); // new status re-surfaces
+  });
+});


### PR DESCRIPTION
Browsers revoke file-write permission when the app fully closes, so auto-backup silently paused after every restart — the status only showed inside the Save menu, so a returning user couldn't tell their backup had stopped.

Adds a dismissible strip (mirroring StorageNotice) shown when the backup needs reconnecting or a write failed, with a one-click Reconnect / Choose file action. Found during the v1.2.3 device smoke-test. Version 1.2.4.