### PR TITLE
fix(airgap): vendor pandoc as sub-25MiB same-origin parts (supersedes #75)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,12 @@ KNOWN_ISSUES.md
 dist
 build
 
+# Vendored pandoc parts — staged fresh inside the build (see Dockerfile), so a
+# dev machine's copy must not ride in via the build context and overwrite them.
+public/lib/pandoc/pandoc.wasm
+public/lib/pandoc/pandoc.wasm.part*
+public/lib/pandoc/pandoc.wasm.manifest.json
+
 # Logs
 *.log
 npm-debug.log*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,17 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - run: npm ci
+      # Cache the vendored pandoc parts so build doesn't re-download ~58MB from
+      # unpkg on every run — keyed on the vendor script (which pins the version),
+      # so a version bump invalidates it. On a hit, prebuild's isCurrent() skips
+      # the download; on a miss, the script retries transient failures.
+      - name: cache pandoc wasm parts
+        uses: actions/cache@v4
+        with:
+          path: |
+            public/lib/pandoc/pandoc.wasm.part*
+            public/lib/pandoc/pandoc.wasm.manifest.json
+          key: pandoc-wasm-${{ hashFiles('scripts/vendor-assets.mjs') }}
       - run: npm run build
       - name: assert no test file in dist
         # Sanity check: tests/ MUST NOT end up in the production bundle.

--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,12 @@ Desktop.ini
 .claude/
 
 
-# Large binary assets (fetched at runtime / cached by service worker)
+# Build-time vendored binaries (downloaded + split by scripts/vendor-assets.mjs;
+# baked into dist/ so the deployed artifact is air-gap self-contained)
 public/lib/pandoc/pandoc.wasm
+public/lib/pandoc/pandoc.wasm.part*
+public/lib/pandoc/pandoc.wasm.manifest.json
+public/lib/pandoc/*.partial
 
 # Node / Vite
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.5] — 2026-07-02
+
+### Fixed
+
+- DOCX export now works on a genuinely air-gapped network. The pandoc
+  engine (WASI shim + 56 MB WASM binary) was fetched from public CDNs at
+  runtime — fine with a warm cache, a hard failure on isolated networks
+  with a cold one, despite the app's air-gap promise. Both assets are now
+  vendored same-origin at build time; the binary ships as sub-25 MiB parts
+  (the hosting platform's per-file limit) reassembled in the browser.
+
+### Added
+
+- A build guard (`check-no-cdn`) that fails CI if any shipped asset
+  references a public CDN, so the air-gap capability can't silently
+  regress.
+
 ## [1.2.4] — 2026-07-01
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,22 @@ COPY package.json package-lock.json ./
 # Install dependencies
 RUN npm ci
 
-# Copy source code
-COPY . .
-
-# Vendor the pandoc WASM parts (npm lifecycle hooks don't run here because
-# the build invokes vite directly). Without this, DOCX export ships broken —
-# the app loads pandoc same-origin and has no CDN fallback.
+# Vendor the pandoc WASM parts BEFORE copying source, so the ~58MB download
+# layer-caches until the vendor script itself changes — not on every source
+# edit. The script uses only Node builtins, so it needs no app source.
+COPY scripts ./scripts
 RUN node scripts/vendor-assets.mjs
 
-# Build the application with configurable base path
-RUN npx tsc -b && npx vite build --base=$BASE_PATH
+# Copy source code (.dockerignore excludes the gitignored pandoc artifacts, so
+# this can't clobber the freshly-vendored parts with a dev machine's stale ones).
+COPY . .
+
+# Build via npm so BOTH lifecycle hooks run: prebuild (an idempotent re-vendor —
+# a no-op given the cached parts) and, critically, postbuild (the check-no-cdn
+# air-gap guard). Invoking vite directly here was the one build path that shipped
+# the release image unscanned. npm appends trailing args to the last command in
+# the build script, so --base lands on `vite build`.
+RUN npm run build -- --base=$BASE_PATH
 
 # Production stage with Caddy
 FROM caddy:2-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,11 @@ RUN npm ci
 # Copy source code
 COPY . .
 
+# Vendor the pandoc WASM parts (npm lifecycle hooks don't run here because
+# the build invokes vite directly). Without this, DOCX export ships broken —
+# the app loads pandoc same-origin and has no CDN fallback.
+RUN node scripts/vendor-assets.mjs
+
 # Build the application with configurable base path
 RUN npx tsc -b && npx vite build --base=$BASE_PATH
 

--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ After pandoc produces the DOCX, `pandoc-converter.ts` opens it with JSZip and fi
 | `src/services/docx/pandoc-converter.ts` | Pandoc WASM loading, conversion, and OOXML post-processing |
 | `src/services/docx/layout-config.ts` | Shared layout proportions (used by both flat-generator and converter) |
 | `public/lib/pandoc/pandoc.js` | Pandoc 3.9+ WASM module loader |
-| `public/lib/pandoc/pandoc.wasm` | Pandoc WASM binary (~58MB) |
+| `public/lib/pandoc/pandoc.wasm.part*` + `pandoc.wasm.manifest.json` | Pandoc WASM binary (~58MB), vendored at build time as sub-25MiB same-origin parts (gitignored; staged by `scripts/vendor-assets.mjs`, reassembled in the browser) |
 | `public/lib/pandoc/dondocs.lua` | Four-pass Lua filter for DOCX formatting |
 | `public/lib/pandoc/reference.docx` | DOCX template with base styles |
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -12,10 +12,10 @@ grant in `LICENSE` does **not** extend to these components.
 | SwiftLaTeX (PdfTeXEngine) | `public/lib/PdfTeXEngine.js`, `public/lib/swiftlatexpdftex.js`, `public/lib/swiftlatexpdftex.wasm` | AGPL-3.0 (SwiftLaTeX project); the engine wraps pdfTeX, see below |
 | pdfTeX (compiled into the SwiftLaTeX WASM) | `public/lib/swiftlatexpdftex.wasm` | GPL-2.0-or-later |
 | TeX Live packages and fonts | `public/lib/texlive/`, `public/lib/texlive-packages.js` | LaTeX Project Public License (LPPL) and per-package licenses; Computer Modern fonts under their respective font licenses |
-| Pandoc (WASM, fetched at build time) | `public/lib/pandoc/pandoc.wasm` (via `scripts/vendor-assets.mjs`, from the `pandoc-wasm` npm package) | GPL-2.0-or-later |
+| Pandoc (WASM, fetched at build time) | `public/lib/pandoc/pandoc.wasm.part*` (downloaded and split by `scripts/vendor-assets.mjs` from the `pandoc-wasm` npm package) | GPL-2.0-or-later |
 | pandoc.js interface | `public/lib/pandoc/pandoc.js` | MIT (Tweag I/O Limited and John MacFarlane) |
 | browser_wasi_shim | `public/lib/pandoc/wasi-shim.js` (bundled from `@bjorn3/browser_wasi_shim`) | MIT OR Apache-2.0 |
-| PDF.js worker | `public/lib/pdf.worker.min.mjs`, `public/lib/pdf.worker-3.11.min.js` | Apache-2.0 (Mozilla) |
+| PDF.js worker | `public/lib/pdf.worker.min.mjs` (synced from `react-pdf`'s pdfjs-dist by `scripts/sync-pdf-worker.mjs`) | Apache-2.0 (Mozilla) |
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.2.5",
   "type": "module",
   "scripts": {
-    "predev": "node scripts/vendor-assets.mjs",
+    "predev": "node scripts/vendor-assets.mjs --allow-offline",
     "dev": "vite",
     "vendor-assets": "node scripts/vendor-assets.mjs",
     "prebuild": "node scripts/vendor-assets.mjs",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "version": "1.2.4",
   "type": "module",
   "scripts": {
+    "predev": "node scripts/vendor-assets.mjs",
     "dev": "vite",
+    "vendor-assets": "node scripts/vendor-assets.mjs",
+    "prebuild": "node scripts/vendor-assets.mjs",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.4",
+  "version": "1.2.5",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "vendor-assets": "node scripts/vendor-assets.mjs",
     "prebuild": "node scripts/vendor-assets.mjs",
     "build": "tsc -b && vite build",
+    "postbuild": "node scripts/check-no-cdn.mjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",

--- a/public/lib/pandoc/pandoc.js
+++ b/public/lib/pandoc/pandoc.js
@@ -28,13 +28,18 @@
    of strings.
 */
 
+// Air-gap: the WASI shim is vendored locally (public/lib/pandoc/wasi-shim.js,
+// a self-contained bundle of @bjorn3/browser_wasi_shim@0.3.0). This import
+// used to be a top-level await on a public CDN — on an isolated network the
+// whole module (and with it DOCX export) died at load time. Don't name CDN
+// hosts even in comments here: check-no-cdn scans shipped text verbatim.
 import {
   WASI,
   OpenFile,
   File,
   ConsoleStdout,
   PreopenDirectory,
-} from "https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim@0.3.0/dist/index.js";
+} from "./wasi-shim.js";
 
 const args = ["pandoc.wasm", "+RTS", "-H64m", "-RTS"];
 const env = [];
@@ -47,14 +52,15 @@ const fds = [
 ];
 const options = { debug: false };
 const wasi = new WASI(args, env, fds, options);
-// Fetch pandoc WASM binary from unpkg CDN (pandoc-wasm npm package, pandoc 3.9).
-// NOTE: we previously used jsDelivr, but jsDelivr enforces a 50 MB/file limit and
-// this WASM is ~58 MB. jsDelivr responds with HTTP 403 and a plain-text body
-// ("File size exceeded the configured limit of 50 MB."), which then fails
-// WebAssembly.instantiate() with a cryptic "expected magic word 00 61 73 6d,
-// found 46 69 6c 65" error (the ASCII bytes of "File"). unpkg has no such limit.
-// Uses ArrayBuffer instantiation instead of instantiateStreaming to bypass MIME type checks.
-const wasmUrl = "https://unpkg.com/pandoc-wasm@1.0.1/src/pandoc.wasm";
+// Air-gap: pandoc.wasm is vendored same-origin, split into sub-25MiB parts
+// (Cloudflare's per-file deploy limit) by scripts/vendor-assets.mjs and
+// reassembled here before instantiation. The manifest carries the part list
+// and exact sizes, so progress reports against a real total and a truncated
+// part (or an error body standing in for one) is caught before
+// WebAssembly.instantiate can fail cryptically. Resolved against
+// import.meta.url so any BASE_URL deployment works.
+const MANIFEST_URL = new URL("./pandoc.wasm.manifest.json", import.meta.url);
+const WASM_MAGIC = [0x00, 0x61, 0x73, 0x6d];
 
 // Progress reporting hook: consumers (e.g. the DOCX converter UI) can set
 // `globalThis.__dondocsPandocProgress` to a function BEFORE importing this
@@ -73,60 +79,93 @@ function reportProgress(event) {
   }
 }
 
-async function fetchWasmBytes(url) {
+async function fetchWasmParts() {
   reportProgress({ kind: "fetch-start" });
-  const response = await fetch(url);
-  if (!response.ok) {
+
+  const manRes = await fetch(MANIFEST_URL);
+  if (!manRes.ok) {
     throw new Error(
-      `Failed to fetch pandoc.wasm from ${url}: ` +
-      `HTTP ${response.status} ${response.statusText}`
+      `Failed to fetch pandoc.wasm manifest: HTTP ${manRes.status} ${manRes.statusText}. ` +
+      "If developing locally, run `npm run vendor-assets` to stage the parts."
     );
   }
-  const totalHeader = response.headers.get("content-length");
-  const total = totalHeader ? Number(totalHeader) : 0;
-
-  // Fallback when streaming isn't available (e.g. older runtimes or opaque bodies):
-  // read the whole response at once and emit a single progress event.
-  if (!response.body || typeof response.body.getReader !== "function") {
-    const buf = await response.arrayBuffer();
-    reportProgress({
-      kind: "fetch-progress",
-      loaded: buf.byteLength,
-      total: total || buf.byteLength,
-    });
-    return buf;
+  const { parts, partBytes, totalBytes } = await manRes.json();
+  if (
+    !Array.isArray(parts) || parts.length === 0 ||
+    !Array.isArray(partBytes) || partBytes.length !== parts.length ||
+    !Number.isInteger(totalBytes) || totalBytes <= 0
+  ) {
+    throw new Error("pandoc.wasm.manifest.json is malformed — re-run `npm run vendor-assets`");
   }
 
-  const reader = response.body.getReader();
-  const chunks = [];
+  // The manifest gives the exact size upfront, so ONE allocation receives the
+  // streamed bytes directly — no chunks[]+merge pass, halving peak memory for
+  // a ~58 MB payload.
+  const merged = new Uint8Array(totalBytes);
   let loaded = 0;
   // Throttle progress events to roughly once per 64 KB of download to avoid
   // flooding the React render loop on fast connections.
   const EMIT_EVERY = 64 * 1024;
   let nextEmitAt = EMIT_EVERY;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-    loaded += value.byteLength;
-    if (loaded >= nextEmitAt) {
-      reportProgress({ kind: "fetch-progress", loaded, total });
-      nextEmitAt = loaded + EMIT_EVERY;
+
+  for (let i = 0; i < parts.length; i++) {
+    const response = await fetch(new URL(`./${parts[i]}`, import.meta.url));
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch ${parts[i]}: HTTP ${response.status} ${response.statusText}`
+      );
+    }
+    const partStart = loaded;
+
+    // Fallback when streaming isn't available (older runtimes / opaque bodies).
+    if (!response.body || typeof response.body.getReader !== "function") {
+      const buf = new Uint8Array(await response.arrayBuffer());
+      if (partStart + buf.byteLength > totalBytes) {
+        throw new Error(`${parts[i]} overflows the manifest's totalBytes`);
+      }
+      merged.set(buf, partStart);
+      loaded += buf.byteLength;
+      reportProgress({ kind: "fetch-progress", loaded, total: totalBytes });
+    } else {
+      const reader = response.body.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (loaded + value.byteLength > totalBytes) {
+          throw new Error(`${parts[i]} overflows the manifest's totalBytes`);
+        }
+        merged.set(value, loaded);
+        loaded += value.byteLength;
+        if (loaded >= nextEmitAt) {
+          reportProgress({ kind: "fetch-progress", loaded, total: totalBytes });
+          nextEmitAt = loaded + EMIT_EVERY;
+        }
+      }
+    }
+
+    // Exact per-part size gate: a truncated download or an HTML error body
+    // fails HERE with a named part, not later in instantiate with a cryptic
+    // magic-word error.
+    const got = loaded - partStart;
+    if (got !== partBytes[i]) {
+      throw new Error(
+        `${parts[i]}: expected ${partBytes[i]} bytes, got ${got} (truncated or error body)`
+      );
     }
   }
-  // Final progress tick so the UI can settle at 100%.
-  reportProgress({ kind: "fetch-progress", loaded, total: total || loaded });
 
-  const merged = new Uint8Array(loaded);
-  let offset = 0;
-  for (const chunk of chunks) {
-    merged.set(chunk, offset);
-    offset += chunk.byteLength;
+  if (loaded !== totalBytes) {
+    throw new Error(`pandoc.wasm reassembly: expected ${totalBytes} bytes, got ${loaded}`);
   }
+  if (!WASM_MAGIC.every((b, i) => merged[i] === b)) {
+    throw new Error("pandoc.wasm reassembly failed the magic-byte check (00 61 73 6d)");
+  }
+  // Final progress tick so the UI can settle at 100%.
+  reportProgress({ kind: "fetch-progress", loaded, total: totalBytes });
   return merged.buffer;
 }
 
-const wasmBytes = await fetchWasmBytes(wasmUrl);
+const wasmBytes = await fetchWasmParts();
 reportProgress({ kind: "instantiate-start" });
 const { instance } = await WebAssembly.instantiate(wasmBytes, {
   wasi_snapshot_preview1: wasi.wasiImport,

--- a/public/lib/pandoc/pandoc.js
+++ b/public/lib/pandoc/pandoc.js
@@ -165,11 +165,15 @@ async function fetchWasmParts() {
   return merged.buffer;
 }
 
-const wasmBytes = await fetchWasmParts();
+let wasmBytes = await fetchWasmParts();
 reportProgress({ kind: "instantiate-start" });
 const { instance } = await WebAssembly.instantiate(wasmBytes, {
   wasi_snapshot_preview1: wasi.wasiImport,
 });
+// Release the ~58MB reassembled buffer: instantiate has compiled its own copy,
+// but this module-scope binding would otherwise retain it for the tab's
+// lifetime on top of pandoc's linear memory.
+wasmBytes = null;
 
 wasi.initialize(instance);
 instance.exports.__wasm_call_ctors();

--- a/public/lib/pandoc/wasi-shim.js
+++ b/public/lib/pandoc/wasi-shim.js
@@ -1,0 +1,1734 @@
+var __defProp = Object.defineProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+
+// node_modules/@bjorn3/browser_wasi_shim/dist/wasi_defs.js
+var wasi_defs_exports = {};
+__export(wasi_defs_exports, {
+  ADVICE_DONTNEED: () => ADVICE_DONTNEED,
+  ADVICE_NOREUSE: () => ADVICE_NOREUSE,
+  ADVICE_NORMAL: () => ADVICE_NORMAL,
+  ADVICE_RANDOM: () => ADVICE_RANDOM,
+  ADVICE_SEQUENTIAL: () => ADVICE_SEQUENTIAL,
+  ADVICE_WILLNEED: () => ADVICE_WILLNEED,
+  CLOCKID_MONOTONIC: () => CLOCKID_MONOTONIC,
+  CLOCKID_PROCESS_CPUTIME_ID: () => CLOCKID_PROCESS_CPUTIME_ID,
+  CLOCKID_REALTIME: () => CLOCKID_REALTIME,
+  CLOCKID_THREAD_CPUTIME_ID: () => CLOCKID_THREAD_CPUTIME_ID,
+  Ciovec: () => Ciovec,
+  Dirent: () => Dirent,
+  ERRNO_2BIG: () => ERRNO_2BIG,
+  ERRNO_ACCES: () => ERRNO_ACCES,
+  ERRNO_ADDRINUSE: () => ERRNO_ADDRINUSE,
+  ERRNO_ADDRNOTAVAIL: () => ERRNO_ADDRNOTAVAIL,
+  ERRNO_AFNOSUPPORT: () => ERRNO_AFNOSUPPORT,
+  ERRNO_AGAIN: () => ERRNO_AGAIN,
+  ERRNO_ALREADY: () => ERRNO_ALREADY,
+  ERRNO_BADF: () => ERRNO_BADF,
+  ERRNO_BADMSG: () => ERRNO_BADMSG,
+  ERRNO_BUSY: () => ERRNO_BUSY,
+  ERRNO_CANCELED: () => ERRNO_CANCELED,
+  ERRNO_CHILD: () => ERRNO_CHILD,
+  ERRNO_CONNABORTED: () => ERRNO_CONNABORTED,
+  ERRNO_CONNREFUSED: () => ERRNO_CONNREFUSED,
+  ERRNO_CONNRESET: () => ERRNO_CONNRESET,
+  ERRNO_DEADLK: () => ERRNO_DEADLK,
+  ERRNO_DESTADDRREQ: () => ERRNO_DESTADDRREQ,
+  ERRNO_DOM: () => ERRNO_DOM,
+  ERRNO_DQUOT: () => ERRNO_DQUOT,
+  ERRNO_EXIST: () => ERRNO_EXIST,
+  ERRNO_FAULT: () => ERRNO_FAULT,
+  ERRNO_FBIG: () => ERRNO_FBIG,
+  ERRNO_HOSTUNREACH: () => ERRNO_HOSTUNREACH,
+  ERRNO_IDRM: () => ERRNO_IDRM,
+  ERRNO_ILSEQ: () => ERRNO_ILSEQ,
+  ERRNO_INPROGRESS: () => ERRNO_INPROGRESS,
+  ERRNO_INTR: () => ERRNO_INTR,
+  ERRNO_INVAL: () => ERRNO_INVAL,
+  ERRNO_IO: () => ERRNO_IO,
+  ERRNO_ISCONN: () => ERRNO_ISCONN,
+  ERRNO_ISDIR: () => ERRNO_ISDIR,
+  ERRNO_LOOP: () => ERRNO_LOOP,
+  ERRNO_MFILE: () => ERRNO_MFILE,
+  ERRNO_MLINK: () => ERRNO_MLINK,
+  ERRNO_MSGSIZE: () => ERRNO_MSGSIZE,
+  ERRNO_MULTIHOP: () => ERRNO_MULTIHOP,
+  ERRNO_NAMETOOLONG: () => ERRNO_NAMETOOLONG,
+  ERRNO_NETDOWN: () => ERRNO_NETDOWN,
+  ERRNO_NETRESET: () => ERRNO_NETRESET,
+  ERRNO_NETUNREACH: () => ERRNO_NETUNREACH,
+  ERRNO_NFILE: () => ERRNO_NFILE,
+  ERRNO_NOBUFS: () => ERRNO_NOBUFS,
+  ERRNO_NODEV: () => ERRNO_NODEV,
+  ERRNO_NOENT: () => ERRNO_NOENT,
+  ERRNO_NOEXEC: () => ERRNO_NOEXEC,
+  ERRNO_NOLCK: () => ERRNO_NOLCK,
+  ERRNO_NOLINK: () => ERRNO_NOLINK,
+  ERRNO_NOMEM: () => ERRNO_NOMEM,
+  ERRNO_NOMSG: () => ERRNO_NOMSG,
+  ERRNO_NOPROTOOPT: () => ERRNO_NOPROTOOPT,
+  ERRNO_NOSPC: () => ERRNO_NOSPC,
+  ERRNO_NOSYS: () => ERRNO_NOSYS,
+  ERRNO_NOTCAPABLE: () => ERRNO_NOTCAPABLE,
+  ERRNO_NOTCONN: () => ERRNO_NOTCONN,
+  ERRNO_NOTDIR: () => ERRNO_NOTDIR,
+  ERRNO_NOTEMPTY: () => ERRNO_NOTEMPTY,
+  ERRNO_NOTRECOVERABLE: () => ERRNO_NOTRECOVERABLE,
+  ERRNO_NOTSOCK: () => ERRNO_NOTSOCK,
+  ERRNO_NOTSUP: () => ERRNO_NOTSUP,
+  ERRNO_NOTTY: () => ERRNO_NOTTY,
+  ERRNO_NXIO: () => ERRNO_NXIO,
+  ERRNO_OVERFLOW: () => ERRNO_OVERFLOW,
+  ERRNO_OWNERDEAD: () => ERRNO_OWNERDEAD,
+  ERRNO_PERM: () => ERRNO_PERM,
+  ERRNO_PIPE: () => ERRNO_PIPE,
+  ERRNO_PROTO: () => ERRNO_PROTO,
+  ERRNO_PROTONOSUPPORT: () => ERRNO_PROTONOSUPPORT,
+  ERRNO_PROTOTYPE: () => ERRNO_PROTOTYPE,
+  ERRNO_RANGE: () => ERRNO_RANGE,
+  ERRNO_ROFS: () => ERRNO_ROFS,
+  ERRNO_SPIPE: () => ERRNO_SPIPE,
+  ERRNO_SRCH: () => ERRNO_SRCH,
+  ERRNO_STALE: () => ERRNO_STALE,
+  ERRNO_SUCCESS: () => ERRNO_SUCCESS,
+  ERRNO_TIMEDOUT: () => ERRNO_TIMEDOUT,
+  ERRNO_TXTBSY: () => ERRNO_TXTBSY,
+  ERRNO_XDEV: () => ERRNO_XDEV,
+  EVENTRWFLAGS_FD_READWRITE_HANGUP: () => EVENTRWFLAGS_FD_READWRITE_HANGUP,
+  EVENTTYPE_CLOCK: () => EVENTTYPE_CLOCK,
+  EVENTTYPE_FD_READ: () => EVENTTYPE_FD_READ,
+  EVENTTYPE_FD_WRITE: () => EVENTTYPE_FD_WRITE,
+  FDFLAGS_APPEND: () => FDFLAGS_APPEND,
+  FDFLAGS_DSYNC: () => FDFLAGS_DSYNC,
+  FDFLAGS_NONBLOCK: () => FDFLAGS_NONBLOCK,
+  FDFLAGS_RSYNC: () => FDFLAGS_RSYNC,
+  FDFLAGS_SYNC: () => FDFLAGS_SYNC,
+  FD_STDERR: () => FD_STDERR,
+  FD_STDIN: () => FD_STDIN,
+  FD_STDOUT: () => FD_STDOUT,
+  FILETYPE_BLOCK_DEVICE: () => FILETYPE_BLOCK_DEVICE,
+  FILETYPE_CHARACTER_DEVICE: () => FILETYPE_CHARACTER_DEVICE,
+  FILETYPE_DIRECTORY: () => FILETYPE_DIRECTORY,
+  FILETYPE_REGULAR_FILE: () => FILETYPE_REGULAR_FILE,
+  FILETYPE_SOCKET_DGRAM: () => FILETYPE_SOCKET_DGRAM,
+  FILETYPE_SOCKET_STREAM: () => FILETYPE_SOCKET_STREAM,
+  FILETYPE_SYMBOLIC_LINK: () => FILETYPE_SYMBOLIC_LINK,
+  FILETYPE_UNKNOWN: () => FILETYPE_UNKNOWN,
+  FSTFLAGS_ATIM: () => FSTFLAGS_ATIM,
+  FSTFLAGS_ATIM_NOW: () => FSTFLAGS_ATIM_NOW,
+  FSTFLAGS_MTIM: () => FSTFLAGS_MTIM,
+  FSTFLAGS_MTIM_NOW: () => FSTFLAGS_MTIM_NOW,
+  Fdstat: () => Fdstat,
+  Filestat: () => Filestat,
+  Iovec: () => Iovec,
+  OFLAGS_CREAT: () => OFLAGS_CREAT,
+  OFLAGS_DIRECTORY: () => OFLAGS_DIRECTORY,
+  OFLAGS_EXCL: () => OFLAGS_EXCL,
+  OFLAGS_TRUNC: () => OFLAGS_TRUNC,
+  PREOPENTYPE_DIR: () => PREOPENTYPE_DIR,
+  Prestat: () => Prestat,
+  PrestatDir: () => PrestatDir,
+  RIFLAGS_RECV_PEEK: () => RIFLAGS_RECV_PEEK,
+  RIFLAGS_RECV_WAITALL: () => RIFLAGS_RECV_WAITALL,
+  RIGHTS_FD_ADVISE: () => RIGHTS_FD_ADVISE,
+  RIGHTS_FD_ALLOCATE: () => RIGHTS_FD_ALLOCATE,
+  RIGHTS_FD_DATASYNC: () => RIGHTS_FD_DATASYNC,
+  RIGHTS_FD_FDSTAT_SET_FLAGS: () => RIGHTS_FD_FDSTAT_SET_FLAGS,
+  RIGHTS_FD_FILESTAT_GET: () => RIGHTS_FD_FILESTAT_GET,
+  RIGHTS_FD_FILESTAT_SET_SIZE: () => RIGHTS_FD_FILESTAT_SET_SIZE,
+  RIGHTS_FD_FILESTAT_SET_TIMES: () => RIGHTS_FD_FILESTAT_SET_TIMES,
+  RIGHTS_FD_READ: () => RIGHTS_FD_READ,
+  RIGHTS_FD_READDIR: () => RIGHTS_FD_READDIR,
+  RIGHTS_FD_SEEK: () => RIGHTS_FD_SEEK,
+  RIGHTS_FD_SYNC: () => RIGHTS_FD_SYNC,
+  RIGHTS_FD_TELL: () => RIGHTS_FD_TELL,
+  RIGHTS_FD_WRITE: () => RIGHTS_FD_WRITE,
+  RIGHTS_PATH_CREATE_DIRECTORY: () => RIGHTS_PATH_CREATE_DIRECTORY,
+  RIGHTS_PATH_CREATE_FILE: () => RIGHTS_PATH_CREATE_FILE,
+  RIGHTS_PATH_FILESTAT_GET: () => RIGHTS_PATH_FILESTAT_GET,
+  RIGHTS_PATH_FILESTAT_SET_SIZE: () => RIGHTS_PATH_FILESTAT_SET_SIZE,
+  RIGHTS_PATH_FILESTAT_SET_TIMES: () => RIGHTS_PATH_FILESTAT_SET_TIMES,
+  RIGHTS_PATH_LINK_SOURCE: () => RIGHTS_PATH_LINK_SOURCE,
+  RIGHTS_PATH_LINK_TARGET: () => RIGHTS_PATH_LINK_TARGET,
+  RIGHTS_PATH_OPEN: () => RIGHTS_PATH_OPEN,
+  RIGHTS_PATH_READLINK: () => RIGHTS_PATH_READLINK,
+  RIGHTS_PATH_REMOVE_DIRECTORY: () => RIGHTS_PATH_REMOVE_DIRECTORY,
+  RIGHTS_PATH_RENAME_SOURCE: () => RIGHTS_PATH_RENAME_SOURCE,
+  RIGHTS_PATH_RENAME_TARGET: () => RIGHTS_PATH_RENAME_TARGET,
+  RIGHTS_PATH_SYMLINK: () => RIGHTS_PATH_SYMLINK,
+  RIGHTS_PATH_UNLINK_FILE: () => RIGHTS_PATH_UNLINK_FILE,
+  RIGHTS_POLL_FD_READWRITE: () => RIGHTS_POLL_FD_READWRITE,
+  RIGHTS_SOCK_SHUTDOWN: () => RIGHTS_SOCK_SHUTDOWN,
+  ROFLAGS_RECV_DATA_TRUNCATED: () => ROFLAGS_RECV_DATA_TRUNCATED,
+  SDFLAGS_RD: () => SDFLAGS_RD,
+  SDFLAGS_WR: () => SDFLAGS_WR,
+  SIGNAL_ABRT: () => SIGNAL_ABRT,
+  SIGNAL_ALRM: () => SIGNAL_ALRM,
+  SIGNAL_BUS: () => SIGNAL_BUS,
+  SIGNAL_CHLD: () => SIGNAL_CHLD,
+  SIGNAL_CONT: () => SIGNAL_CONT,
+  SIGNAL_FPE: () => SIGNAL_FPE,
+  SIGNAL_HUP: () => SIGNAL_HUP,
+  SIGNAL_ILL: () => SIGNAL_ILL,
+  SIGNAL_INT: () => SIGNAL_INT,
+  SIGNAL_KILL: () => SIGNAL_KILL,
+  SIGNAL_NONE: () => SIGNAL_NONE,
+  SIGNAL_PIPE: () => SIGNAL_PIPE,
+  SIGNAL_POLL: () => SIGNAL_POLL,
+  SIGNAL_PROF: () => SIGNAL_PROF,
+  SIGNAL_PWR: () => SIGNAL_PWR,
+  SIGNAL_QUIT: () => SIGNAL_QUIT,
+  SIGNAL_SEGV: () => SIGNAL_SEGV,
+  SIGNAL_STOP: () => SIGNAL_STOP,
+  SIGNAL_SYS: () => SIGNAL_SYS,
+  SIGNAL_TERM: () => SIGNAL_TERM,
+  SIGNAL_TRAP: () => SIGNAL_TRAP,
+  SIGNAL_TSTP: () => SIGNAL_TSTP,
+  SIGNAL_TTIN: () => SIGNAL_TTIN,
+  SIGNAL_TTOU: () => SIGNAL_TTOU,
+  SIGNAL_URG: () => SIGNAL_URG,
+  SIGNAL_USR1: () => SIGNAL_USR1,
+  SIGNAL_USR2: () => SIGNAL_USR2,
+  SIGNAL_VTALRM: () => SIGNAL_VTALRM,
+  SIGNAL_WINCH: () => SIGNAL_WINCH,
+  SIGNAL_XCPU: () => SIGNAL_XCPU,
+  SIGNAL_XFSZ: () => SIGNAL_XFSZ,
+  SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME: () => SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME,
+  WHENCE_CUR: () => WHENCE_CUR,
+  WHENCE_END: () => WHENCE_END,
+  WHENCE_SET: () => WHENCE_SET
+});
+var FD_STDIN = 0;
+var FD_STDOUT = 1;
+var FD_STDERR = 2;
+var CLOCKID_REALTIME = 0;
+var CLOCKID_MONOTONIC = 1;
+var CLOCKID_PROCESS_CPUTIME_ID = 2;
+var CLOCKID_THREAD_CPUTIME_ID = 3;
+var ERRNO_SUCCESS = 0;
+var ERRNO_2BIG = 1;
+var ERRNO_ACCES = 2;
+var ERRNO_ADDRINUSE = 3;
+var ERRNO_ADDRNOTAVAIL = 4;
+var ERRNO_AFNOSUPPORT = 5;
+var ERRNO_AGAIN = 6;
+var ERRNO_ALREADY = 7;
+var ERRNO_BADF = 8;
+var ERRNO_BADMSG = 9;
+var ERRNO_BUSY = 10;
+var ERRNO_CANCELED = 11;
+var ERRNO_CHILD = 12;
+var ERRNO_CONNABORTED = 13;
+var ERRNO_CONNREFUSED = 14;
+var ERRNO_CONNRESET = 15;
+var ERRNO_DEADLK = 16;
+var ERRNO_DESTADDRREQ = 17;
+var ERRNO_DOM = 18;
+var ERRNO_DQUOT = 19;
+var ERRNO_EXIST = 20;
+var ERRNO_FAULT = 21;
+var ERRNO_FBIG = 22;
+var ERRNO_HOSTUNREACH = 23;
+var ERRNO_IDRM = 24;
+var ERRNO_ILSEQ = 25;
+var ERRNO_INPROGRESS = 26;
+var ERRNO_INTR = 27;
+var ERRNO_INVAL = 28;
+var ERRNO_IO = 29;
+var ERRNO_ISCONN = 30;
+var ERRNO_ISDIR = 31;
+var ERRNO_LOOP = 32;
+var ERRNO_MFILE = 33;
+var ERRNO_MLINK = 34;
+var ERRNO_MSGSIZE = 35;
+var ERRNO_MULTIHOP = 36;
+var ERRNO_NAMETOOLONG = 37;
+var ERRNO_NETDOWN = 38;
+var ERRNO_NETRESET = 39;
+var ERRNO_NETUNREACH = 40;
+var ERRNO_NFILE = 41;
+var ERRNO_NOBUFS = 42;
+var ERRNO_NODEV = 43;
+var ERRNO_NOENT = 44;
+var ERRNO_NOEXEC = 45;
+var ERRNO_NOLCK = 46;
+var ERRNO_NOLINK = 47;
+var ERRNO_NOMEM = 48;
+var ERRNO_NOMSG = 49;
+var ERRNO_NOPROTOOPT = 50;
+var ERRNO_NOSPC = 51;
+var ERRNO_NOSYS = 52;
+var ERRNO_NOTCONN = 53;
+var ERRNO_NOTDIR = 54;
+var ERRNO_NOTEMPTY = 55;
+var ERRNO_NOTRECOVERABLE = 56;
+var ERRNO_NOTSOCK = 57;
+var ERRNO_NOTSUP = 58;
+var ERRNO_NOTTY = 59;
+var ERRNO_NXIO = 60;
+var ERRNO_OVERFLOW = 61;
+var ERRNO_OWNERDEAD = 62;
+var ERRNO_PERM = 63;
+var ERRNO_PIPE = 64;
+var ERRNO_PROTO = 65;
+var ERRNO_PROTONOSUPPORT = 66;
+var ERRNO_PROTOTYPE = 67;
+var ERRNO_RANGE = 68;
+var ERRNO_ROFS = 69;
+var ERRNO_SPIPE = 70;
+var ERRNO_SRCH = 71;
+var ERRNO_STALE = 72;
+var ERRNO_TIMEDOUT = 73;
+var ERRNO_TXTBSY = 74;
+var ERRNO_XDEV = 75;
+var ERRNO_NOTCAPABLE = 76;
+var RIGHTS_FD_DATASYNC = 1 << 0;
+var RIGHTS_FD_READ = 1 << 1;
+var RIGHTS_FD_SEEK = 1 << 2;
+var RIGHTS_FD_FDSTAT_SET_FLAGS = 1 << 3;
+var RIGHTS_FD_SYNC = 1 << 4;
+var RIGHTS_FD_TELL = 1 << 5;
+var RIGHTS_FD_WRITE = 1 << 6;
+var RIGHTS_FD_ADVISE = 1 << 7;
+var RIGHTS_FD_ALLOCATE = 1 << 8;
+var RIGHTS_PATH_CREATE_DIRECTORY = 1 << 9;
+var RIGHTS_PATH_CREATE_FILE = 1 << 10;
+var RIGHTS_PATH_LINK_SOURCE = 1 << 11;
+var RIGHTS_PATH_LINK_TARGET = 1 << 12;
+var RIGHTS_PATH_OPEN = 1 << 13;
+var RIGHTS_FD_READDIR = 1 << 14;
+var RIGHTS_PATH_READLINK = 1 << 15;
+var RIGHTS_PATH_RENAME_SOURCE = 1 << 16;
+var RIGHTS_PATH_RENAME_TARGET = 1 << 17;
+var RIGHTS_PATH_FILESTAT_GET = 1 << 18;
+var RIGHTS_PATH_FILESTAT_SET_SIZE = 1 << 19;
+var RIGHTS_PATH_FILESTAT_SET_TIMES = 1 << 20;
+var RIGHTS_FD_FILESTAT_GET = 1 << 21;
+var RIGHTS_FD_FILESTAT_SET_SIZE = 1 << 22;
+var RIGHTS_FD_FILESTAT_SET_TIMES = 1 << 23;
+var RIGHTS_PATH_SYMLINK = 1 << 24;
+var RIGHTS_PATH_REMOVE_DIRECTORY = 1 << 25;
+var RIGHTS_PATH_UNLINK_FILE = 1 << 26;
+var RIGHTS_POLL_FD_READWRITE = 1 << 27;
+var RIGHTS_SOCK_SHUTDOWN = 1 << 28;
+var Iovec = class _Iovec {
+  static read_bytes(view, ptr) {
+    const iovec = new _Iovec();
+    iovec.buf = view.getUint32(ptr, true);
+    iovec.buf_len = view.getUint32(ptr + 4, true);
+    return iovec;
+  }
+  static read_bytes_array(view, ptr, len) {
+    const iovecs = [];
+    for (let i = 0; i < len; i++) {
+      iovecs.push(_Iovec.read_bytes(view, ptr + 8 * i));
+    }
+    return iovecs;
+  }
+};
+var Ciovec = class _Ciovec {
+  static read_bytes(view, ptr) {
+    const iovec = new _Ciovec();
+    iovec.buf = view.getUint32(ptr, true);
+    iovec.buf_len = view.getUint32(ptr + 4, true);
+    return iovec;
+  }
+  static read_bytes_array(view, ptr, len) {
+    const iovecs = [];
+    for (let i = 0; i < len; i++) {
+      iovecs.push(_Ciovec.read_bytes(view, ptr + 8 * i));
+    }
+    return iovecs;
+  }
+};
+var WHENCE_SET = 0;
+var WHENCE_CUR = 1;
+var WHENCE_END = 2;
+var FILETYPE_UNKNOWN = 0;
+var FILETYPE_BLOCK_DEVICE = 1;
+var FILETYPE_CHARACTER_DEVICE = 2;
+var FILETYPE_DIRECTORY = 3;
+var FILETYPE_REGULAR_FILE = 4;
+var FILETYPE_SOCKET_DGRAM = 5;
+var FILETYPE_SOCKET_STREAM = 6;
+var FILETYPE_SYMBOLIC_LINK = 7;
+var Dirent = class {
+  head_length() {
+    return 24;
+  }
+  name_length() {
+    return this.dir_name.byteLength;
+  }
+  write_head_bytes(view, ptr) {
+    view.setBigUint64(ptr, this.d_next, true);
+    view.setBigUint64(ptr + 8, this.d_ino, true);
+    view.setUint32(ptr + 16, this.dir_name.length, true);
+    view.setUint8(ptr + 20, this.d_type);
+  }
+  write_name_bytes(view8, ptr, buf_len) {
+    view8.set(this.dir_name.slice(0, Math.min(this.dir_name.byteLength, buf_len)), ptr);
+  }
+  constructor(next_cookie, name, type) {
+    this.d_ino = 0n;
+    const encoded_name = new TextEncoder().encode(name);
+    this.d_next = next_cookie;
+    this.d_namlen = encoded_name.byteLength;
+    this.d_type = type;
+    this.dir_name = encoded_name;
+  }
+};
+var ADVICE_NORMAL = 0;
+var ADVICE_SEQUENTIAL = 1;
+var ADVICE_RANDOM = 2;
+var ADVICE_WILLNEED = 3;
+var ADVICE_DONTNEED = 4;
+var ADVICE_NOREUSE = 5;
+var FDFLAGS_APPEND = 1 << 0;
+var FDFLAGS_DSYNC = 1 << 1;
+var FDFLAGS_NONBLOCK = 1 << 2;
+var FDFLAGS_RSYNC = 1 << 3;
+var FDFLAGS_SYNC = 1 << 4;
+var Fdstat = class {
+  write_bytes(view, ptr) {
+    view.setUint8(ptr, this.fs_filetype);
+    view.setUint16(ptr + 2, this.fs_flags, true);
+    view.setBigUint64(ptr + 8, this.fs_rights_base, true);
+    view.setBigUint64(ptr + 16, this.fs_rights_inherited, true);
+  }
+  constructor(filetype, flags) {
+    this.fs_rights_base = 0n;
+    this.fs_rights_inherited = 0n;
+    this.fs_filetype = filetype;
+    this.fs_flags = flags;
+  }
+};
+var FSTFLAGS_ATIM = 1 << 0;
+var FSTFLAGS_ATIM_NOW = 1 << 1;
+var FSTFLAGS_MTIM = 1 << 2;
+var FSTFLAGS_MTIM_NOW = 1 << 3;
+var OFLAGS_CREAT = 1 << 0;
+var OFLAGS_DIRECTORY = 1 << 1;
+var OFLAGS_EXCL = 1 << 2;
+var OFLAGS_TRUNC = 1 << 3;
+var Filestat = class {
+  write_bytes(view, ptr) {
+    view.setBigUint64(ptr, this.dev, true);
+    view.setBigUint64(ptr + 8, this.ino, true);
+    view.setUint8(ptr + 16, this.filetype);
+    view.setBigUint64(ptr + 24, this.nlink, true);
+    view.setBigUint64(ptr + 32, this.size, true);
+    view.setBigUint64(ptr + 38, this.atim, true);
+    view.setBigUint64(ptr + 46, this.mtim, true);
+    view.setBigUint64(ptr + 52, this.ctim, true);
+  }
+  constructor(filetype, size) {
+    this.dev = 0n;
+    this.ino = 0n;
+    this.nlink = 0n;
+    this.atim = 0n;
+    this.mtim = 0n;
+    this.ctim = 0n;
+    this.filetype = filetype;
+    this.size = size;
+  }
+};
+var EVENTTYPE_CLOCK = 0;
+var EVENTTYPE_FD_READ = 1;
+var EVENTTYPE_FD_WRITE = 2;
+var EVENTRWFLAGS_FD_READWRITE_HANGUP = 1 << 0;
+var SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME = 1 << 0;
+var SIGNAL_NONE = 0;
+var SIGNAL_HUP = 1;
+var SIGNAL_INT = 2;
+var SIGNAL_QUIT = 3;
+var SIGNAL_ILL = 4;
+var SIGNAL_TRAP = 5;
+var SIGNAL_ABRT = 6;
+var SIGNAL_BUS = 7;
+var SIGNAL_FPE = 8;
+var SIGNAL_KILL = 9;
+var SIGNAL_USR1 = 10;
+var SIGNAL_SEGV = 11;
+var SIGNAL_USR2 = 12;
+var SIGNAL_PIPE = 13;
+var SIGNAL_ALRM = 14;
+var SIGNAL_TERM = 15;
+var SIGNAL_CHLD = 16;
+var SIGNAL_CONT = 17;
+var SIGNAL_STOP = 18;
+var SIGNAL_TSTP = 19;
+var SIGNAL_TTIN = 20;
+var SIGNAL_TTOU = 21;
+var SIGNAL_URG = 22;
+var SIGNAL_XCPU = 23;
+var SIGNAL_XFSZ = 24;
+var SIGNAL_VTALRM = 25;
+var SIGNAL_PROF = 26;
+var SIGNAL_WINCH = 27;
+var SIGNAL_POLL = 28;
+var SIGNAL_PWR = 29;
+var SIGNAL_SYS = 30;
+var RIFLAGS_RECV_PEEK = 1 << 0;
+var RIFLAGS_RECV_WAITALL = 1 << 1;
+var ROFLAGS_RECV_DATA_TRUNCATED = 1 << 0;
+var SDFLAGS_RD = 1 << 0;
+var SDFLAGS_WR = 1 << 1;
+var PREOPENTYPE_DIR = 0;
+var PrestatDir = class {
+  write_bytes(view, ptr) {
+    view.setUint32(ptr, this.pr_name.byteLength, true);
+  }
+  constructor(name) {
+    this.pr_name = new TextEncoder().encode(name);
+  }
+};
+var Prestat = class _Prestat {
+  static dir(name) {
+    const prestat = new _Prestat();
+    prestat.tag = PREOPENTYPE_DIR;
+    prestat.inner = new PrestatDir(name);
+    return prestat;
+  }
+  write_bytes(view, ptr) {
+    view.setUint32(ptr, this.tag, true);
+    this.inner.write_bytes(view, ptr + 4);
+  }
+};
+
+// node_modules/@bjorn3/browser_wasi_shim/dist/debug.js
+var Debug = class Debug2 {
+  enable(enabled) {
+    this.log = createLogger(enabled === void 0 ? true : enabled, this.prefix);
+  }
+  get enabled() {
+    return this.isEnabled;
+  }
+  constructor(isEnabled) {
+    this.isEnabled = isEnabled;
+    this.prefix = "wasi:";
+    this.enable(isEnabled);
+  }
+};
+function createLogger(enabled, prefix) {
+  if (enabled) {
+    const a = console.log.bind(console, "%c%s", "color: #265BA0", prefix);
+    return a;
+  } else {
+    return () => {
+    };
+  }
+}
+var debug = new Debug(false);
+
+// node_modules/@bjorn3/browser_wasi_shim/dist/wasi.js
+var WASIProcExit = class extends Error {
+  constructor(code) {
+    super("exit with exit code " + code);
+    this.code = code;
+  }
+};
+var WASI = class WASI2 {
+  start(instance) {
+    this.inst = instance;
+    try {
+      instance.exports._start();
+      return 0;
+    } catch (e) {
+      if (e instanceof WASIProcExit) {
+        return e.code;
+      } else {
+        throw e;
+      }
+    }
+  }
+  initialize(instance) {
+    this.inst = instance;
+    if (instance.exports._initialize) {
+      instance.exports._initialize();
+    }
+  }
+  constructor(args, env, fds, options = {}) {
+    this.args = [];
+    this.env = [];
+    this.fds = [];
+    debug.enable(options.debug);
+    this.args = args;
+    this.env = env;
+    this.fds = fds;
+    const self = this;
+    this.wasiImport = { args_sizes_get(argc, argv_buf_size) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      buffer.setUint32(argc, self.args.length, true);
+      let buf_size = 0;
+      for (const arg of self.args) {
+        buf_size += arg.length + 1;
+      }
+      buffer.setUint32(argv_buf_size, buf_size, true);
+      debug.log(buffer.getUint32(argc, true), buffer.getUint32(argv_buf_size, true));
+      return 0;
+    }, args_get(argv, argv_buf) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      const orig_argv_buf = argv_buf;
+      for (let i = 0; i < self.args.length; i++) {
+        buffer.setUint32(argv, argv_buf, true);
+        argv += 4;
+        const arg = new TextEncoder().encode(self.args[i]);
+        buffer8.set(arg, argv_buf);
+        buffer.setUint8(argv_buf + arg.length, 0);
+        argv_buf += arg.length + 1;
+      }
+      if (debug.enabled) {
+        debug.log(new TextDecoder("utf-8").decode(buffer8.slice(orig_argv_buf, argv_buf)));
+      }
+      return 0;
+    }, environ_sizes_get(environ_count, environ_size) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      buffer.setUint32(environ_count, self.env.length, true);
+      let buf_size = 0;
+      for (const environ of self.env) {
+        buf_size += environ.length + 1;
+      }
+      buffer.setUint32(environ_size, buf_size, true);
+      debug.log(buffer.getUint32(environ_count, true), buffer.getUint32(environ_size, true));
+      return 0;
+    }, environ_get(environ, environ_buf) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      const orig_environ_buf = environ_buf;
+      for (let i = 0; i < self.env.length; i++) {
+        buffer.setUint32(environ, environ_buf, true);
+        environ += 4;
+        const e = new TextEncoder().encode(self.env[i]);
+        buffer8.set(e, environ_buf);
+        buffer.setUint8(environ_buf + e.length, 0);
+        environ_buf += e.length + 1;
+      }
+      if (debug.enabled) {
+        debug.log(new TextDecoder("utf-8").decode(buffer8.slice(orig_environ_buf, environ_buf)));
+      }
+      return 0;
+    }, clock_res_get(id, res_ptr) {
+      let resolutionValue;
+      switch (id) {
+        case CLOCKID_MONOTONIC: {
+          resolutionValue = 5000n;
+          break;
+        }
+        case CLOCKID_REALTIME: {
+          resolutionValue = 1000000n;
+          break;
+        }
+        default:
+          return ERRNO_NOSYS;
+      }
+      const view = new DataView(self.inst.exports.memory.buffer);
+      view.setBigUint64(res_ptr, resolutionValue, true);
+      return ERRNO_SUCCESS;
+    }, clock_time_get(id, precision, time) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      if (id === CLOCKID_REALTIME) {
+        buffer.setBigUint64(time, BigInt((/* @__PURE__ */ new Date()).getTime()) * 1000000n, true);
+      } else if (id == CLOCKID_MONOTONIC) {
+        let monotonic_time;
+        try {
+          monotonic_time = BigInt(Math.round(performance.now() * 1e6));
+        } catch (e) {
+          monotonic_time = 0n;
+        }
+        buffer.setBigUint64(time, monotonic_time, true);
+      } else {
+        buffer.setBigUint64(time, 0n, true);
+      }
+      return 0;
+    }, fd_advise(fd, offset, len, advice) {
+      if (self.fds[fd] != void 0) {
+        return ERRNO_SUCCESS;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_allocate(fd, offset, len) {
+      if (self.fds[fd] != void 0) {
+        return self.fds[fd].fd_allocate(offset, len);
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_close(fd) {
+      if (self.fds[fd] != void 0) {
+        const ret = self.fds[fd].fd_close();
+        self.fds[fd] = void 0;
+        return ret;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_datasync(fd) {
+      if (self.fds[fd] != void 0) {
+        return self.fds[fd].fd_sync();
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_fdstat_get(fd, fdstat_ptr) {
+      if (self.fds[fd] != void 0) {
+        const { ret, fdstat } = self.fds[fd].fd_fdstat_get();
+        if (fdstat != null) {
+          fdstat.write_bytes(new DataView(self.inst.exports.memory.buffer), fdstat_ptr);
+        }
+        return ret;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_fdstat_set_flags(fd, flags) {
+      if (self.fds[fd] != void 0) {
+        return self.fds[fd].fd_fdstat_set_flags(flags);
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_fdstat_set_rights(fd, fs_rights_base, fs_rights_inheriting) {
+      if (self.fds[fd] != void 0) {
+        return self.fds[fd].fd_fdstat_set_rights(fs_rights_base, fs_rights_inheriting);
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_filestat_get(fd, filestat_ptr) {
+      if (self.fds[fd] != void 0) {
+        const { ret, filestat } = self.fds[fd].fd_filestat_get();
+        if (filestat != null) {
+          filestat.write_bytes(new DataView(self.inst.exports.memory.buffer), filestat_ptr);
+        }
+        return ret;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_filestat_set_size(fd, size) {
+      if (self.fds[fd] != void 0) {
+        return self.fds[fd].fd_filestat_set_size(size);
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_filestat_set_times(fd, atim, mtim, fst_flags) {
+      if (self.fds[fd] != void 0) {
+        return self.fds[fd].fd_filestat_set_times(atim, mtim, fst_flags);
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_pread(fd, iovs_ptr, iovs_len, offset, nread_ptr) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const iovecs = Iovec.read_bytes_array(buffer, iovs_ptr, iovs_len);
+        let nread = 0;
+        for (const iovec of iovecs) {
+          const { ret, data } = self.fds[fd].fd_pread(iovec.buf_len, offset);
+          if (ret != ERRNO_SUCCESS) {
+            buffer.setUint32(nread_ptr, nread, true);
+            return ret;
+          }
+          buffer8.set(data, iovec.buf);
+          nread += data.length;
+          offset += BigInt(data.length);
+          if (data.length != iovec.buf_len) {
+            break;
+          }
+        }
+        buffer.setUint32(nread_ptr, nread, true);
+        return ERRNO_SUCCESS;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_prestat_get(fd, buf_ptr) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const { ret, prestat } = self.fds[fd].fd_prestat_get();
+        if (prestat != null) {
+          prestat.write_bytes(buffer, buf_ptr);
+        }
+        return ret;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_prestat_dir_name(fd, path_ptr, path_len) {
+      if (self.fds[fd] != void 0) {
+        const { ret, prestat } = self.fds[fd].fd_prestat_get();
+        if (prestat == null) {
+          return ret;
+        }
+        const prestat_dir_name = prestat.inner.pr_name;
+        const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+        buffer8.set(prestat_dir_name.slice(0, path_len), path_ptr);
+        return prestat_dir_name.byteLength > path_len ? ERRNO_NAMETOOLONG : ERRNO_SUCCESS;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_pwrite(fd, iovs_ptr, iovs_len, offset, nwritten_ptr) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const iovecs = Ciovec.read_bytes_array(buffer, iovs_ptr, iovs_len);
+        let nwritten = 0;
+        for (const iovec of iovecs) {
+          const data = buffer8.slice(iovec.buf, iovec.buf + iovec.buf_len);
+          const { ret, nwritten: nwritten_part } = self.fds[fd].fd_pwrite(data, offset);
+          if (ret != ERRNO_SUCCESS) {
+            buffer.setUint32(nwritten_ptr, nwritten, true);
+            return ret;
+          }
+          nwritten += nwritten_part;
+          offset += BigInt(nwritten_part);
+          if (nwritten_part != data.byteLength) {
+            break;
+          }
+        }
+        buffer.setUint32(nwritten_ptr, nwritten, true);
+        return ERRNO_SUCCESS;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_read(fd, iovs_ptr, iovs_len, nread_ptr) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const iovecs = Iovec.read_bytes_array(buffer, iovs_ptr, iovs_len);
+        let nread = 0;
+        for (const iovec of iovecs) {
+          const { ret, data } = self.fds[fd].fd_read(iovec.buf_len);
+          if (ret != ERRNO_SUCCESS) {
+            buffer.setUint32(nread_ptr, nread, true);
+            return ret;
+          }
+          buffer8.set(data, iovec.buf);
+          nread += data.length;
+          if (data.length != iovec.buf_len) {
+            break;
+          }
+        }
+        buffer.setUint32(nread_ptr, nread, true);
+        return ERRNO_SUCCESS;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_readdir(fd, buf, buf_len, cookie, bufused_ptr) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        let bufused = 0;
+        while (true) {
+          const { ret, dirent } = self.fds[fd].fd_readdir_single(cookie);
+          if (ret != 0) {
+            buffer.setUint32(bufused_ptr, bufused, true);
+            return ret;
+          }
+          if (dirent == null) {
+            break;
+          }
+          if (buf_len - bufused < dirent.head_length()) {
+            bufused = buf_len;
+            break;
+          }
+          const head_bytes = new ArrayBuffer(dirent.head_length());
+          dirent.write_head_bytes(new DataView(head_bytes), 0);
+          buffer8.set(new Uint8Array(head_bytes).slice(0, Math.min(head_bytes.byteLength, buf_len - bufused)), buf);
+          buf += dirent.head_length();
+          bufused += dirent.head_length();
+          if (buf_len - bufused < dirent.name_length()) {
+            bufused = buf_len;
+            break;
+          }
+          dirent.write_name_bytes(buffer8, buf, buf_len - bufused);
+          buf += dirent.name_length();
+          bufused += dirent.name_length();
+          cookie = dirent.d_next;
+        }
+        buffer.setUint32(bufused_ptr, bufused, true);
+        return 0;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_renumber(fd, to) {
+      if (self.fds[fd] != void 0 && self.fds[to] != void 0) {
+        const ret = self.fds[to].fd_close();
+        if (ret != 0) {
+          return ret;
+        }
+        self.fds[to] = self.fds[fd];
+        self.fds[fd] = void 0;
+        return 0;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_seek(fd, offset, whence, offset_out_ptr) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const { ret, offset: offset_out } = self.fds[fd].fd_seek(offset, whence);
+        buffer.setBigInt64(offset_out_ptr, offset_out, true);
+        return ret;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_sync(fd) {
+      if (self.fds[fd] != void 0) {
+        return self.fds[fd].fd_sync();
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_tell(fd, offset_ptr) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const { ret, offset } = self.fds[fd].fd_tell();
+        buffer.setBigUint64(offset_ptr, offset, true);
+        return ret;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, fd_write(fd, iovs_ptr, iovs_len, nwritten_ptr) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const iovecs = Ciovec.read_bytes_array(buffer, iovs_ptr, iovs_len);
+        let nwritten = 0;
+        for (const iovec of iovecs) {
+          const data = buffer8.slice(iovec.buf, iovec.buf + iovec.buf_len);
+          const { ret, nwritten: nwritten_part } = self.fds[fd].fd_write(data);
+          if (ret != ERRNO_SUCCESS) {
+            buffer.setUint32(nwritten_ptr, nwritten, true);
+            return ret;
+          }
+          nwritten += nwritten_part;
+          if (nwritten_part != data.byteLength) {
+            break;
+          }
+        }
+        buffer.setUint32(nwritten_ptr, nwritten, true);
+        return ERRNO_SUCCESS;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, path_create_directory(fd, path_ptr, path_len) {
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const path = new TextDecoder("utf-8").decode(buffer8.slice(path_ptr, path_ptr + path_len));
+        return self.fds[fd].path_create_directory(path);
+      } else {
+        return ERRNO_BADF;
+      }
+    }, path_filestat_get(fd, flags, path_ptr, path_len, filestat_ptr) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const path = new TextDecoder("utf-8").decode(buffer8.slice(path_ptr, path_ptr + path_len));
+        const { ret, filestat } = self.fds[fd].path_filestat_get(flags, path);
+        if (filestat != null) {
+          filestat.write_bytes(buffer, filestat_ptr);
+        }
+        return ret;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, path_filestat_set_times(fd, flags, path_ptr, path_len, atim, mtim, fst_flags) {
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const path = new TextDecoder("utf-8").decode(buffer8.slice(path_ptr, path_ptr + path_len));
+        return self.fds[fd].path_filestat_set_times(flags, path, atim, mtim, fst_flags);
+      } else {
+        return ERRNO_BADF;
+      }
+    }, path_link(old_fd, old_flags, old_path_ptr, old_path_len, new_fd, new_path_ptr, new_path_len) {
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[old_fd] != void 0 && self.fds[new_fd] != void 0) {
+        const old_path = new TextDecoder("utf-8").decode(buffer8.slice(old_path_ptr, old_path_ptr + old_path_len));
+        const new_path = new TextDecoder("utf-8").decode(buffer8.slice(new_path_ptr, new_path_ptr + new_path_len));
+        const { ret, inode_obj } = self.fds[old_fd].path_lookup(old_path, old_flags);
+        if (inode_obj == null) {
+          return ret;
+        }
+        return self.fds[new_fd].path_link(new_path, inode_obj, false);
+      } else {
+        return ERRNO_BADF;
+      }
+    }, path_open(fd, dirflags, path_ptr, path_len, oflags, fs_rights_base, fs_rights_inheriting, fd_flags, opened_fd_ptr) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const path = new TextDecoder("utf-8").decode(buffer8.slice(path_ptr, path_ptr + path_len));
+        debug.log(path);
+        const { ret, fd_obj } = self.fds[fd].path_open(dirflags, path, oflags, fs_rights_base, fs_rights_inheriting, fd_flags);
+        if (ret != 0) {
+          return ret;
+        }
+        self.fds.push(fd_obj);
+        const opened_fd = self.fds.length - 1;
+        buffer.setUint32(opened_fd_ptr, opened_fd, true);
+        return 0;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, path_readlink(fd, path_ptr, path_len, buf_ptr, buf_len, nread_ptr) {
+      const buffer = new DataView(self.inst.exports.memory.buffer);
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const path = new TextDecoder("utf-8").decode(buffer8.slice(path_ptr, path_ptr + path_len));
+        debug.log(path);
+        const { ret, data } = self.fds[fd].path_readlink(path);
+        if (data != null) {
+          const data_buf = new TextEncoder().encode(data);
+          if (data_buf.length > buf_len) {
+            buffer.setUint32(nread_ptr, 0, true);
+            return ERRNO_BADF;
+          }
+          buffer8.set(data_buf, buf_ptr);
+          buffer.setUint32(nread_ptr, data_buf.length, true);
+        }
+        return ret;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, path_remove_directory(fd, path_ptr, path_len) {
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const path = new TextDecoder("utf-8").decode(buffer8.slice(path_ptr, path_ptr + path_len));
+        return self.fds[fd].path_remove_directory(path);
+      } else {
+        return ERRNO_BADF;
+      }
+    }, path_rename(fd, old_path_ptr, old_path_len, new_fd, new_path_ptr, new_path_len) {
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0 && self.fds[new_fd] != void 0) {
+        const old_path = new TextDecoder("utf-8").decode(buffer8.slice(old_path_ptr, old_path_ptr + old_path_len));
+        const new_path = new TextDecoder("utf-8").decode(buffer8.slice(new_path_ptr, new_path_ptr + new_path_len));
+        let { ret, inode_obj } = self.fds[fd].path_unlink(old_path);
+        if (inode_obj == null) {
+          return ret;
+        }
+        ret = self.fds[new_fd].path_link(new_path, inode_obj, true);
+        if (ret != ERRNO_SUCCESS) {
+          if (self.fds[fd].path_link(old_path, inode_obj, true) != ERRNO_SUCCESS) {
+            throw "path_link should always return success when relinking an inode back to the original place";
+          }
+        }
+        return ret;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, path_symlink(old_path_ptr, old_path_len, fd, new_path_ptr, new_path_len) {
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const old_path = new TextDecoder("utf-8").decode(buffer8.slice(old_path_ptr, old_path_ptr + old_path_len));
+        const new_path = new TextDecoder("utf-8").decode(buffer8.slice(new_path_ptr, new_path_ptr + new_path_len));
+        return ERRNO_NOTSUP;
+      } else {
+        return ERRNO_BADF;
+      }
+    }, path_unlink_file(fd, path_ptr, path_len) {
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      if (self.fds[fd] != void 0) {
+        const path = new TextDecoder("utf-8").decode(buffer8.slice(path_ptr, path_ptr + path_len));
+        return self.fds[fd].path_unlink_file(path);
+      } else {
+        return ERRNO_BADF;
+      }
+    }, poll_oneoff(in_, out, nsubscriptions) {
+      throw "async io not supported";
+    }, proc_exit(exit_code) {
+      throw new WASIProcExit(exit_code);
+    }, proc_raise(sig) {
+      throw "raised signal " + sig;
+    }, sched_yield() {
+    }, random_get(buf, buf_len) {
+      const buffer8 = new Uint8Array(self.inst.exports.memory.buffer);
+      for (let i = 0; i < buf_len; i++) {
+        buffer8[buf + i] = Math.random() * 256 | 0;
+      }
+    }, sock_recv(fd, ri_data, ri_flags) {
+      throw "sockets not supported";
+    }, sock_send(fd, si_data, si_flags) {
+      throw "sockets not supported";
+    }, sock_shutdown(fd, how) {
+      throw "sockets not supported";
+    }, sock_accept(fd, flags) {
+      throw "sockets not supported";
+    } };
+  }
+};
+
+// node_modules/@bjorn3/browser_wasi_shim/dist/fd.js
+var Fd = class {
+  fd_allocate(offset, len) {
+    return ERRNO_NOTSUP;
+  }
+  fd_close() {
+    return 0;
+  }
+  fd_fdstat_get() {
+    return { ret: ERRNO_NOTSUP, fdstat: null };
+  }
+  fd_fdstat_set_flags(flags) {
+    return ERRNO_NOTSUP;
+  }
+  fd_fdstat_set_rights(fs_rights_base, fs_rights_inheriting) {
+    return ERRNO_NOTSUP;
+  }
+  fd_filestat_get() {
+    return { ret: ERRNO_NOTSUP, filestat: null };
+  }
+  fd_filestat_set_size(size) {
+    return ERRNO_NOTSUP;
+  }
+  fd_filestat_set_times(atim, mtim, fst_flags) {
+    return ERRNO_NOTSUP;
+  }
+  fd_pread(size, offset) {
+    return { ret: ERRNO_NOTSUP, data: new Uint8Array() };
+  }
+  fd_prestat_get() {
+    return { ret: ERRNO_NOTSUP, prestat: null };
+  }
+  fd_pwrite(data, offset) {
+    return { ret: ERRNO_NOTSUP, nwritten: 0 };
+  }
+  fd_read(size) {
+    return { ret: ERRNO_NOTSUP, data: new Uint8Array() };
+  }
+  fd_readdir_single(cookie) {
+    return { ret: ERRNO_NOTSUP, dirent: null };
+  }
+  fd_seek(offset, whence) {
+    return { ret: ERRNO_NOTSUP, offset: 0n };
+  }
+  fd_sync() {
+    return 0;
+  }
+  fd_tell() {
+    return { ret: ERRNO_NOTSUP, offset: 0n };
+  }
+  fd_write(data) {
+    return { ret: ERRNO_NOTSUP, nwritten: 0 };
+  }
+  path_create_directory(path) {
+    return ERRNO_NOTSUP;
+  }
+  path_filestat_get(flags, path) {
+    return { ret: ERRNO_NOTSUP, filestat: null };
+  }
+  path_filestat_set_times(flags, path, atim, mtim, fst_flags) {
+    return ERRNO_NOTSUP;
+  }
+  path_link(path, inode, allow_dir) {
+    return ERRNO_NOTSUP;
+  }
+  path_unlink(path) {
+    return { ret: ERRNO_NOTSUP, inode_obj: null };
+  }
+  path_lookup(path, dirflags) {
+    return { ret: ERRNO_NOTSUP, inode_obj: null };
+  }
+  path_open(dirflags, path, oflags, fs_rights_base, fs_rights_inheriting, fd_flags) {
+    return { ret: ERRNO_NOTDIR, fd_obj: null };
+  }
+  path_readlink(path) {
+    return { ret: ERRNO_NOTSUP, data: null };
+  }
+  path_remove_directory(path) {
+    return ERRNO_NOTSUP;
+  }
+  path_rename(old_path, new_fd, new_path) {
+    return ERRNO_NOTSUP;
+  }
+  path_unlink_file(path) {
+    return ERRNO_NOTSUP;
+  }
+};
+var Inode = class {
+};
+
+// node_modules/@bjorn3/browser_wasi_shim/dist/fs_mem.js
+var OpenFile = class extends Fd {
+  fd_allocate(offset, len) {
+    if (this.file.size > offset + len) {
+    } else {
+      const new_data = new Uint8Array(Number(offset + len));
+      new_data.set(this.file.data, 0);
+      this.file.data = new_data;
+    }
+    return ERRNO_SUCCESS;
+  }
+  fd_fdstat_get() {
+    return { ret: 0, fdstat: new Fdstat(FILETYPE_REGULAR_FILE, 0) };
+  }
+  fd_filestat_set_size(size) {
+    if (this.file.size > size) {
+      this.file.data = new Uint8Array(this.file.data.buffer.slice(0, Number(size)));
+    } else {
+      const new_data = new Uint8Array(Number(size));
+      new_data.set(this.file.data, 0);
+      this.file.data = new_data;
+    }
+    return ERRNO_SUCCESS;
+  }
+  fd_read(size) {
+    const slice = this.file.data.slice(Number(this.file_pos), Number(this.file_pos + BigInt(size)));
+    this.file_pos += BigInt(slice.length);
+    return { ret: 0, data: slice };
+  }
+  fd_pread(size, offset) {
+    const slice = this.file.data.slice(Number(offset), Number(offset + BigInt(size)));
+    return { ret: 0, data: slice };
+  }
+  fd_seek(offset, whence) {
+    let calculated_offset;
+    switch (whence) {
+      case WHENCE_SET:
+        calculated_offset = offset;
+        break;
+      case WHENCE_CUR:
+        calculated_offset = this.file_pos + offset;
+        break;
+      case WHENCE_END:
+        calculated_offset = BigInt(this.file.data.byteLength) + offset;
+        break;
+      default:
+        return { ret: ERRNO_INVAL, offset: 0n };
+    }
+    if (calculated_offset < 0) {
+      return { ret: ERRNO_INVAL, offset: 0n };
+    }
+    this.file_pos = calculated_offset;
+    return { ret: 0, offset: this.file_pos };
+  }
+  fd_tell() {
+    return { ret: 0, offset: this.file_pos };
+  }
+  fd_write(data) {
+    if (this.file.readonly) return { ret: ERRNO_BADF, nwritten: 0 };
+    if (this.file_pos + BigInt(data.byteLength) > this.file.size) {
+      const old = this.file.data;
+      this.file.data = new Uint8Array(Number(this.file_pos + BigInt(data.byteLength)));
+      this.file.data.set(old);
+    }
+    this.file.data.set(data, Number(this.file_pos));
+    this.file_pos += BigInt(data.byteLength);
+    return { ret: 0, nwritten: data.byteLength };
+  }
+  fd_pwrite(data, offset) {
+    if (this.file.readonly) return { ret: ERRNO_BADF, nwritten: 0 };
+    if (offset + BigInt(data.byteLength) > this.file.size) {
+      const old = this.file.data;
+      this.file.data = new Uint8Array(Number(offset + BigInt(data.byteLength)));
+      this.file.data.set(old);
+    }
+    this.file.data.set(data, Number(offset));
+    return { ret: 0, nwritten: data.byteLength };
+  }
+  fd_filestat_get() {
+    return { ret: 0, filestat: this.file.stat() };
+  }
+  constructor(file) {
+    super();
+    this.file_pos = 0n;
+    this.file = file;
+  }
+};
+var OpenDirectory = class extends Fd {
+  fd_seek(offset, whence) {
+    return { ret: ERRNO_BADF, offset: 0n };
+  }
+  fd_tell() {
+    return { ret: ERRNO_BADF, offset: 0n };
+  }
+  fd_allocate(offset, len) {
+    return ERRNO_BADF;
+  }
+  fd_fdstat_get() {
+    return { ret: 0, fdstat: new Fdstat(FILETYPE_DIRECTORY, 0) };
+  }
+  fd_readdir_single(cookie) {
+    if (debug.enabled) {
+      debug.log("readdir_single", cookie);
+      debug.log(cookie, this.dir.contents.keys());
+    }
+    if (cookie == 0n) {
+      return { ret: ERRNO_SUCCESS, dirent: new Dirent(1n, ".", FILETYPE_DIRECTORY) };
+    } else if (cookie == 1n) {
+      return { ret: ERRNO_SUCCESS, dirent: new Dirent(2n, "..", FILETYPE_DIRECTORY) };
+    }
+    if (cookie >= BigInt(this.dir.contents.size) + 2n) {
+      return { ret: 0, dirent: null };
+    }
+    const [name, entry] = Array.from(this.dir.contents.entries())[Number(cookie - 2n)];
+    return { ret: 0, dirent: new Dirent(cookie + 1n, name, entry.stat().filetype) };
+  }
+  path_filestat_get(flags, path_str) {
+    const { ret: path_err, path } = Path.from(path_str);
+    if (path == null) {
+      return { ret: path_err, filestat: null };
+    }
+    const { ret, entry } = this.dir.get_entry_for_path(path);
+    if (entry == null) {
+      return { ret, filestat: null };
+    }
+    return { ret: 0, filestat: entry.stat() };
+  }
+  path_lookup(path_str, dirflags) {
+    const { ret: path_ret, path } = Path.from(path_str);
+    if (path == null) {
+      return { ret: path_ret, inode_obj: null };
+    }
+    const { ret, entry } = this.dir.get_entry_for_path(path);
+    if (entry == null) {
+      return { ret, inode_obj: null };
+    }
+    return { ret: ERRNO_SUCCESS, inode_obj: entry };
+  }
+  path_open(dirflags, path_str, oflags, fs_rights_base, fs_rights_inheriting, fd_flags) {
+    const { ret: path_ret, path } = Path.from(path_str);
+    if (path == null) {
+      return { ret: path_ret, fd_obj: null };
+    }
+    let { ret, entry } = this.dir.get_entry_for_path(path);
+    if (entry == null) {
+      if (ret != ERRNO_NOENT) {
+        return { ret, fd_obj: null };
+      }
+      if ((oflags & OFLAGS_CREAT) == OFLAGS_CREAT) {
+        const { ret: ret2, entry: new_entry } = this.dir.create_entry_for_path(path_str, (oflags & OFLAGS_DIRECTORY) == OFLAGS_DIRECTORY);
+        if (new_entry == null) {
+          return { ret: ret2, fd_obj: null };
+        }
+        entry = new_entry;
+      } else {
+        return { ret: ERRNO_NOENT, fd_obj: null };
+      }
+    } else if ((oflags & OFLAGS_EXCL) == OFLAGS_EXCL) {
+      return { ret: ERRNO_EXIST, fd_obj: null };
+    }
+    if ((oflags & OFLAGS_DIRECTORY) == OFLAGS_DIRECTORY && entry.stat().filetype !== FILETYPE_DIRECTORY) {
+      return { ret: ERRNO_NOTDIR, fd_obj: null };
+    }
+    return entry.path_open(oflags, fs_rights_base, fd_flags);
+  }
+  path_create_directory(path) {
+    return this.path_open(0, path, OFLAGS_CREAT | OFLAGS_DIRECTORY, 0n, 0n, 0).ret;
+  }
+  path_link(path_str, inode, allow_dir) {
+    const { ret: path_ret, path } = Path.from(path_str);
+    if (path == null) {
+      return path_ret;
+    }
+    if (path.is_dir) {
+      return ERRNO_NOENT;
+    }
+    const { ret: parent_ret, parent_entry, filename, entry } = this.dir.get_parent_dir_and_entry_for_path(path, true);
+    if (parent_entry == null || filename == null) {
+      return parent_ret;
+    }
+    if (entry != null) {
+      const source_is_dir = inode.stat().filetype == FILETYPE_DIRECTORY;
+      const target_is_dir = entry.stat().filetype == FILETYPE_DIRECTORY;
+      if (source_is_dir && target_is_dir) {
+        if (allow_dir && entry instanceof Directory) {
+          if (entry.contents.size == 0) {
+          } else {
+            return ERRNO_NOTEMPTY;
+          }
+        } else {
+          return ERRNO_EXIST;
+        }
+      } else if (source_is_dir && !target_is_dir) {
+        return ERRNO_NOTDIR;
+      } else if (!source_is_dir && target_is_dir) {
+        return ERRNO_ISDIR;
+      } else if (inode.stat().filetype == FILETYPE_REGULAR_FILE && entry.stat().filetype == FILETYPE_REGULAR_FILE) {
+      } else {
+        return ERRNO_EXIST;
+      }
+    }
+    if (!allow_dir && inode.stat().filetype == FILETYPE_DIRECTORY) {
+      return ERRNO_PERM;
+    }
+    parent_entry.contents.set(filename, inode);
+    return ERRNO_SUCCESS;
+  }
+  path_unlink(path_str) {
+    const { ret: path_ret, path } = Path.from(path_str);
+    if (path == null) {
+      return { ret: path_ret, inode_obj: null };
+    }
+    const { ret: parent_ret, parent_entry, filename, entry } = this.dir.get_parent_dir_and_entry_for_path(path, true);
+    if (parent_entry == null || filename == null) {
+      return { ret: parent_ret, inode_obj: null };
+    }
+    if (entry == null) {
+      return { ret: ERRNO_NOENT, inode_obj: null };
+    }
+    parent_entry.contents.delete(filename);
+    return { ret: ERRNO_SUCCESS, inode_obj: entry };
+  }
+  path_unlink_file(path_str) {
+    const { ret: path_ret, path } = Path.from(path_str);
+    if (path == null) {
+      return path_ret;
+    }
+    const { ret: parent_ret, parent_entry, filename, entry } = this.dir.get_parent_dir_and_entry_for_path(path, false);
+    if (parent_entry == null || filename == null || entry == null) {
+      return parent_ret;
+    }
+    if (entry.stat().filetype === FILETYPE_DIRECTORY) {
+      return ERRNO_ISDIR;
+    }
+    parent_entry.contents.delete(filename);
+    return ERRNO_SUCCESS;
+  }
+  path_remove_directory(path_str) {
+    const { ret: path_ret, path } = Path.from(path_str);
+    if (path == null) {
+      return path_ret;
+    }
+    const { ret: parent_ret, parent_entry, filename, entry } = this.dir.get_parent_dir_and_entry_for_path(path, false);
+    if (parent_entry == null || filename == null || entry == null) {
+      return parent_ret;
+    }
+    if (!(entry instanceof Directory) || entry.stat().filetype !== FILETYPE_DIRECTORY) {
+      return ERRNO_NOTDIR;
+    }
+    if (entry.contents.size !== 0) {
+      return ERRNO_NOTEMPTY;
+    }
+    if (!parent_entry.contents.delete(filename)) {
+      return ERRNO_NOENT;
+    }
+    return ERRNO_SUCCESS;
+  }
+  fd_filestat_get() {
+    return { ret: 0, filestat: this.dir.stat() };
+  }
+  fd_filestat_set_size(size) {
+    return ERRNO_BADF;
+  }
+  fd_read(size) {
+    return { ret: ERRNO_BADF, data: new Uint8Array() };
+  }
+  fd_pread(size, offset) {
+    return { ret: ERRNO_BADF, data: new Uint8Array() };
+  }
+  fd_write(data) {
+    return { ret: ERRNO_BADF, nwritten: 0 };
+  }
+  fd_pwrite(data, offset) {
+    return { ret: ERRNO_BADF, nwritten: 0 };
+  }
+  constructor(dir) {
+    super();
+    this.dir = dir;
+  }
+};
+var PreopenDirectory = class extends OpenDirectory {
+  fd_prestat_get() {
+    return { ret: 0, prestat: Prestat.dir(this.prestat_name) };
+  }
+  constructor(name, contents) {
+    super(new Directory(contents));
+    this.prestat_name = name;
+  }
+};
+var File = class extends Inode {
+  path_open(oflags, fs_rights_base, fd_flags) {
+    if (this.readonly && (fs_rights_base & BigInt(RIGHTS_FD_WRITE)) == BigInt(RIGHTS_FD_WRITE)) {
+      return { ret: ERRNO_PERM, fd_obj: null };
+    }
+    if ((oflags & OFLAGS_TRUNC) == OFLAGS_TRUNC) {
+      if (this.readonly) return { ret: ERRNO_PERM, fd_obj: null };
+      this.data = new Uint8Array([]);
+    }
+    const file = new OpenFile(this);
+    if (fd_flags & FDFLAGS_APPEND) file.fd_seek(0n, WHENCE_END);
+    return { ret: ERRNO_SUCCESS, fd_obj: file };
+  }
+  get size() {
+    return BigInt(this.data.byteLength);
+  }
+  stat() {
+    return new Filestat(FILETYPE_REGULAR_FILE, this.size);
+  }
+  constructor(data, options) {
+    super();
+    this.data = new Uint8Array(data);
+    this.readonly = !!options?.readonly;
+  }
+};
+var Path = class Path2 {
+  static from(path) {
+    const self = new Path2();
+    self.is_dir = path.endsWith("/");
+    if (path.startsWith("/")) {
+      return { ret: ERRNO_NOTCAPABLE, path: null };
+    }
+    if (path.includes("\0")) {
+      return { ret: ERRNO_INVAL, path: null };
+    }
+    for (const component of path.split("/")) {
+      if (component === "" || component === ".") {
+        continue;
+      }
+      if (component === "..") {
+        if (self.parts.pop() == void 0) {
+          return { ret: ERRNO_NOTCAPABLE, path: null };
+        }
+        continue;
+      }
+      self.parts.push(component);
+    }
+    return { ret: ERRNO_SUCCESS, path: self };
+  }
+  to_path_string() {
+    let s = this.parts.join("/");
+    if (this.is_dir) {
+      s += "/";
+    }
+    return s;
+  }
+  constructor() {
+    this.parts = [];
+    this.is_dir = false;
+  }
+};
+var Directory = class _Directory extends Inode {
+  path_open(oflags, fs_rights_base, fd_flags) {
+    return { ret: ERRNO_SUCCESS, fd_obj: new OpenDirectory(this) };
+  }
+  stat() {
+    return new Filestat(FILETYPE_DIRECTORY, 0n);
+  }
+  get_entry_for_path(path) {
+    let entry = this;
+    for (const component of path.parts) {
+      if (!(entry instanceof _Directory)) {
+        return { ret: ERRNO_NOTDIR, entry: null };
+      }
+      const child = entry.contents.get(component);
+      if (child !== void 0) {
+        entry = child;
+      } else {
+        debug.log(component);
+        return { ret: ERRNO_NOENT, entry: null };
+      }
+    }
+    if (path.is_dir) {
+      if (entry.stat().filetype != FILETYPE_DIRECTORY) {
+        return { ret: ERRNO_NOTDIR, entry: null };
+      }
+    }
+    return { ret: ERRNO_SUCCESS, entry };
+  }
+  get_parent_dir_and_entry_for_path(path, allow_undefined) {
+    const filename = path.parts.pop();
+    if (filename === void 0) {
+      return { ret: ERRNO_INVAL, parent_entry: null, filename: null, entry: null };
+    }
+    const { ret: entry_ret, entry: parent_entry } = this.get_entry_for_path(path);
+    if (parent_entry == null) {
+      return { ret: entry_ret, parent_entry: null, filename: null, entry: null };
+    }
+    if (!(parent_entry instanceof _Directory)) {
+      return { ret: ERRNO_NOTDIR, parent_entry: null, filename: null, entry: null };
+    }
+    const entry = parent_entry.contents.get(filename);
+    if (entry === void 0) {
+      if (!allow_undefined) {
+        return { ret: ERRNO_NOENT, parent_entry: null, filename: null, entry: null };
+      } else {
+        return { ret: ERRNO_SUCCESS, parent_entry, filename, entry: null };
+      }
+    }
+    if (path.is_dir) {
+      if (entry.stat().filetype != FILETYPE_DIRECTORY) {
+        return { ret: ERRNO_NOTDIR, parent_entry: null, filename: null, entry: null };
+      }
+    }
+    return { ret: ERRNO_SUCCESS, parent_entry, filename, entry };
+  }
+  create_entry_for_path(path_str, is_dir) {
+    const { ret: path_ret, path } = Path.from(path_str);
+    if (path == null) {
+      return { ret: path_ret, entry: null };
+    }
+    let { ret: parent_ret, parent_entry, filename, entry } = this.get_parent_dir_and_entry_for_path(path, true);
+    if (parent_entry == null || filename == null) {
+      return { ret: parent_ret, entry: null };
+    }
+    if (entry != null) {
+      return { ret: ERRNO_EXIST, entry: null };
+    }
+    debug.log("create", path);
+    let new_child;
+    if (!is_dir) {
+      new_child = new File(new ArrayBuffer(0));
+    } else {
+      new_child = new _Directory(/* @__PURE__ */ new Map());
+    }
+    parent_entry.contents.set(filename, new_child);
+    entry = new_child;
+    return { ret: ERRNO_SUCCESS, entry };
+  }
+  constructor(contents) {
+    super();
+    if (contents instanceof Array) {
+      this.contents = new Map(contents);
+    } else {
+      this.contents = contents;
+    }
+  }
+};
+var ConsoleStdout = class _ConsoleStdout extends Fd {
+  fd_filestat_get() {
+    const filestat = new Filestat(FILETYPE_CHARACTER_DEVICE, BigInt(0));
+    return { ret: 0, filestat };
+  }
+  fd_fdstat_get() {
+    const fdstat = new Fdstat(FILETYPE_CHARACTER_DEVICE, 0);
+    fdstat.fs_rights_base = BigInt(RIGHTS_FD_WRITE);
+    return { ret: 0, fdstat };
+  }
+  fd_write(data) {
+    this.write(data);
+    return { ret: 0, nwritten: data.byteLength };
+  }
+  static lineBuffered(write) {
+    const dec = new TextDecoder("utf-8", { fatal: false });
+    let line_buf = "";
+    return new _ConsoleStdout((buffer) => {
+      line_buf += dec.decode(buffer, { stream: true });
+      const lines = line_buf.split("\n");
+      for (const [i, line] of lines.entries()) {
+        if (i < lines.length - 1) {
+          write(line);
+        } else {
+          line_buf = line;
+        }
+      }
+    });
+  }
+  constructor(write) {
+    super();
+    this.write = write;
+  }
+};
+
+// node_modules/@bjorn3/browser_wasi_shim/dist/fs_opfs.js
+var SyncOPFSFile = class extends Inode {
+  path_open(oflags, fs_rights_base, fd_flags) {
+    if (this.readonly && (fs_rights_base & BigInt(RIGHTS_FD_WRITE)) == BigInt(RIGHTS_FD_WRITE)) {
+      return { ret: ERRNO_PERM, fd_obj: null };
+    }
+    if ((oflags & OFLAGS_TRUNC) == OFLAGS_TRUNC) {
+      if (this.readonly) return { ret: ERRNO_PERM, fd_obj: null };
+      this.handle.truncate(0);
+    }
+    const file = new OpenSyncOPFSFile(this);
+    if (fd_flags & FDFLAGS_APPEND) file.fd_seek(0n, WHENCE_END);
+    return { ret: ERRNO_SUCCESS, fd_obj: file };
+  }
+  get size() {
+    return BigInt(this.handle.getSize());
+  }
+  stat() {
+    return new Filestat(FILETYPE_REGULAR_FILE, this.size);
+  }
+  constructor(handle, options) {
+    super();
+    this.handle = handle;
+    this.readonly = !!options?.readonly;
+  }
+};
+var OpenSyncOPFSFile = class extends Fd {
+  fd_allocate(offset, len) {
+    if (BigInt(this.file.handle.getSize()) > offset + len) {
+    } else {
+      this.file.handle.truncate(Number(offset + len));
+    }
+    return ERRNO_SUCCESS;
+  }
+  fd_fdstat_get() {
+    return { ret: 0, fdstat: new Fdstat(FILETYPE_REGULAR_FILE, 0) };
+  }
+  fd_filestat_get() {
+    return { ret: 0, filestat: new Filestat(FILETYPE_REGULAR_FILE, BigInt(this.file.handle.getSize())) };
+  }
+  fd_filestat_set_size(size) {
+    this.file.handle.truncate(Number(size));
+    return ERRNO_SUCCESS;
+  }
+  fd_read(size) {
+    const buf = new Uint8Array(size);
+    const n = this.file.handle.read(buf, { at: Number(this.position) });
+    this.position += BigInt(n);
+    return { ret: 0, data: buf.slice(0, n) };
+  }
+  fd_seek(offset, whence) {
+    let calculated_offset;
+    switch (whence) {
+      case WHENCE_SET:
+        calculated_offset = BigInt(offset);
+        break;
+      case WHENCE_CUR:
+        calculated_offset = this.position + BigInt(offset);
+        break;
+      case WHENCE_END:
+        calculated_offset = BigInt(this.file.handle.getSize()) + BigInt(offset);
+        break;
+      default:
+        return { ret: ERRNO_INVAL, offset: 0n };
+    }
+    if (calculated_offset < 0) {
+      return { ret: ERRNO_INVAL, offset: 0n };
+    }
+    this.position = calculated_offset;
+    return { ret: ERRNO_SUCCESS, offset: this.position };
+  }
+  fd_write(data) {
+    if (this.file.readonly) return { ret: ERRNO_BADF, nwritten: 0 };
+    const n = this.file.handle.write(data, { at: Number(this.position) });
+    this.position += BigInt(n);
+    return { ret: ERRNO_SUCCESS, nwritten: n };
+  }
+  fd_sync() {
+    this.file.handle.flush();
+    return ERRNO_SUCCESS;
+  }
+  constructor(file) {
+    super();
+    this.position = 0n;
+    this.file = file;
+  }
+};
+
+// node_modules/@bjorn3/browser_wasi_shim/dist/strace.js
+function strace(imports, no_trace) {
+  return new Proxy(imports, { get(target, prop, receiver) {
+    const f = Reflect.get(target, prop, receiver);
+    if (no_trace.includes(prop)) {
+      return f;
+    }
+    return function(...args) {
+      console.log(prop, "(", ...args, ")");
+      const result = Reflect.apply(f, receiver, args);
+      console.log(" =", result);
+      return result;
+    };
+  } });
+}
+export {
+  ConsoleStdout,
+  Directory,
+  Fd,
+  File,
+  Inode,
+  OpenDirectory,
+  OpenFile,
+  OpenSyncOPFSFile,
+  PreopenDirectory,
+  SyncOPFSFile,
+  WASI,
+  WASIProcExit,
+  strace,
+  wasi_defs_exports as wasi
+};

--- a/public/sw-cleanup.js
+++ b/public/sw-cleanup.js
@@ -1,0 +1,19 @@
+// Imported into the generated service worker (see vite.config.ts
+// workbox.importScripts). Workbox's generateSW only cleans its OWN precache, so
+// runtime caches from earlier releases linger on returning clients until the
+// browser evicts them under quota pressure — and one of them, the CDN-era
+// pandoc-wasm-cdn-cache-v1, holds ~58MB. Delete the retired names on activate
+// so that dead weight is reclaimed.
+//
+// On a pandoc version bump (which rotates the live cache to
+// pandoc-wasm-cache-<newversion>), add the prior version's cache name here.
+const RETIRED_CACHES = [
+  'pandoc-wasm-cache-v1',
+  'pandoc-wasm-cache-v2',
+  'pandoc-wasm-cdn-cache-v1',
+  'wasi-shim-cdn-cache-v1',
+];
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(Promise.all(RETIRED_CACHES.map((name) => caches.delete(name))));
+});

--- a/scripts/check-no-cdn.mjs
+++ b/scripts/check-no-cdn.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Postbuild guard: fail the build if any shipped asset references a public
+ * CDN. The app promises air-gap operation (SIPR/JWICS) — a dependency bump or
+ * a copied snippet can quietly reintroduce a CDN fetch that works in an
+ * online dev session and only fails in the field, where nobody sees the
+ * error. This converts that silent regression into a loud CI stop.
+ *
+ * Runs via the `postbuild` npm hook, so the existing "production build" CI
+ * job enforces it with no workflow changes.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, extname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Hosts that must never appear in a shipped asset. */
+export const FORBIDDEN = [
+  'unpkg.com',
+  'cdn.jsdelivr.net',
+  'cdnjs.cloudflare.com',
+  'fonts.googleapis.com',
+  'fonts.gstatic.com',
+  'ajax.googleapis.com',
+];
+
+const SCAN_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.css', '.html', '.json', '.map']);
+
+/**
+ * Pure detector: every {host, line} hit in a text blob. Exported for unit
+ * tests (tests/unit/checkNoCdn.test.ts) — CI proves absence on the current
+ * dist; the test proves the detector actually fires when a host appears.
+ */
+export function findCdnHits(text, forbidden = FORBIDDEN) {
+  const hits = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    for (const host of forbidden) {
+      if (lines[i].includes(host)) hits.push({ host, line: i + 1 });
+    }
+  }
+  return hits;
+}
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) yield* walk(full);
+    else yield full;
+  }
+}
+
+function main() {
+  // Resolved here, not at module load: vitest imports this module under a
+  // non-file URL scheme, where fileURLToPath throws. Only execution needs it.
+  const DIST = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist');
+  let scanned = 0;
+  let failed = false;
+  for (const file of walk(DIST)) {
+    if (!SCAN_EXTENSIONS.has(extname(file))) continue;
+    scanned++;
+    const hits = findCdnHits(readFileSync(file, 'utf8'));
+    for (const { host, line } of hits) {
+      failed = true;
+      console.error(`[check-no-cdn] ${relative(DIST, file)}:${line} references ${host}`);
+    }
+  }
+  if (failed) {
+    console.error(
+      '\n[check-no-cdn] FAIL — the build references public CDNs, which breaks the ' +
+        'advertised air-gap capability. Vendor the asset same-origin (see ' +
+        'scripts/vendor-assets.mjs) instead of fetching it from a CDN.'
+    );
+    process.exit(1);
+  }
+  console.log(`[check-no-cdn] OK — ${scanned} dist assets scanned, no CDN references`);
+}
+
+// Execution guard: unit tests import findCdnHits without scanning anything.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-no-cdn.mjs
+++ b/scripts/check-no-cdn.mjs
@@ -9,9 +9,20 @@
  * Runs via the `postbuild` npm hook, so the existing "production build" CI
  * job enforces it with no workflow changes.
  */
-import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { dirname, extname, join, relative, resolve } from 'node:path';
+import { readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { dirname, extname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+/** True when this module is the entry point. Realpath-resolves both sides so a
+ *  symlinked absolute invocation (e.g. via /tmp on macOS) still runs the guard
+ *  instead of silently passing — see the matching note in vendor-assets.mjs. */
+function isMainModule() {
+  try {
+    return !!process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
 
 /** Hosts that must never appear in a shipped asset. */
 export const FORBIDDEN = [
@@ -76,6 +87,6 @@ function main() {
 }
 
 // Execution guard: unit tests import findCdnHits without scanning anything.
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (isMainModule()) {
   main();
 }

--- a/scripts/check-no-cdn.mjs
+++ b/scripts/check-no-cdn.mjs
@@ -24,11 +24,19 @@ function isMainModule() {
   }
 }
 
-/** Hosts that must never appear in a shipped asset. */
+/** Public CDN hosts that must never appear in a shipped asset. A denylist, not
+ *  a proof of no cross-origin fetch — it enumerates the well-known JS-module and
+ *  font CDNs an accidental `import from 'https://…'` would realistically pull
+ *  from. Add new module CDNs here as they appear. */
 export const FORBIDDEN = [
   'unpkg.com',
   'cdn.jsdelivr.net',
   'cdnjs.cloudflare.com',
+  'esm.sh',
+  'esm.run',
+  'cdn.skypack.dev',
+  'jspm.io',
+  'raw.githubusercontent.com',
   'fonts.googleapis.com',
   'fonts.gstatic.com',
   'ajax.googleapis.com',

--- a/scripts/vendor-assets.mjs
+++ b/scripts/vendor-assets.mjs
@@ -113,7 +113,9 @@ async function vendorPandocWasm() {
 
   mkdirSync(PANDOC_DIR, { recursive: true });
   console.log(`[vendor] ${WASM.name}: downloading ${WASM.url} ...`);
-  const res = await fetch(WASM.url);
+  // Bounded: a black-holing proxy would otherwise hang the build/dev startup
+  // forever (native fetch has no default timeout).
+  const res = await fetch(WASM.url, { signal: AbortSignal.timeout(120_000) });
   if (!res.ok || !res.body) {
     throw new Error(`[vendor] ${WASM.name}: HTTP ${res.status} ${res.statusText} fetching ${WASM.url}`);
   }
@@ -164,6 +166,10 @@ async function vendorPandocWasm() {
 }
 
 async function main() {
+  // predev passes --allow-offline: dev doesn't need DOCX to boot, so a failed
+  // vendor there is a warning, not a hard stop. prebuild passes nothing, so a
+  // release build still fails loudly if the parts can't be staged.
+  const allowOffline = process.argv.includes('--allow-offline');
   await cleanupLegacyFiles();
   try {
     if (process.env.SKIP_VENDOR_ASSETS === '1') {
@@ -182,10 +188,14 @@ async function main() {
     await vendorPandocWasm();
   } catch (err) {
     console.error(String(err instanceof Error ? err.message : err));
-    console.error(
-      '\n[vendor] pandoc parts are unavailable — DOCX export will not work until they exist. ' +
-        'Offline? Stage the parts + manifest into public/lib/pandoc/ and set SKIP_VENDOR_ASSETS=1.'
-    );
+    const guidance =
+      '[vendor] pandoc parts are unavailable — DOCX export will not work until they exist. ' +
+      'Offline? Stage the parts + manifest into public/lib/pandoc/ and set SKIP_VENDOR_ASSETS=1.';
+    if (allowOffline) {
+      console.warn(`${guidance}\n[vendor] --allow-offline: continuing without them (dev only).`);
+      return;
+    }
+    console.error(guidance);
     process.exit(1);
   }
 }

--- a/scripts/vendor-assets.mjs
+++ b/scripts/vendor-assets.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * Vendor the pandoc WASM binary into public/lib/pandoc/ as same-origin PARTS,
+ * so the deployed artifact is fully self-contained and works on air-gapped
+ * SIPR/JWICS networks — the app's advertised promise.
+ *
+ * Why parts instead of one file:
+ *   pandoc.wasm is ~58 MB. Cloudflare Pages and Workers static assets enforce
+ *   a 25 MiB per-file limit — a single vendored wasm cannot deploy (this is
+ *   the failure that stalled the original vendoring attempt, PR #75). The
+ *   binary is split into ≤19 MiB parts here and reassembled by
+ *   public/lib/pandoc/pandoc.js in the browser before instantiation.
+ *
+ * Why a build-time download instead of committing the binary:
+ *   Committing ~58 MB would triple the repo and live in history forever.
+ *   Instead we fetch a pinned version before dev/build (when machines are
+ *   online) and .gitignore the output. Vite copies public/ verbatim into
+ *   dist/, so the DEPLOYED bundle bakes the parts in. Never contacted at app
+ *   runtime — only here, at build time.
+ *
+ * The manifest (pandoc.wasm.manifest.json) is written LAST, atomically: its
+ * presence is the commit point. A crash mid-split leaves no valid manifest,
+ * so the next run redoes the work instead of trusting half-written parts.
+ *
+ * Idempotent: skips when the manifest matches the pinned version and every
+ * listed part exists at its recorded size. SKIP_VENDOR_ASSETS=1 bypasses all
+ * network work for fully-offline builders that pre-stage the files.
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
+import { open, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+const PANDOC_DIR = join(REPO_ROOT, 'public/lib/pandoc');
+
+const WASM = {
+  name: 'pandoc.wasm',
+  version: '1.0.1', // pinned upstream release — reproducible artifact
+  url: 'https://unpkg.com/pandoc-wasm@1.0.1/src/pandoc.wasm',
+  minBytes: 50 * 1024 * 1024, // sanity floor: rejects truncated/HTML error bodies
+  magic: [0x00, 0x61, 0x73, 0x6d], // WASM magic word
+};
+
+const MANIFEST_PATH = join(PANDOC_DIR, 'pandoc.wasm.manifest.json');
+
+/** Cloudflare's per-file limit is 25 MiB; 19 MiB leaves ~6 MiB of headroom. */
+export const PART_SIZE = 19 * 1024 * 1024;
+
+/**
+ * Pure split plan: the byte length of each part for a payload of totalBytes.
+ * Exported for unit tests (tests/unit/vendorAssets.split.test.ts).
+ */
+export function planParts(totalBytes, partSize = PART_SIZE) {
+  if (!Number.isInteger(totalBytes) || totalBytes <= 0) {
+    throw new Error(`planParts: invalid totalBytes ${totalBytes}`);
+  }
+  if (!Number.isInteger(partSize) || partSize <= 0) {
+    throw new Error(`planParts: invalid partSize ${partSize}`);
+  }
+  const sizes = [];
+  for (let off = 0; off < totalBytes; off += partSize) {
+    sizes.push(Math.min(partSize, totalBytes - off));
+  }
+  return sizes;
+}
+
+/** The stale whole-file and any half-written temp must never reach dist/ —
+ *  a single >25 MiB file re-kills the Cloudflare deploy even with parts
+ *  present. Runs unconditionally, including on the idempotent-skip path. */
+async function cleanupLegacyFiles() {
+  await rm(join(PANDOC_DIR, 'pandoc.wasm'), { force: true });
+  if (!existsSync(PANDOC_DIR)) return;
+  for (const f of readdirSync(PANDOC_DIR)) {
+    if (f.endsWith('.partial')) await rm(join(PANDOC_DIR, f), { force: true });
+  }
+}
+
+async function isCurrent() {
+  try {
+    const manifest = JSON.parse(await readFile(MANIFEST_PATH, 'utf8'));
+    if (manifest.version !== WASM.version) return false;
+    if (!Array.isArray(manifest.parts) || manifest.parts.length !== manifest.partBytes?.length) return false;
+    return manifest.parts.every((part, i) => {
+      const p = join(PANDOC_DIR, part);
+      return existsSync(p) && statSync(p).size === manifest.partBytes[i];
+    });
+  } catch {
+    return false;
+  }
+}
+
+async function vendorPandocWasm() {
+  if (await isCurrent()) {
+    console.log(`[vendor] ${WASM.name} ${WASM.version}: parts current per manifest — skipping download`);
+    return;
+  }
+
+  mkdirSync(PANDOC_DIR, { recursive: true });
+  console.log(`[vendor] ${WASM.name}: downloading ${WASM.url} ...`);
+  const res = await fetch(WASM.url);
+  if (!res.ok || !res.body) {
+    throw new Error(`[vendor] ${WASM.name}: HTTP ${res.status} ${res.statusText} fetching ${WASM.url}`);
+  }
+  const bytes = Buffer.from(await res.arrayBuffer());
+
+  if (bytes.byteLength < WASM.minBytes) {
+    throw new Error(
+      `[vendor] ${WASM.name}: got ${bytes.byteLength} bytes (< ${WASM.minBytes}); likely a CDN error body, not the asset`
+    );
+  }
+  if (!WASM.magic.every((b, i) => bytes[i] === b)) {
+    throw new Error(`[vendor] ${WASM.name}: magic-byte check failed; refusing to ship a corrupt asset`);
+  }
+  const sha256 = createHash('sha256').update(bytes).digest('hex');
+
+  // Split into parts, each staged as .partial and renamed only when complete.
+  const sizes = planParts(bytes.byteLength);
+  const parts = sizes.map((_, i) => `pandoc.wasm.part${i}`);
+  let offset = 0;
+  for (let i = 0; i < sizes.length; i++) {
+    const tmp = join(PANDOC_DIR, `${parts[i]}.partial`);
+    const fh = await open(tmp, 'w');
+    await fh.write(bytes, offset, sizes[i]);
+    await fh.close();
+    await rename(tmp, join(PANDOC_DIR, parts[i]));
+    offset += sizes[i];
+  }
+
+  // Manifest last: presence == the whole set is valid.
+  const manifest = {
+    name: WASM.name,
+    version: WASM.version,
+    totalBytes: bytes.byteLength,
+    parts,
+    partBytes: sizes,
+    sha256,
+  };
+  const tmpManifest = `${MANIFEST_PATH}.partial`;
+  await writeFile(tmpManifest, `${JSON.stringify(manifest, null, 2)}\n`);
+  await rename(tmpManifest, MANIFEST_PATH);
+
+  console.log(
+    `[vendor] ${WASM.name}: OK — ${sizes.length} parts (${sizes
+      .map((s) => `${(s / 1024 / 1024).toFixed(1)}MB`)
+      .join(' + ')}), sha256 ${sha256.slice(0, 12)}…`
+  );
+}
+
+async function main() {
+  if (process.env.SKIP_VENDOR_ASSETS === '1') {
+    console.log('[vendor] SKIP_VENDOR_ASSETS=1 — skipping downloads (pre-staged builder)');
+    await cleanupLegacyFiles();
+    return;
+  }
+  try {
+    await cleanupLegacyFiles();
+    await vendorPandocWasm();
+  } catch (err) {
+    console.error(String(err instanceof Error ? err.message : err));
+    console.error(
+      '\n[vendor] pandoc parts are missing — DOCX export will not work until they exist. ' +
+        'If this machine is offline, stage the parts + manifest into public/lib/pandoc/ ' +
+        'manually and set SKIP_VENDOR_ASSETS=1.'
+    );
+    process.exit(1);
+  }
+}
+
+// Execution guard: unit tests import planParts without triggering a download.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/vendor-assets.mjs
+++ b/scripts/vendor-assets.mjs
@@ -28,7 +28,7 @@
  */
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readdirSync, realpathSync, statSync } from 'node:fs';
-import { open, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -129,16 +129,17 @@ async function vendorPandocWasm() {
   }
   const sha256 = createHash('sha256').update(bytes).digest('hex');
 
-  // Split into parts, each staged as .partial and renamed only when complete.
+  // Write each part directly. writeFile loops on short writes internally
+  // (a single fh.write does not — its bytesWritten can be < length on ENOSPC/
+  // RLIMIT and the caller must retry the remainder), so this can't ship a
+  // truncated part the manifest then blesses. Per-part .partial staging would
+  // be redundant: the manifest is written last as the commit point, so a crash
+  // before it lands leaves isCurrent() false and the next run re-vendors.
   const sizes = planParts(bytes.byteLength);
   const parts = sizes.map((_, i) => `pandoc.wasm.part${i}`);
   let offset = 0;
   for (let i = 0; i < sizes.length; i++) {
-    const tmp = join(PANDOC_DIR, `${parts[i]}.partial`);
-    const fh = await open(tmp, 'w');
-    await fh.write(bytes, offset, sizes[i]);
-    await fh.close();
-    await rename(tmp, join(PANDOC_DIR, parts[i]));
+    await writeFile(join(PANDOC_DIR, parts[i]), bytes.subarray(offset, offset + sizes[i]));
     offset += sizes[i];
   }
 

--- a/scripts/vendor-assets.mjs
+++ b/scripts/vendor-assets.mjs
@@ -27,10 +27,23 @@
  * network work for fully-offline builders that pre-stage the files.
  */
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, realpathSync, statSync } from 'node:fs';
 import { open, readFile, rename, rm, writeFile } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+/** True when this module is the entry point. Both sides are realpath-resolved:
+ *  Node realpaths import.meta.url for the main module, but process.argv[1] keeps
+ *  any symlink as typed, so a plain path.resolve comparison is false under a
+ *  symlinked checkout (e.g. macOS /tmp → /private/tmp) and the script would
+ *  silently no-op — disabling the air-gap staging it exists to guarantee. */
+function isMainModule() {
+  try {
+    return !!process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..');
@@ -170,6 +183,6 @@ async function main() {
 }
 
 // Execution guard: unit tests import planParts without triggering a download.
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (isMainModule()) {
   await main();
 }

--- a/scripts/vendor-assets.mjs
+++ b/scripts/vendor-assets.mjs
@@ -163,20 +163,27 @@ async function vendorPandocWasm() {
 }
 
 async function main() {
-  if (process.env.SKIP_VENDOR_ASSETS === '1') {
-    console.log('[vendor] SKIP_VENDOR_ASSETS=1 — skipping downloads (pre-staged builder)');
-    await cleanupLegacyFiles();
-    return;
-  }
+  await cleanupLegacyFiles();
   try {
-    await cleanupLegacyFiles();
+    if (process.env.SKIP_VENDOR_ASSETS === '1') {
+      // Pre-staged builder: don't download, but DO verify the operator actually
+      // staged valid parts. isCurrent() is pure local filesystem work — there's
+      // no air-gap reason to skip it — and a green build with no parts is the
+      // exact silent regression this pipeline exists to prevent.
+      if (await isCurrent()) {
+        console.log(`[vendor] SKIP_VENDOR_ASSETS=1 — pre-staged parts verified (${WASM.name} ${WASM.version})`);
+        return;
+      }
+      throw new Error(
+        'SKIP_VENDOR_ASSETS=1 but the pandoc parts/manifest are missing or stale in public/lib/pandoc/'
+      );
+    }
     await vendorPandocWasm();
   } catch (err) {
     console.error(String(err instanceof Error ? err.message : err));
     console.error(
-      '\n[vendor] pandoc parts are missing — DOCX export will not work until they exist. ' +
-        'If this machine is offline, stage the parts + manifest into public/lib/pandoc/ ' +
-        'manually and set SKIP_VENDOR_ASSETS=1.'
+      '\n[vendor] pandoc parts are unavailable — DOCX export will not work until they exist. ' +
+        'Offline? Stage the parts + manifest into public/lib/pandoc/ and set SKIP_VENDOR_ASSETS=1.'
     );
     process.exit(1);
   }

--- a/scripts/vendor-assets.mjs
+++ b/scripts/vendor-assets.mjs
@@ -105,6 +105,28 @@ async function isCurrent() {
   }
 }
 
+/** Fetch with retries + backoff so a transient unpkg blip doesn't fail an
+ *  otherwise-green build (or the docker-release build). Each attempt gets its
+ *  own timeout — an AbortSignal can't be reused once it has fired. */
+async function fetchWithRetry(url, attempts = 3, timeoutMs = 120_000) {
+  let lastErr;
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+      if (res.ok && res.body) return res;
+      lastErr = new Error(`HTTP ${res.status} ${res.statusText}`);
+    } catch (err) {
+      lastErr = err instanceof Error ? err : new Error(String(err));
+    }
+    if (i < attempts) {
+      const backoff = 1000 * 2 ** (i - 1);
+      console.warn(`[vendor] download attempt ${i}/${attempts} failed (${lastErr.message}); retrying in ${backoff}ms`);
+      await new Promise((r) => setTimeout(r, backoff));
+    }
+  }
+  throw new Error(`[vendor] ${WASM.name}: download failed after ${attempts} attempts — ${lastErr?.message}`);
+}
+
 async function vendorPandocWasm() {
   if (await isCurrent()) {
     console.log(`[vendor] ${WASM.name} ${WASM.version}: parts current per manifest — skipping download`);
@@ -113,12 +135,7 @@ async function vendorPandocWasm() {
 
   mkdirSync(PANDOC_DIR, { recursive: true });
   console.log(`[vendor] ${WASM.name}: downloading ${WASM.url} ...`);
-  // Bounded: a black-holing proxy would otherwise hang the build/dev startup
-  // forever (native fetch has no default timeout).
-  const res = await fetch(WASM.url, { signal: AbortSignal.timeout(120_000) });
-  if (!res.ok || !res.body) {
-    throw new Error(`[vendor] ${WASM.name}: HTTP ${res.status} ${res.statusText} fetching ${WASM.url}`);
-  }
+  const res = await fetchWithRetry(WASM.url);
   const bytes = Buffer.from(await res.arrayBuffer());
 
   if (bytes.byteLength < WASM.minBytes) {

--- a/src/hooks/usePandocIdlePrefetch.ts
+++ b/src/hooks/usePandocIdlePrefetch.ts
@@ -1,10 +1,11 @@
 /**
  * Idle-time prefetch of the Pandoc WASM module (~58 MB).
  *
- * The first DOCX export downloads the Pandoc WASM binary from unpkg, plus
- * a small WASI shim from jsdelivr. On a typical connection that's a
- * 5-15s wait between the user clicking "Download DOCX" and the file
- * actually being generated -- a noticeably bad first-time experience.
+ * The first DOCX export downloads the Pandoc WASM binary as same-origin
+ * parts from /lib/pandoc/ (vendored at build time — no CDN, so it works
+ * air-gapped). On a typical connection that's still a 5-15s wait between
+ * the user clicking "Download DOCX" and the file actually being
+ * generated -- a noticeably bad first-time experience.
  *
  * This hook fires `prefetchPandocModule()` shortly after the page is
  * idle, populating the in-memory singleton + workbox runtime cache in

--- a/src/services/docx/pandoc-converter.ts
+++ b/src/services/docx/pandoc-converter.ts
@@ -64,8 +64,10 @@ let referenceDocxBlob: Blob | null = null;
 let luaFilterBlob: Blob | null = null;
 
 async function loadPandocModule(): Promise<PandocModule> {
-  // pandoc.js is an ES module with top-level await and CDN imports.
-  // It lives in public/ and must NOT go through Vite's transform pipeline.
+  // pandoc.js is an ES module with top-level await; it loads the WASI shim
+  // and the pandoc WASM parts same-origin from /lib/pandoc/ (vendored at
+  // build time — air-gap safe, no CDN). It lives in public/ and must NOT go
+  // through Vite's transform pipeline.
   // We construct a full absolute URL so the browser loads it directly.
   const moduleUrl = new URL(`${BASE_PATH}lib/pandoc/pandoc.js`, window.location.origin).href;
   debug.log('DOCX', `Loading pandoc WASM module from ${moduleUrl}`);

--- a/tests/unit/checkNoCdn.test.ts
+++ b/tests/unit/checkNoCdn.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+// Safe to import: check-no-cdn.mjs has an execution guard, so no dist scan runs.
+import { findCdnHits, FORBIDDEN } from '../../scripts/check-no-cdn.mjs';
+
+describe('findCdnHits — the air-gap regression detector', () => {
+  it('flags every forbidden host with the right line number', () => {
+    for (const host of FORBIDDEN) {
+      const text = `line one\nconst url = "https://${host}/some/asset.js";\nline three`;
+      expect(findCdnHits(text)).toEqual([{ host, line: 2 }]);
+    }
+  });
+
+  it('reports multiple hits across lines', () => {
+    const text = 'import x from "https://cdn.jsdelivr.net/a.js";\nok\nfetch("https://unpkg.com/b.wasm");';
+    expect(findCdnHits(text)).toEqual([
+      { host: 'cdn.jsdelivr.net', line: 1 },
+      { host: 'unpkg.com', line: 3 },
+    ]);
+  });
+
+  it('clean text produces no hits', () => {
+    const text = 'const wasmUrl = new URL("./pandoc.wasm.part0", import.meta.url);\nfetch("/lib/pandoc/pandoc.wasm.manifest.json");';
+    expect(findCdnHits(text)).toEqual([]);
+  });
+});

--- a/tests/unit/vendorAssets.split.test.ts
+++ b/tests/unit/vendorAssets.split.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+// Importing is safe: vendor-assets.mjs has an execution guard, so no download runs.
+import { planParts, PART_SIZE } from '../../scripts/vendor-assets.mjs';
+
+const CLOUDFLARE_LIMIT = 25 * 1024 * 1024; // the per-file cap that killed PR #75
+const PANDOC_WASM_BYTES = 58_379_729; // pandoc-wasm@1.0.1, pinned in the script
+
+describe('planParts — the split that keeps every deployed file under 25MiB', () => {
+  it('splits the real pandoc.wasm size into the expected three parts', () => {
+    expect(planParts(PANDOC_WASM_BYTES)).toEqual([19_922_944, 19_922_944, 18_533_841]);
+  });
+
+  it('property: parts always sum to the total and each clears the Cloudflare limit', () => {
+    for (const total of [1, PART_SIZE - 1, PART_SIZE, PART_SIZE + 1, PANDOC_WASM_BYTES, 100_000_000]) {
+      const sizes = planParts(total);
+      expect(sizes.reduce((a, b) => a + b, 0)).toBe(total);
+      for (const s of sizes) {
+        expect(s).toBeGreaterThan(0);
+        expect(s).toBeLessThan(CLOUDFLARE_LIMIT);
+      }
+    }
+  });
+
+  it('a payload at exactly one part size yields a single part', () => {
+    expect(planParts(PART_SIZE)).toEqual([PART_SIZE]);
+  });
+
+  it('rejects invalid inputs', () => {
+    expect(() => planParts(0)).toThrow();
+    expect(() => planParts(-5)).toThrow();
+    expect(() => planParts(1.5)).toThrow();
+    expect(() => planParts(100, 0)).toThrow();
+  });
+
+  it('reassembly identity: slicing a buffer per plan and concatenating restores it', () => {
+    // Synthetic 1MB pseudo-random buffer, split with a small part size.
+    const total = 1_000_003; // deliberately not a multiple
+    const src = new Uint8Array(total);
+    for (let i = 0; i < total; i++) src[i] = (i * 31 + 7) % 256;
+
+    const sizes = planParts(total, 123_457);
+    const parts: Uint8Array[] = [];
+    let off = 0;
+    for (const s of sizes) {
+      parts.push(src.slice(off, off + s));
+      off += s;
+    }
+
+    const merged = new Uint8Array(total);
+    let w = 0;
+    for (const p of parts) {
+      merged.set(p, w);
+      w += p.byteLength;
+    }
+    expect(w).toBe(total);
+    expect(Buffer.from(merged).equals(Buffer.from(src))).toBe(true);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -361,55 +361,23 @@ export default defineConfig({
             },
           },
           {
-            // Cache pandoc WASM files for offline DOCX generation
+            // Pandoc assets (manifest + wasm parts + lua filter + reference
+            // docx) — all same-origin since the air-gap vendoring; the old
+            // unpkg/jsdelivr rules are gone with the CDN fetches themselves.
+            // v2: v1 may hold a stale whole pandoc.wasm entry from the CDN
+            // era. Workbox never deletes unreferenced runtime caches, so v1
+            // (and the two retired CDN caches) linger on returning clients
+            // until the browser evicts them — same accepted cost as the
+            // versioned app-shell caches above.
             urlPattern: /\/lib\/pandoc\/.*/,
             handler: 'CacheFirst',
             options: {
-              cacheName: 'pandoc-wasm-cache-v1',
+              cacheName: 'pandoc-wasm-cache-v2',
               expiration: {
+                // manifest + 3 parts + dondocs.lua + reference.docx = 6 live
+                // entries (pandoc.js and wasi-shim.js are precached).
                 maxEntries: 10,
                 maxAgeSeconds: 60 * 60 * 24 * 90, // 90 days
-              },
-            },
-          },
-          {
-            // Cache the Pandoc WASM binary fetched from unpkg by pandoc.js
-            // (`https://unpkg.com/pandoc-wasm@1.0.1/src/pandoc.wasm`, ~58 MB).
-            // Without this rule, only the browser's HTTP cache would protect
-            // against re-downloading after the user clears site data or after
-            // the browser cache evicts under pressure. With workbox's 90-day
-            // CacheFirst, the bytes survive across sessions and the
-            // `usePandocIdlePrefetch` warm-up is durable.
-            urlPattern: /^https:\/\/unpkg\.com\/pandoc-wasm@/,
-            handler: 'CacheFirst',
-            options: {
-              cacheName: 'pandoc-wasm-cdn-cache-v1',
-              expiration: {
-                maxEntries: 5,
-                maxAgeSeconds: 60 * 60 * 24 * 90, // 90 days
-              },
-              cacheableResponse: {
-                // unpkg returns 200 for cache hits; opaque (0) responses
-                // can occur for cross-origin requests without CORS, but
-                // unpkg sets CORS headers so we should always get 200.
-                statuses: [0, 200],
-              },
-            },
-          },
-          {
-            // Cache the WASI shim that pandoc.js imports from jsdelivr
-            // (`https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim@.../index.js`,
-            // ~50 KB). Same rationale as the unpkg rule above.
-            urlPattern: /^https:\/\/cdn\.jsdelivr\.net\/npm\/@bjorn3\/browser_wasi_shim/,
-            handler: 'CacheFirst',
-            options: {
-              cacheName: 'wasi-shim-cdn-cache-v1',
-              expiration: {
-                maxEntries: 5,
-                maxAgeSeconds: 60 * 60 * 24 * 90, // 90 days
-              },
-              cacheableResponse: {
-                statuses: [0, 200],
               },
             },
           },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -251,6 +251,9 @@ export default defineConfig({
       workbox: {
         // With registerType: 'prompt', vite-plugin-pwa handles skipWaiting via message
         // Do NOT add skipWaiting or clientsClaim here - they cause auto-reload
+        // Reclaim retired runtime caches on activate (workbox only cleans its
+        // own precache). public/sw-cleanup.js is served next to sw.js.
+        importScripts: ['sw-cleanup.js'],
         // Increase limit for large JS bundles (SwiftLaTeX is ~9MB)
         maximumFileSizeToCacheInBytes: 10 * 1024 * 1024, // 10MB
         // SW-2: the app loads latex-templates.js?v=11 and swiftlatexpdftex.js?v=6;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,22 @@ const GIT_SHA = (() => {
 })();
 const BUILD_TIME = new Date().toISOString();
 
+// The vendored pandoc-wasm release (from the manifest scripts/vendor-assets.mjs
+// wrote at prebuild). The pandoc runtime cache is named after it, so bumping
+// the pinned version rotates to a brand-new cache — a returning client can
+// never reassemble a mix of old cached parts and new network parts. 'dev' when
+// the manifest isn't staged yet (e.g. dev without a prior vendor run).
+const PANDOC_VERSION = (() => {
+  try {
+    const m = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, 'public/lib/pandoc/pandoc.wasm.manifest.json'), 'utf-8')
+    );
+    return typeof m.version === 'string' ? m.version : 'dev';
+  } catch {
+    return 'dev';
+  }
+})();
+
 // Inject version metadata into index.html as <meta> tags so deployed version
 // can be verified without running JS (e.g., `curl site.com | grep dondocs-version`).
 function versionMetaPlugin(): Plugin {
@@ -362,17 +378,16 @@ export default defineConfig({
           },
           {
             // Pandoc assets (manifest + wasm parts + lua filter + reference
-            // docx) — all same-origin since the air-gap vendoring; the old
-            // unpkg/jsdelivr rules are gone with the CDN fetches themselves.
-            // v2: v1 may hold a stale whole pandoc.wasm entry from the CDN
-            // era. Workbox never deletes unreferenced runtime caches, so v1
-            // (and the two retired CDN caches) linger on returning clients
-            // until the browser evicts them — same accepted cost as the
-            // versioned app-shell caches above.
+            // docx) — all same-origin since the air-gap vendoring. The cache
+            // name is stamped with the pandoc release, so a version bump lands
+            // on an empty cache and the manifest + every part are fetched fresh
+            // together: no returning client can ever assemble a stale-part /
+            // fresh-part mix from an unversioned CacheFirst URL. Retired caches
+            // are reclaimed by public/sw-cleanup.js on activate.
             urlPattern: /\/lib\/pandoc\/.*/,
             handler: 'CacheFirst',
             options: {
-              cacheName: 'pandoc-wasm-cache-v2',
+              cacheName: `pandoc-wasm-cache-${PANDOC_VERSION}`,
               expiration: {
                 // manifest + 3 parts + dondocs.lua + reference.docx = 6 live
                 // entries (pandoc.js and wasi-shim.js are precached).


### PR DESCRIPTION
## Why

The app advertises **"air-gap capable — works completely offline on SIPR/JWICS"** (README, About, NIST compliance modal), but the DOCX pipeline had **two runtime fetches to public CDNs** in `public/lib/pandoc/pandoc.js`:

1. It imported the WASI shim from a public CDN as a **top-level `await`** — on an isolated network the whole module died at load, taking DOCX export with it.
2. It fetched the **~58 MB `pandoc.wasm` from a public CDN**.

Warm-cache offline worked (the service worker had cached the CDN URLs), so it looked fine in dev — but a true air-gap with a cold cache hard-failed. That's the opposite of the headline promise for its actual audience.

This supersedes #75, which fixed the same problem but **could not deploy**: its CI failed because a single 58 MB `pandoc.wasm` exceeds **Cloudflare's 25 MiB-per-file limit**. This branch re-derives that work with the missing piece — the wasm ships as **3 raw parts ≤ 19 MiB each**, reassembled in the browser before instantiation.

## What changed

**Mechanism — vendor both assets same-origin**

- `scripts/vendor-assets.mjs` (new) downloads the pinned `pandoc-wasm@1.0.1` binary at build time and writes it as **3 parts + a manifest** (`pandoc.wasm.part0/1/2` + `pandoc.wasm.manifest.json`). Parts are gitignored build output.
- `public/lib/pandoc/wasi-shim.js` (new) is a self-contained, in-tree bundle of `@bjorn3/browser_wasi_shim` — no network at module load.
- `public/lib/pandoc/pandoc.js` rewritten: fetches the manifest + parts **same-origin** (resolved against `import.meta.url`), streams them into a single pre-sized buffer, gates each part on its exact expected size, and checks the wasm magic bytes before instantiating. Event shapes are unchanged, so `pandoc-converter.ts` needs no changes.

**Guardrails — keep it air-gapped**

- `scripts/check-no-cdn.mjs` (new) scans every shipped `dist` asset against a CDN denylist and fails the build if one appears. Runs as `postbuild`, so existing CI enforces it with no workflow change.
- `vite.config.ts`: drops the dead CDN runtime-cache rules, keeps a same-origin `CacheFirst` for `/lib/pandoc/*`, and versions the pandoc cache by the vendored release.
- `public/sw-cleanup.js` (new) is injected into the service worker to delete retired CDN-era caches on activate, reclaiming ~58 MB from returning clients.

**Plumbing — vendor everywhere the build runs**

- `package.json`: `predev`/`prebuild` vendor the parts; `postbuild` runs the CDN guard; version → 1.2.5.
- `Dockerfile` + `.dockerignore`: image build vendors the parts and builds via npm so the guard runs on the release image.
- `.github/workflows/test.yml`: caches the vendored parts (keyed on the vendor script) + retries the download.
- `.gitignore`: parts + manifest are build output, never committed.
- Comments in `pandoc-converter.ts` / `usePandocIdlePrefetch.ts` updated to describe the same-origin path.

## Verification

- **Build clean**; postbuild guard scans dist and reports no CDN references.
- **No dist file > 25 MiB** — largest is a 19.0 MiB part (the exact bar that failed #75). Parts reassemble byte-perfect (size + wasm magic).
- **1427 unit tests pass** (incl. new `planParts` split math + `findCdnHits` detector tests); typecheck clean.
- **Live air-gap test**: with `window.fetch` armed to reject any off-origin request, a fresh pandoc load reassembled the parts and converted markdown → a valid DOCX. Network showed only `manifest → part0 → part1 → part2`, all same-origin; zero off-origin requests; empty pandoc stderr.

## Notes

- Runtime integrity gate is exact per-part size + wasm magic; the manifest `sha256` is build provenance only.
- The vendor script's build-time download of the pinned wasm is idempotent (skips when parts are current) and retries transient failures.
