### PR TITLE
chore(lint): clear the lint baseline and gate it in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,16 +32,12 @@ jobs:
         # and what Cloudflare Pages runs by default. The codebase ships to
         # browsers, not Node, so the only Node-specific surface is the
         # build / test tooling. Single version is enough.
-        task: [unit, typecheck]
-        # Lint is intentionally not in this matrix. The baseline has a
-        # cluster of `react-refresh/only-export-components` warnings
-        # from earlier component refactors; enabling lint as a gate
-        # would block every PR on pre-existing noise. Cleanup is
-        # tracked as a follow-up PR that will also turn on
-        # `eslint-plugin-security`. Bundle-size and `npm audit` gates
-        # already exist (see the `build` and `audit` jobs below).
-        # CodeQL runs separately via the auto-generated `codeql.yml`
-        # workflow.
+        task: [unit, typecheck, lint]
+        # Lint is now a gate: the baseline is clean (0 errors). The
+        # `eslint-plugin-security` follow-up is still open. Bundle-size
+        # and `npm audit` gates already exist (see the `build` and
+        # `audit` jobs below). CodeQL runs separately via the
+        # auto-generated `codeql.yml` workflow.
     steps:
       - uses: actions/checkout@v4
 
@@ -58,6 +54,7 @@ jobs:
           case "${{ matrix.task }}" in
             unit)      npm test ;;
             typecheck) npx tsc --noEmit ;;
+            lint)      npm run lint ;;
           esac
 
   coverage:

--- a/build-templates.mjs
+++ b/build-templates.mjs
@@ -94,5 +94,4 @@ for (const name of files) {
 const output = HEADER + body + FOOTER;
 writeFileSync(OUTPUT_PUBLIC, output);
 
-// eslint-disable-next-line no-console
 console.log(`Generated ${OUTPUT_PUBLIC} (${output.length.toLocaleString()} bytes, ${files.length + 1} templates)`);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,4 +34,22 @@ export default defineConfig([
       ],
     },
   },
+  {
+    // `react-refresh/only-export-components` is a Fast Refresh (dev HMR) hint,
+    // not a correctness rule. These files intentionally export a component
+    // alongside non-component values, and splitting them would fight the
+    // established pattern:
+    //   - badge/button: the shadcn convention of co-locating the cva variants
+    //   - variable-chip-editor: document-variable helpers used across editors
+    //   - WelcomeModal: a reset helper for the settings/help menu
+    files: [
+      'src/components/ui/badge.tsx',
+      'src/components/ui/button.tsx',
+      'src/components/ui/variable-chip-editor.tsx',
+      'src/components/modals/WelcomeModal.tsx',
+    ],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 ])

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { X, Building2, BookOpen, Upload, FileImage } from 'lucide-react';
 import { FILE_LIMITS } from '@/lib/constants';
 import {
@@ -249,11 +249,12 @@ export function ProfileModal() {
     setFormState((prev) => ({ ...prev, [field]: value }));
   };
 
-  // Generate preview URL from base64 signature
-  const signaturePreviewUrl = useMemo(() => {
-    if (!formState.signatureImage?.data) return null;
-    return base64ToDataUrl(formState.signatureImage.data, 'image/png');
-  }, [formState.signatureImage?.data]);
+  // Generate preview URL from base64 signature. No manual useMemo: the React
+  // Compiler memoizes this derivation automatically, and a hand-written memo
+  // here trips react-hooks/preserve-manual-memoization.
+  const signaturePreviewUrl = formState.signatureImage?.data
+    ? base64ToDataUrl(formState.signatureImage.data, 'image/png')
+    : null;
 
   // Handle signature image upload
   const handleSignatureUpload = useCallback(async (file: File) => {

--- a/src/components/ui/variable-autocomplete.tsx
+++ b/src/components/ui/variable-autocomplete.tsx
@@ -39,7 +39,10 @@ const categoryIcons: Record<string, string> = {
   'Entry': '📝',
 };
 
-export function useVariableAutocomplete({
+// Internal to this module (used by InputWithVariables/TextareaWithVariables
+// below). Not exported: keeping it unexported lets Fast Refresh treat this
+// file as component-only.
+function useVariableAutocomplete({
   inputRef,
   value,
   onChange,


### PR DESCRIPTION
Clears the 10 pre-existing ESLint errors so `npm run lint` passes clean, and adds lint to the CI matrix so it stays that way.

- Un-export the internal-only `useVariableAutocomplete` hook
- Drop a redundant `useMemo` in `ProfileModal` (React Compiler handles it)
- Scoped eslint override for files that intentionally co-locate non-component exports (shadcn variants, editor var helpers, WelcomeModal reset)
- Remove a stale `eslint-disable` in `build-templates.mjs`
- Add `lint` to the test workflow

No runtime behavior change. `eslint-plugin-security` is left as a separate follow-up.