### PR TITLE
ci: bump GitHub Actions off deprecated Node 20

### DIFF
--- a/.github/workflows/cartesian.yml
+++ b/.github/workflows/cartesian.yml
@@ -115,9 +115,9 @@ jobs:
     # has time to finish reporting + uploading artifacts before kill.
     timeout-minutes: 350
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -151,7 +151,7 @@ jobs:
 
       - name: upload result CSV + log
         if: always()  # Upload even on failure / timeout
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cartesian-results
           path: .cartesian-results/
@@ -160,7 +160,7 @@ jobs:
 
       - name: upload failing tex dirs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cartesian-failing-tex
           path: |
@@ -181,9 +181,9 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -220,7 +220,7 @@ jobs:
 
       - name: upload result CSV + log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cartesian-nightly-${{ github.run_number }}
           path: .cartesian-results/
@@ -232,7 +232,7 @@ jobs:
         # team sees it instead of having it sit in workflow-history
         # purgatory.
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const day = new Date().toISOString().split('T')[0];

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,9 +43,9 @@ jobs:
         # CodeQL runs separately via the auto-generated `codeql.yml`
         # workflow.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -69,8 +69,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -84,8 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -95,7 +95,7 @@ jobs:
       # so a version bump invalidates it. On a hit, prebuild's isCurrent() skips
       # the download; on a miss, the script retries transient failures.
       - name: cache pandoc wasm parts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             public/lib/pandoc/pandoc.wasm.part*
@@ -152,8 +152,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
       - name: rebuild bundle and assert no diff
@@ -176,8 +176,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -196,8 +196,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -232,9 +232,9 @@ jobs:
     # it burn 25 min of runner time.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -263,7 +263,7 @@ jobs:
         # with the .tex files + log so a dev can `cd` in and reproduce.
         # Pull them out as artifacts to make CI failures debuggable.
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: failing-compile-artifacts
           path: |


### PR DESCRIPTION
Every workflow run currently logs a warning that `actions/checkout`, `actions/setup-node`, and `actions/cache` are pinned to Node 20, which GitHub is deprecating (forced onto Node 24). This bumps all pinned actions to their latest majors, which target Node 24:

- `checkout` v4 → v7
- `setup-node` v4 → v6
- `cache` v4 → v6
- `upload-artifact` v4 → v7
- `github-script` v7 → v9

Version pins only — no workflow logic changed. Our usage (plain checkout, `node-version`/`cache` inputs, standard artifact + `issues.create` calls) is unchanged across these majors.