### PR TITLE
feat(references): unify reference library modals over one shared dataset

### DIFF
--- a/src/components/modals/FormReferenceLibraryModal.tsx
+++ b/src/components/modals/FormReferenceLibraryModal.tsx
@@ -1,65 +1,5 @@
-import { useState, useMemo } from 'react';
-import { Search, Plus, Library } from 'lucide-react';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { ScrollArea } from '@/components/ui/scroll-area';
-
-// Common military references library for forms/counseling
-const FORM_REFERENCE_LIBRARY = [
-  // Personnel/Admin Orders
-  { category: 'Personnel Administration', title: 'MCO 1610.7A - Performance Evaluation System' },
-  { category: 'Personnel Administration', title: 'MCO 1900.16 - Separation and Retirement Manual' },
-  { category: 'Personnel Administration', title: 'MCO 1070.12K - Individual Records Administration Manual' },
-  { category: 'Personnel Administration', title: 'MCO P1080.20 - Marine Corps Promotions Manual' },
-  { category: 'Personnel Administration', title: 'MCO 1001R.1L - MCTFS User Manual' },
-
-  // Physical Fitness
-  { category: 'Physical Fitness', title: 'MCO 6100.13A W/CH 1 - Marine Corps Physical Fitness and Combat Fitness Tests' },
-  { category: 'Physical Fitness', title: 'MCO 6110.3A - Marine Corps Body Composition and Military Appearance Program' },
-
-  // Conduct/Discipline
-  { category: 'Conduct & Discipline', title: 'MCO 5800.16A - Marine Corps Manual for Legal Administration (LEGADMINMAN)' },
-  { category: 'Conduct & Discipline', title: 'MCO 1752.5C - Sexual Assault Prevention and Response Program' },
-  { category: 'Conduct & Discipline', title: 'MCO 5354.1F - Marine Corps Prohibited Activities and Conduct Prevention' },
-  { category: 'Conduct & Discipline', title: 'JAGMAN - Manual of the Judge Advocate General' },
-
-  // Uniforms/Standards
-  { category: 'Standards', title: 'MCO 1020.34H - Marine Corps Uniform Regulations' },
-  { category: 'Standards', title: 'MCO P1100.72C - Military Occupational Specialties Manual' },
-
-  // Substance Abuse
-  { category: 'Substance Abuse', title: 'MCO 5300.17A - Marine Corps Substance Abuse Program' },
-  { category: 'Substance Abuse', title: 'MCO 5300.6 - Urinalysis Program' },
-
-  // Leave/Liberty
-  { category: 'Leave & Liberty', title: 'MCO 1050.3J - Regulations for Leave, Liberty, and Administrative Absence' },
-
-  // Training
-  { category: 'Training', title: 'MCO 1510.118 - Individual Training Standards' },
-  { category: 'Training', title: 'MCO 3500.27C - Operational Risk Management' },
-
-  // Safety
-  { category: 'Safety', title: 'MCO 5100.29C - Marine Corps Safety Program' },
-  { category: 'Safety', title: 'MCO 5100.19F - Marine Corps Traffic Safety Program' },
-
-  // UCMJ Articles (commonly referenced)
-  { category: 'UCMJ', title: 'UCMJ Article 86 - Absence Without Leave' },
-  { category: 'UCMJ', title: 'UCMJ Article 91 - Insubordinate Conduct' },
-  { category: 'UCMJ', title: 'UCMJ Article 92 - Failure to Obey Order or Regulation' },
-  { category: 'UCMJ', title: 'UCMJ Article 107 - False Official Statements' },
-  { category: 'UCMJ', title: 'UCMJ Article 112a - Wrongful Use of Controlled Substances' },
-  { category: 'UCMJ', title: 'UCMJ Article 128 - Assault' },
-  { category: 'UCMJ', title: 'UCMJ Article 134 - General Article' },
-
-  // Financial
-  { category: 'Financial', title: 'MCO 7220.52F - Marine Corps Indebtedness Processing Procedures' },
-];
+import { Library } from 'lucide-react';
+import { ReferenceLibraryPicker } from './ReferenceLibraryPicker';
 
 interface FormReferenceLibraryModalProps {
   open: boolean;
@@ -67,98 +7,26 @@ interface FormReferenceLibraryModalProps {
   onSelect: (reference: string) => void;
 }
 
+/**
+ * Reference picker for NAVMC counseling forms (Form 6105). Thin wrapper over
+ * the shared ReferenceLibraryPicker with counseling-oriented copy; the caller
+ * owns open state and receives the picked citation via onSelect.
+ */
 export function FormReferenceLibraryModal({ open, onOpenChange, onSelect }: FormReferenceLibraryModalProps) {
-  const [searchQuery, setSearchQuery] = useState('');
-
-  const groupedReferences = useMemo(() => {
-    const filtered = FORM_REFERENCE_LIBRARY.filter(
-      (ref) =>
-        ref.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        ref.category.toLowerCase().includes(searchQuery.toLowerCase())
-    );
-
-    const grouped: Record<string, string[]> = {};
-    for (const ref of filtered) {
-      if (!grouped[ref.category]) {
-        grouped[ref.category] = [];
-      }
-      grouped[ref.category].push(ref.title);
-    }
-    return grouped;
-  }, [searchQuery]);
-
-  const handleAddReference = (title: string) => {
-    onSelect(title);
-  };
-
-  const totalResults = Object.values(groupedReferences).reduce((acc, refs) => acc + refs.length, 0);
-
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg max-h-[80vh]">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Library className="h-5 w-5" />
-            Reference Library
-          </DialogTitle>
-        </DialogHeader>
-
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Search references..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-9"
-            autoFocus
-          />
-        </div>
-
-        <p className="text-sm text-muted-foreground">
-          {searchQuery ? `${totalResults} results found` : 'Browse or search common references for counseling and administrative actions'}
-        </p>
-
-        <ScrollArea className="h-[400px] pr-4">
-          {Object.entries(groupedReferences).map(([category, refs]) => (
-            <div key={category} className="mb-4">
-              <h4 className="text-sm font-semibold text-muted-foreground mb-2">
-                {category}
-              </h4>
-              <div className="space-y-1">
-                {refs.map((title) => (
-                  <div
-                    key={title}
-                    className="flex items-center justify-between p-2 rounded-md hover:bg-secondary/50 group"
-                  >
-                    <span className="text-sm">{title}</span>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleAddReference(title)}
-                      className="opacity-0 group-hover:opacity-100 transition-opacity"
-                    >
-                      <Plus className="h-4 w-4 mr-1" />
-                      Add
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))}
-
-          {Object.keys(groupedReferences).length === 0 && (
-            <div className="text-center text-muted-foreground py-8">
-              <Library className="h-12 w-12 mx-auto mb-3 opacity-50" />
-              <p>No references found matching "{searchQuery}"</p>
-              <p className="text-sm mt-1">Try a different search term</p>
-            </div>
-          )}
-        </ScrollArea>
-
-        <div className="text-xs text-muted-foreground border-t pt-3">
-          Click "Add" to append a reference to your form. References will be automatically lettered.
-        </div>
-      </DialogContent>
-    </Dialog>
+    <ReferenceLibraryPicker
+      open={open}
+      onOpenChange={onOpenChange}
+      onSelect={onSelect}
+      title={
+        <>
+          <Library className="h-5 w-5" />
+          Reference Library
+        </>
+      }
+      showResultCount
+      autoFocus
+      footer='Click "Add" to append a reference to your form. References will be automatically lettered.'
+    />
   );
 }

--- a/src/components/modals/ReferenceLibraryModal.tsx
+++ b/src/components/modals/ReferenceLibraryModal.tsx
@@ -1,141 +1,24 @@
-import { useState, useMemo } from 'react';
-import { Search, Plus } from 'lucide-react';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { useUIStore } from '@/stores/uiStore';
 import { useDocumentStore } from '@/stores/documentStore';
+import { ReferenceLibraryPicker } from './ReferenceLibraryPicker';
 
-// Common military references library
-const REFERENCE_LIBRARY = [
-  // Marine Corps Orders
-  { category: 'Marine Corps Orders', title: 'MCO 5215.1L - Directives Management Program' },
-  { category: 'Marine Corps Orders', title: 'MCO 5216.20 - Correspondence Manual' },
-  { category: 'Marine Corps Orders', title: 'MCO 5210.11F - Record Management Program' },
-  { category: 'Marine Corps Orders', title: 'MCO 1650.19K - Decorations and Awards' },
-  { category: 'Marine Corps Orders', title: 'MCO 1900.16 - Separation and Retirement' },
-  { category: 'Marine Corps Orders', title: 'MCO 1001R.1L - MCTFS User Manual' },
-  { category: 'Marine Corps Orders', title: 'MCO 1020.34H - Marine Corps Uniform Regulations' },
-  { category: 'Marine Corps Orders', title: 'MCO 3000.11B - Marine Air Ground Task Force Staff Training Program' },
-  { category: 'Marine Corps Orders', title: 'MCO 3500.27C - Operational Risk Management' },
-  { category: 'Marine Corps Orders', title: 'MCO 5580.2B - Law Enforcement Manual' },
-
-  // SECNAV Manuals
-  { category: 'SECNAV Manuals', title: 'SECNAV M-5210.1 - Department of the Navy Records Management Manual' },
-  { category: 'SECNAV Manuals', title: 'SECNAV M-5216.5 - Department of the Navy Correspondence Manual' },
-  { category: 'SECNAV Manuals', title: 'SECNAV M-5239.2 - DON Cybersecurity Program' },
-
-  // SECNAV Instructions
-  { category: 'SECNAV Instructions', title: 'SECNAVINST 5211.5F - Privacy Act' },
-  { category: 'SECNAV Instructions', title: 'SECNAVINST 5510.30C - DON Personnel Security Program' },
-  { category: 'SECNAV Instructions', title: 'SECNAVINST 5510.36B - DON Information Security Program' },
-
-  // Marine Corps Bulletins
-  { category: 'Marine Corps Bulletins', title: 'MCBul 5216 - Correspondence Procedures' },
-  { category: 'Marine Corps Bulletins', title: 'MCBul 1020 - Uniform Board Decisions' },
-
-  // Navy Regulations
-  { category: 'Navy Regulations', title: 'U.S. Navy Regulations, 1990' },
-  { category: 'Navy Regulations', title: 'OPNAVINST 5215.17A - Navy Directives Issuance System' },
-
-  // Training & Readiness
-  { category: 'Training & Readiness', title: 'MCRP 3-0B - How to Conduct Training' },
-  { category: 'Training & Readiness', title: 'MCWP 5-10 - Marine Corps Planning Process' },
-
-  // Common Enclosure Types
-  { category: 'Common References', title: 'Reference (a)' },
-  { category: 'Common References', title: 'Basic Correspondence' },
-  { category: 'Common References', title: 'Endorsement 1' },
-];
-
+/**
+ * Top-bar "Reference Library" picker for general documents. Thin wrapper over
+ * the shared ReferenceLibraryPicker: opens from the uiStore flag and appends
+ * the picked citation to the document's references.
+ */
 export function ReferenceLibraryModal() {
   // Individual selectors — modal only re-renders on its own flag changing.
   const referenceLibraryOpen = useUIStore((s) => s.referenceLibraryOpen);
   const setReferenceLibraryOpen = useUIStore((s) => s.setReferenceLibraryOpen);
   const { addReference } = useDocumentStore();
-  const [searchQuery, setSearchQuery] = useState('');
-
-  const groupedReferences = useMemo(() => {
-    const filtered = REFERENCE_LIBRARY.filter(
-      (ref) =>
-        ref.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        ref.category.toLowerCase().includes(searchQuery.toLowerCase())
-    );
-
-    const grouped: Record<string, string[]> = {};
-    for (const ref of filtered) {
-      if (!grouped[ref.category]) {
-        grouped[ref.category] = [];
-      }
-      grouped[ref.category].push(ref.title);
-    }
-    return grouped;
-  }, [searchQuery]);
-
-  const handleAddReference = (title: string) => {
-    addReference(title);
-  };
 
   return (
-    <Dialog open={referenceLibraryOpen} onOpenChange={setReferenceLibraryOpen}>
-      <DialogContent className="sm:max-w-lg max-h-[80vh]">
-        <DialogHeader>
-          <DialogTitle>Reference Library</DialogTitle>
-          <DialogDescription>Common Marine Corps directives and orders</DialogDescription>
-        </DialogHeader>
-
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Search references..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="pl-9"
-          />
-        </div>
-
-        <ScrollArea className="h-[400px] pr-4">
-          {Object.entries(groupedReferences).map(([category, refs]) => (
-            <div key={category} className="mb-4">
-              <h4 className="text-sm font-semibold text-muted-foreground mb-2">
-                {category}
-              </h4>
-              <div className="space-y-1">
-                {refs.map((title) => (
-                  <div
-                    key={title}
-                    className="flex items-center justify-between p-2 rounded-md hover:bg-secondary/50 group"
-                  >
-                    <span className="text-sm">{title}</span>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => handleAddReference(title)}
-                      className="opacity-0 group-hover:opacity-100 transition-opacity"
-                    >
-                      <Plus className="h-4 w-4 mr-1" />
-                      Add
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            </div>
-          ))}
-
-          {Object.keys(groupedReferences).length === 0 && (
-            <div className="text-center text-muted-foreground py-8">
-              No references found matching "{searchQuery}"
-            </div>
-          )}
-        </ScrollArea>
-      </DialogContent>
-    </Dialog>
+    <ReferenceLibraryPicker
+      open={referenceLibraryOpen}
+      onOpenChange={setReferenceLibraryOpen}
+      onSelect={addReference}
+      description="Common Marine Corps directives and orders"
+    />
   );
 }

--- a/src/components/modals/ReferenceLibraryPicker.tsx
+++ b/src/components/modals/ReferenceLibraryPicker.tsx
@@ -1,0 +1,129 @@
+import { useState, useMemo, type ReactNode } from 'react';
+import { Search, Plus } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  formatReference,
+  getReferencesByCategory,
+  searchReferences,
+} from '@/data/references';
+
+interface ReferenceLibraryPickerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called with the formatted citation string when the user picks a reference. */
+  onSelect: (citation: string) => void;
+  /** Dialog title (defaults to "Reference Library"). */
+  title?: ReactNode;
+  /** Optional sub-description under the title. */
+  description?: ReactNode;
+  /** Optional footer note under the list. */
+  footer?: ReactNode;
+  /** Show a live "N results found" line under the search box. */
+  showResultCount?: boolean;
+  /** Autofocus the search box on open. */
+  autoFocus?: boolean;
+}
+
+/**
+ * Shared reference-library picker used by both ReferenceLibraryModal (top bar,
+ * general docs) and FormReferenceLibraryModal (counseling forms). Both consume
+ * the single `src/data/references.ts` dataset with keyword-aware search — no
+ * more duplicated inline arrays. The small copy differences (title icon,
+ * footer, result count, autofocus) are props.
+ */
+export function ReferenceLibraryPicker({
+  open,
+  onOpenChange,
+  onSelect,
+  title = 'Reference Library',
+  description,
+  footer,
+  showResultCount = false,
+  autoFocus = false,
+}: ReferenceLibraryPickerProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const { grouped, total } = useMemo(() => {
+    const matches = searchReferences(searchQuery);
+    return { grouped: getReferencesByCategory(matches), total: matches.length };
+  }, [searchQuery]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-h-[80vh]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search references..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+            autoFocus={autoFocus}
+          />
+        </div>
+
+        {showResultCount && (
+          <p className="text-sm text-muted-foreground">
+            {searchQuery
+              ? `${total} result${total === 1 ? '' : 's'} found`
+              : 'Browse or search common references for counseling and administrative actions'}
+          </p>
+        )}
+
+        <ScrollArea className="h-[400px] pr-4">
+          {Object.entries(grouped).map(([category, refs]) => (
+            <div key={category} className="mb-4">
+              <h4 className="text-sm font-semibold text-muted-foreground mb-2">{category}</h4>
+              <div className="space-y-1">
+                {refs.map((ref) => {
+                  const citation = formatReference(ref);
+                  return (
+                    <div
+                      key={ref.id}
+                      className="flex items-center justify-between p-2 rounded-md hover:bg-secondary/50 group"
+                    >
+                      <span className="text-sm">{citation}</span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onSelect(citation)}
+                        className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+                      >
+                        <Plus className="h-4 w-4 mr-1" />
+                        Add
+                      </Button>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+
+          {total === 0 && (
+            <div className="text-center text-muted-foreground py-8">
+              No references found matching "{searchQuery}"
+            </div>
+          )}
+        </ScrollArea>
+
+        {footer && (
+          <div className="text-xs text-muted-foreground border-t pt-3">{footer}</div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/data/references.json
+++ b/src/data/references.json
@@ -55,7 +55,7 @@
     {
       "id": "mco-1650-19",
       "type": "MCO",
-      "number": "1650.19J",
+      "number": "1650.19K",
       "title": "Marine Corps Awards Manual",
       "shortTitle": "Awards Manual",
       "category": "Awards",
@@ -752,7 +752,7 @@
     {
       "id": "mco-5354-1",
       "type": "MCO",
-      "number": "5354.1E",
+      "number": "5354.1F",
       "title": "Marine Corps Equal Opportunity Program",
       "shortTitle": "EO Order",
       "category": "Personnel",

--- a/src/data/references.json
+++ b/src/data/references.json
@@ -1,0 +1,2093 @@
+{
+  "version": "2.1",
+  "lastUpdated": "2026-07-02",
+  "categories": [
+    "Personnel",
+    "Awards",
+    "Fitness",
+    "Training",
+    "Admin",
+    "Legal",
+    "Supply",
+    "Operations",
+    "Safety",
+    "Medical",
+    "Intelligence",
+    "Communications",
+    "General"
+  ],
+  "references": [
+    {
+      "id": "mco-1050-3",
+      "type": "MCO",
+      "number": "1050.3J",
+      "title": "Regulations for Leave, Liberty, and Administrative Absence",
+      "shortTitle": "Leave Order",
+      "category": "Personnel",
+      "keywords": [
+        "leave",
+        "liberty",
+        "absence",
+        "vacation",
+        "special liberty",
+        "emergency leave",
+        "convalescent",
+        "terminal"
+      ]
+    },
+    {
+      "id": "mco-1610-7",
+      "type": "MCO",
+      "number": "1610.7A",
+      "title": "Performance Evaluation System",
+      "shortTitle": "FITREP/PRO-CON Order",
+      "category": "Personnel",
+      "keywords": [
+        "fitrep",
+        "fitness report",
+        "procon",
+        "evaluation",
+        "performance",
+        "adverse",
+        "observed"
+      ]
+    },
+    {
+      "id": "mco-1650-19",
+      "type": "MCO",
+      "number": "1650.19J",
+      "title": "Marine Corps Awards Manual",
+      "shortTitle": "Awards Manual",
+      "category": "Awards",
+      "keywords": [
+        "award",
+        "medal",
+        "nam",
+        "commendation",
+        "achievement",
+        "meritorious",
+        "certificate",
+        "muc"
+      ]
+    },
+    {
+      "id": "secnavinst-1650-1",
+      "type": "SECNAVINST",
+      "number": "1650.1H",
+      "title": "Navy and Marine Corps Awards Manual",
+      "shortTitle": "DON Awards Manual",
+      "category": "Awards",
+      "keywords": [
+        "award",
+        "medal",
+        "navy",
+        "decoration",
+        "commendation",
+        "purple heart",
+        "bronze star"
+      ]
+    },
+    {
+      "id": "mco-6100-13",
+      "type": "MCO",
+      "number": "6100.13A",
+      "title": "Marine Corps Physical Fitness and Combat Fitness Tests",
+      "shortTitle": "PFT/CFT Order",
+      "category": "Fitness",
+      "keywords": [
+        "pft",
+        "cft",
+        "physical fitness",
+        "combat fitness",
+        "run",
+        "pullups",
+        "crunches",
+        "ammo can",
+        "mtc"
+      ]
+    },
+    {
+      "id": "mco-6110-3",
+      "type": "MCO",
+      "number": "6110.3A",
+      "title": "Marine Corps Body Composition and Military Appearance Program",
+      "shortTitle": "BCP Order",
+      "category": "Fitness",
+      "keywords": [
+        "bcp",
+        "body composition",
+        "weight",
+        "height",
+        "tape",
+        "assignment",
+        "map"
+      ]
+    },
+    {
+      "id": "mco-1070-12",
+      "type": "MCO",
+      "number": "1070.12K",
+      "title": "Individual Records Administration Manual (IRAM)",
+      "shortTitle": "IRAM",
+      "category": "Admin",
+      "keywords": [
+        "page 11",
+        "service record",
+        "srb",
+        "ompf",
+        "admin remarks",
+        "iram",
+        "6105",
+        "page 13"
+      ]
+    },
+    {
+      "id": "mco-1500-52",
+      "type": "MCO",
+      "number": "1500.52F",
+      "title": "Marine Corps Formal Schools Program",
+      "shortTitle": "Schools Order",
+      "category": "Training",
+      "keywords": [
+        "school",
+        "training",
+        "mos",
+        "formal school",
+        "maradmin",
+        "quotas"
+      ]
+    },
+    {
+      "id": "mco-1553-4",
+      "type": "MCO",
+      "number": "1553.4B",
+      "title": "Professional Military Education",
+      "shortTitle": "PME Order",
+      "category": "Training",
+      "keywords": [
+        "pme",
+        "corporals course",
+        "sergeants course",
+        "career course",
+        "enlisted pme",
+        "snco"
+      ]
+    },
+    {
+      "id": "mco-1320-11",
+      "type": "MCO",
+      "number": "1320.11G",
+      "title": "Permanent Change of Station Order",
+      "shortTitle": "PCS Order",
+      "category": "Personnel",
+      "keywords": [
+        "pcs",
+        "orders",
+        "transfer",
+        "duty station",
+        "move",
+        "dity",
+        "hhg"
+      ]
+    },
+    {
+      "id": "mco-1900-16",
+      "type": "MCO",
+      "number": "1900.16",
+      "title": "Marine Corps Separation and Retirement Manual",
+      "shortTitle": "MARCORSEPMAN",
+      "category": "Personnel",
+      "keywords": [
+        "separation",
+        "discharge",
+        "eas",
+        "retirement",
+        "adsep",
+        "chapter",
+        "honorable",
+        "oth"
+      ]
+    },
+    {
+      "id": "mco-1752-5",
+      "type": "MCO",
+      "number": "1752.5C",
+      "title": "Sexual Assault Prevention and Response Program",
+      "shortTitle": "SAPR Order",
+      "category": "Legal",
+      "keywords": [
+        "sapr",
+        "sexual assault",
+        "victim advocate",
+        "unrestricted",
+        "restricted",
+        "sarc"
+      ]
+    },
+    {
+      "id": "mco-5800-16",
+      "type": "MCO",
+      "number": "5800.16A",
+      "title": "Marine Corps Manual for Legal Administration",
+      "shortTitle": "LEGADMINMAN",
+      "category": "Legal",
+      "keywords": [
+        "legal",
+        "njp",
+        "court martial",
+        "article 15",
+        "ucmj",
+        "6105",
+        "adverse action"
+      ]
+    },
+    {
+      "id": "mco-1040-31",
+      "type": "MCO",
+      "number": "1040.31",
+      "title": "Marine Corps Enlisted Retention and Career Development Program",
+      "shortTitle": "Reenlistment Order",
+      "category": "Personnel",
+      "keywords": [
+        "reenlistment",
+        "srb",
+        "bonus",
+        "career",
+        "retention",
+        "extension",
+        "broken service"
+      ]
+    },
+    {
+      "id": "mco-1001-62",
+      "type": "MCO",
+      "number": "1001.62A",
+      "title": "Marine Corps Promotion Manual, Volume 2, Enlisted Promotions",
+      "shortTitle": "Enlisted Promo Manual",
+      "category": "Personnel",
+      "keywords": [
+        "promotion",
+        "meritorious",
+        "cutting score",
+        "composite score",
+        "sergeant",
+        "corporal",
+        "lance corporal"
+      ]
+    },
+    {
+      "id": "mco-1001-64",
+      "type": "MCO",
+      "number": "1001.64F",
+      "title": "Marine Corps Promotion Manual, Volume 3, Officer Promotions",
+      "shortTitle": "Officer Promo Manual",
+      "category": "Personnel",
+      "keywords": [
+        "promotion",
+        "officer",
+        "captain",
+        "major",
+        "selection board",
+        "lieutenant"
+      ]
+    },
+    {
+      "id": "secnav-m-5216-5",
+      "type": "SECNAV M",
+      "number": "5216.5",
+      "title": "Department of the Navy Correspondence Manual",
+      "shortTitle": "Correspondence Manual",
+      "category": "Admin",
+      "keywords": [
+        "naval letter",
+        "correspondence",
+        "format",
+        "memorandum",
+        "endorsement",
+        "standard letter"
+      ]
+    },
+    {
+      "id": "mco-5216-20",
+      "type": "MCO",
+      "number": "5216.20",
+      "title": "Marine Corps Correspondence Manual",
+      "shortTitle": "MC Correspondence",
+      "category": "Admin",
+      "keywords": [
+        "correspondence",
+        "letter",
+        "format",
+        "writing",
+        "memo",
+        "endorsement"
+      ]
+    },
+    {
+      "id": "dod-7000-14r",
+      "type": "DoD",
+      "number": "7000.14-R",
+      "title": "Department of Defense Financial Management Regulations",
+      "shortTitle": "FMR",
+      "category": "Supply",
+      "keywords": [
+        "gtcc",
+        "travel",
+        "per diem",
+        "voucher",
+        "dts",
+        "government travel",
+        "finance"
+      ]
+    },
+    {
+      "id": "jtr",
+      "type": "DoD",
+      "number": "JTR",
+      "title": "Joint Travel Regulations",
+      "shortTitle": "JTR",
+      "category": "Supply",
+      "keywords": [
+        "travel",
+        "per diem",
+        "pcs",
+        "tdy",
+        "tad",
+        "mileage",
+        "lodging",
+        "dts"
+      ]
+    },
+    {
+      "id": "navyregs-1150",
+      "type": "U.S. Navy Regulations",
+      "number": "Article 1150",
+      "title": "Redress of Wrong Committed by Superior",
+      "shortTitle": "Request Mast",
+      "category": "Legal",
+      "keywords": [
+        "request mast",
+        "complaint",
+        "redress",
+        "grievance",
+        "chain of command"
+      ]
+    },
+    {
+      "id": "mco-1700-23",
+      "type": "MCO",
+      "number": "1700.23G",
+      "title": "Marine Corps Community Services Policy Manual",
+      "shortTitle": "MCCS Order",
+      "category": "Personnel",
+      "keywords": [
+        "mccs",
+        "family",
+        "services",
+        "recreation",
+        "fitness center",
+        "mwr"
+      ]
+    },
+    {
+      "id": "mco-1306-9",
+      "type": "MCO",
+      "number": "1306.9E",
+      "title": "Interservice and Intraservice Transfers of Members",
+      "shortTitle": "Transfer Order",
+      "category": "Personnel",
+      "keywords": [
+        "transfer",
+        "lat move",
+        "mos change",
+        "interservice",
+        "lateral move"
+      ]
+    },
+    {
+      "id": "mco-1040-40",
+      "type": "MCO",
+      "number": "1040.40B",
+      "title": "Humanitarian and Hardship Transfer/Discharge Program",
+      "shortTitle": "Humanitarian Order",
+      "category": "Personnel",
+      "keywords": [
+        "humanitarian",
+        "hardship",
+        "dependency",
+        "family emergency",
+        "compassionate"
+      ]
+    },
+    {
+      "id": "ucmj",
+      "type": "Manual",
+      "number": "UCMJ",
+      "title": "Uniform Code of Military Justice",
+      "shortTitle": "UCMJ",
+      "category": "Legal",
+      "keywords": [
+        "ucmj",
+        "court martial",
+        "article",
+        "punishment",
+        "military justice",
+        "offense"
+      ]
+    },
+    {
+      "id": "mcm",
+      "type": "Manual",
+      "number": "MCM",
+      "title": "Manual for Courts-Martial",
+      "shortTitle": "MCM",
+      "category": "Legal",
+      "keywords": [
+        "courts martial",
+        "mcm",
+        "military justice",
+        "trial",
+        "conviction"
+      ]
+    },
+    {
+      "id": "mco-1500-58",
+      "type": "MCO",
+      "number": "1500.58A",
+      "title": "Marine Corps Martial Arts Program",
+      "shortTitle": "MCMAP Order",
+      "category": "Training",
+      "keywords": [
+        "mcmap",
+        "martial arts",
+        "belt",
+        "tan",
+        "gray",
+        "green",
+        "brown",
+        "black"
+      ]
+    },
+    {
+      "id": "mco-1500-55",
+      "type": "MCO",
+      "number": "1500.55",
+      "title": "Marine Corps Water Survival Training Program",
+      "shortTitle": "Swim Qual Order",
+      "category": "Training",
+      "keywords": [
+        "swim",
+        "water survival",
+        "wsi",
+        "qualification",
+        "intermediate",
+        "advanced"
+      ]
+    },
+    {
+      "id": "mco-1510-118",
+      "type": "MCO",
+      "number": "1510.118A",
+      "title": "Marine Corps Common Skills Program",
+      "shortTitle": "Common Skills Order",
+      "category": "Training",
+      "keywords": [
+        "common skills",
+        "annual training",
+        "rifle",
+        "pistol",
+        "gas mask"
+      ]
+    },
+    {
+      "id": "mco-3500-27",
+      "type": "MCO",
+      "number": "3500.27C",
+      "title": "Operational Risk Management",
+      "shortTitle": "ORM Order",
+      "category": "Safety",
+      "keywords": [
+        "orm",
+        "risk management",
+        "safety",
+        "deliberate",
+        "time critical"
+      ]
+    },
+    {
+      "id": "mco-5100-8",
+      "type": "MCO",
+      "number": "5100.8",
+      "title": "Marine Corps Occupational Safety and Health Program",
+      "shortTitle": "OSH Order",
+      "category": "Safety",
+      "keywords": [
+        "osh",
+        "osha",
+        "safety",
+        "occupational",
+        "hazard",
+        "ppe"
+      ]
+    },
+    {
+      "id": "mco-5100-29",
+      "type": "MCO",
+      "number": "5100.29C",
+      "title": "Marine Corps Safety Program",
+      "shortTitle": "Safety Program Order",
+      "category": "Safety",
+      "keywords": [
+        "safety",
+        "mishap",
+        "accident",
+        "investigation",
+        "class a",
+        "class b"
+      ]
+    },
+    {
+      "id": "mco-5104-3",
+      "type": "MCO",
+      "number": "5104.3C",
+      "title": "Marine Corps Motorcycle and All-Terrain Vehicle Safety Program",
+      "shortTitle": "Motorcycle Safety Order",
+      "category": "Safety",
+      "keywords": [
+        "motorcycle",
+        "atv",
+        "safety",
+        "training",
+        "ppe",
+        "level 1"
+      ]
+    },
+    {
+      "id": "mco-1500-12",
+      "type": "MCO",
+      "number": "1500.12L",
+      "title": "Marine Corps Ground Combat Skills Sustainment Training",
+      "shortTitle": "Combat Skills Order",
+      "category": "Training",
+      "keywords": [
+        "rifle",
+        "marksmanship",
+        "qualification",
+        "table",
+        "annual"
+      ]
+    },
+    {
+      "id": "mco-3574-2",
+      "type": "MCO",
+      "number": "3574.2L",
+      "title": "Marine Corps Combat Marksmanship Programs",
+      "shortTitle": "Marksmanship Order",
+      "category": "Training",
+      "keywords": [
+        "rifle",
+        "pistol",
+        "marksmanship",
+        "qualification",
+        "expert",
+        "sharpshooter",
+        "marksman"
+      ]
+    },
+    {
+      "id": "mco-5510-18",
+      "type": "MCO",
+      "number": "5510.18A",
+      "title": "Personnel Security Program",
+      "shortTitle": "Personnel Security Order",
+      "category": "Intelligence",
+      "keywords": [
+        "clearance",
+        "secret",
+        "top secret",
+        "sci",
+        "investigation",
+        "suitability"
+      ]
+    },
+    {
+      "id": "mco-5510-21",
+      "type": "MCO",
+      "number": "5510.21",
+      "title": "Sensitive Compartmented Information Program",
+      "shortTitle": "SCI Program Order",
+      "category": "Intelligence",
+      "keywords": [
+        "sci",
+        "compartmented",
+        "intelligence",
+        "classification",
+        "indoctrination"
+      ]
+    },
+    {
+      "id": "mco-5239-2",
+      "type": "MCO",
+      "number": "5239.2B",
+      "title": "Marine Corps Cybersecurity Program",
+      "shortTitle": "Cybersecurity Order",
+      "category": "Communications",
+      "keywords": [
+        "cybersecurity",
+        "ia",
+        "information assurance",
+        "network",
+        "computer",
+        "nmci"
+      ]
+    },
+    {
+      "id": "mco-3000-13",
+      "type": "MCO",
+      "number": "3000.13A",
+      "title": "Marine Corps Readiness Reporting",
+      "shortTitle": "Readiness Order",
+      "category": "Operations",
+      "keywords": [
+        "readiness",
+        "drrs",
+        "status",
+        "t-rating",
+        "deployment"
+      ]
+    },
+    {
+      "id": "mco-3401-3",
+      "type": "MCO",
+      "number": "3401.3C",
+      "title": "Nuclear, Biological, and Chemical Defense Training Program",
+      "shortTitle": "NBC/CBRN Order",
+      "category": "Training",
+      "keywords": [
+        "nbc",
+        "cbrn",
+        "gas mask",
+        "mopp",
+        "chemical",
+        "biological",
+        "nuclear"
+      ]
+    },
+    {
+      "id": "mco-1750-1",
+      "type": "MCO",
+      "number": "1750.1C",
+      "title": "Family Advocacy Program",
+      "shortTitle": "FAP Order",
+      "category": "Personnel",
+      "keywords": [
+        "fap",
+        "family advocacy",
+        "domestic violence",
+        "child abuse",
+        "counseling"
+      ]
+    },
+    {
+      "id": "mco-1754-9",
+      "type": "MCO",
+      "number": "1754.9A",
+      "title": "Exceptional Family Member Program",
+      "shortTitle": "EFMP Order",
+      "category": "Personnel",
+      "keywords": [
+        "efmp",
+        "exceptional family",
+        "special needs",
+        "medical",
+        "enrollment"
+      ]
+    },
+    {
+      "id": "mco-1740-13",
+      "type": "MCO",
+      "number": "1740.13C",
+      "title": "Marine Corps Family Team Building",
+      "shortTitle": "MCFTB Order",
+      "category": "Personnel",
+      "keywords": [
+        "mcftb",
+        "family readiness",
+        "family team building",
+        "deployment support"
+      ]
+    },
+    {
+      "id": "mco-6000-16",
+      "type": "MCO",
+      "number": "6000.16",
+      "title": "Marine Corps Health Promotion Program",
+      "shortTitle": "Health Promotion Order",
+      "category": "Medical",
+      "keywords": [
+        "health",
+        "promotion",
+        "fitness",
+        "tobacco",
+        "nutrition",
+        "wellness"
+      ]
+    },
+    {
+      "id": "mco-6310-1",
+      "type": "MCO",
+      "number": "6310.1D",
+      "title": "Marine Corps Substance Abuse Program",
+      "shortTitle": "Substance Abuse Order",
+      "category": "Medical",
+      "keywords": [
+        "saco",
+        "substance abuse",
+        "drug",
+        "alcohol",
+        "urinalysis",
+        "treatment"
+      ]
+    },
+    {
+      "id": "mco-5354-1",
+      "type": "MCO",
+      "number": "5354.1E",
+      "title": "Marine Corps Equal Opportunity Program",
+      "shortTitle": "EO Order",
+      "category": "Personnel",
+      "keywords": [
+        "eo",
+        "equal opportunity",
+        "discrimination",
+        "harassment",
+        "complaint"
+      ]
+    },
+    {
+      "id": "mco-1001-45",
+      "type": "MCO",
+      "number": "1001.45K",
+      "title": "Marine Corps Officer Classification Manual",
+      "shortTitle": "Officer Classification",
+      "category": "Personnel",
+      "keywords": [
+        "mos",
+        "officer",
+        "classification",
+        "designation",
+        "pmos",
+        "amos"
+      ]
+    },
+    {
+      "id": "mco-1200-17",
+      "type": "MCO",
+      "number": "1200.17E",
+      "title": "Military Occupational Specialties Manual",
+      "shortTitle": "MOS Manual",
+      "category": "Personnel",
+      "keywords": [
+        "mos",
+        "occupational",
+        "specialty",
+        "enlisted",
+        "classification",
+        "pmos"
+      ]
+    },
+    {
+      "id": "mco-1020-34",
+      "type": "MCO",
+      "number": "1020.34H",
+      "title": "Marine Corps Uniform Regulations",
+      "shortTitle": "Uniform Order",
+      "category": "Admin",
+      "keywords": [
+        "uniform",
+        "dress",
+        "service",
+        "utility",
+        "cammies",
+        "blues",
+        "charlies"
+      ]
+    },
+    {
+      "id": "mco-1100-4",
+      "type": "MCO",
+      "number": "1100.4",
+      "title": "Marine Corps Recruiting Manual",
+      "shortTitle": "Recruiting Order",
+      "category": "Personnel",
+      "keywords": [
+        "recruiting",
+        "enlistment",
+        "waiver",
+        "dep",
+        "recruit"
+      ]
+    },
+    {
+      "id": "mco-1130-80",
+      "type": "MCO",
+      "number": "1130.80A",
+      "title": "Prior Service Enlistment Program",
+      "shortTitle": "PSEP Order",
+      "category": "Personnel",
+      "keywords": [
+        "prior service",
+        "psep",
+        "reenlistment",
+        "broken service",
+        "return"
+      ]
+    },
+    {
+      "id": "mco-1560-25",
+      "type": "MCO",
+      "number": "1560.25B",
+      "title": "Marine Corps Tuition Assistance Program",
+      "shortTitle": "TA Order",
+      "category": "Training",
+      "keywords": [
+        "tuition assistance",
+        "ta",
+        "college",
+        "education",
+        "degree",
+        "clep"
+      ]
+    },
+    {
+      "id": "mco-1560-21",
+      "type": "MCO",
+      "number": "1560.21B",
+      "title": "Marine Corps Enlisted Education Program",
+      "shortTitle": "MCI Order",
+      "category": "Training",
+      "keywords": [
+        "mci",
+        "correspondence",
+        "distance learning",
+        "enlisted education",
+        "marinenet"
+      ]
+    },
+    {
+      "id": "mco-1001-59",
+      "type": "MCO",
+      "number": "1001.59A",
+      "title": "Marine Corps Enlisted Commissioning Programs",
+      "shortTitle": "Commissioning Order",
+      "category": "Personnel",
+      "keywords": [
+        "ecp",
+        "mecep",
+        "commissioning",
+        "officer",
+        "ocs",
+        "nrotc"
+      ]
+    },
+    {
+      "id": "mco-1001-52",
+      "type": "MCO",
+      "number": "1001.52J",
+      "title": "Marine Corps Career Retention Specialist Program",
+      "shortTitle": "Career Planner Order",
+      "category": "Personnel",
+      "keywords": [
+        "career planner",
+        "retention specialist",
+        "crs",
+        "8421"
+      ]
+    },
+    {
+      "id": "mco-4400-150",
+      "type": "MCO",
+      "number": "4400.150F",
+      "title": "Consumer-Level Supply Policy Manual",
+      "shortTitle": "Supply Manual",
+      "category": "Supply",
+      "keywords": [
+        "supply",
+        "inventory",
+        "property",
+        "stock",
+        "requisition",
+        "gcss"
+      ]
+    },
+    {
+      "id": "mco-4400-16",
+      "type": "MCO",
+      "number": "4400.16H",
+      "title": "Management of Property in the Possession of the Marine Corps",
+      "shortTitle": "Property Management Order",
+      "category": "Supply",
+      "keywords": [
+        "property",
+        "cmr",
+        "tir",
+        "inventory",
+        "shortage",
+        "survey"
+      ]
+    },
+    {
+      "id": "mco-4450-14",
+      "type": "MCO",
+      "number": "4450.14A",
+      "title": "Marine Corps Table of Authorized Materiel Control Numbers",
+      "shortTitle": "TAMCN Order",
+      "category": "Supply",
+      "keywords": [
+        "tamcn",
+        "table of equipment",
+        "t/e",
+        "allowance",
+        "authorization"
+      ]
+    },
+    {
+      "id": "mco-4855-10",
+      "type": "MCO",
+      "number": "4855.10C",
+      "title": "Marine Corps Quality Program",
+      "shortTitle": "Quality Program Order",
+      "category": "Supply",
+      "keywords": [
+        "quality",
+        "deficiency",
+        "report",
+        "qdr",
+        "inspection"
+      ]
+    },
+    {
+      "id": "mco-5000-18",
+      "type": "MCO",
+      "number": "5000.18B",
+      "title": "Marine Corps Staff Organization and Tactics",
+      "shortTitle": "Staff Organization Order",
+      "category": "Operations",
+      "keywords": [
+        "staff",
+        "organization",
+        "s-1",
+        "s-2",
+        "s-3",
+        "s-4",
+        "billet"
+      ]
+    },
+    {
+      "id": "mco-5000-12",
+      "type": "MCO",
+      "number": "5000.12F",
+      "title": "Marine Corps Planning Process",
+      "shortTitle": "MCPP Order",
+      "category": "Operations",
+      "keywords": [
+        "mcpp",
+        "planning",
+        "operations",
+        "mission analysis",
+        "coa"
+      ]
+    },
+    {
+      "id": "mco-5211-2",
+      "type": "MCO",
+      "number": "5211.2B",
+      "title": "Privacy and Personally Identifiable Information Program",
+      "shortTitle": "PII Order",
+      "category": "Admin",
+      "keywords": [
+        "pii",
+        "privacy",
+        "personal information",
+        "ssn",
+        "phi",
+        "breach"
+      ]
+    },
+    {
+      "id": "mco-5210-11",
+      "type": "MCO",
+      "number": "5210.11F",
+      "title": "Marine Corps Records Management Program",
+      "shortTitle": "Records Management Order",
+      "category": "Admin",
+      "keywords": [
+        "records",
+        "management",
+        "retention",
+        "disposition",
+        "filing"
+      ]
+    },
+    {
+      "id": "mco-5530-14",
+      "type": "MCO",
+      "number": "5530.14A",
+      "title": "Marine Corps Physical Security Program",
+      "shortTitle": "Physical Security Order",
+      "category": "Operations",
+      "keywords": [
+        "physical security",
+        "access control",
+        "badge",
+        "locks",
+        "intrusion"
+      ]
+    },
+    {
+      "id": "mco-5580-2",
+      "type": "MCO",
+      "number": "5580.2B",
+      "title": "Law Enforcement Manual",
+      "shortTitle": "PMO Manual",
+      "category": "Legal",
+      "keywords": [
+        "pmo",
+        "military police",
+        "law enforcement",
+        "apprehension",
+        "incident"
+      ]
+    },
+    {
+      "id": "mco-5585-5",
+      "type": "MCO",
+      "number": "5585.5",
+      "title": "Marine Corps Corrections Manual",
+      "shortTitle": "Corrections Manual",
+      "category": "Legal",
+      "keywords": [
+        "brig",
+        "corrections",
+        "confinement",
+        "prisoner",
+        "detention"
+      ]
+    },
+    {
+      "id": "mco-11240-106",
+      "type": "MCO",
+      "number": "11240.106B",
+      "title": "Marine Corps Motor Transport Operations",
+      "shortTitle": "Motor-T Order",
+      "category": "Operations",
+      "keywords": [
+        "motor-t",
+        "vehicle",
+        "dispatch",
+        "license",
+        "driver",
+        "transportation"
+      ]
+    },
+    {
+      "id": "mco-11240-66",
+      "type": "MCO",
+      "number": "11240.66D",
+      "title": "Marine Corps Driver Improvement Program",
+      "shortTitle": "Driver Program Order",
+      "category": "Safety",
+      "keywords": [
+        "driver",
+        "improvement",
+        "license",
+        "accident",
+        "citation"
+      ]
+    },
+    {
+      "id": "mco-3400-3",
+      "type": "MCO",
+      "number": "3400.3G",
+      "title": "Individual Training Standards",
+      "shortTitle": "ITS Order",
+      "category": "Training",
+      "keywords": [
+        "its",
+        "individual training",
+        "standards",
+        "mos",
+        "task"
+      ]
+    },
+    {
+      "id": "mco-3500-72",
+      "type": "MCO",
+      "number": "3500.72B",
+      "title": "Marine Corps Combat Hunter Program",
+      "shortTitle": "Combat Hunter Order",
+      "category": "Training",
+      "keywords": [
+        "combat hunter",
+        "tracking",
+        "observation",
+        "profiling"
+      ]
+    },
+    {
+      "id": "mco-3570-1",
+      "type": "MCO",
+      "number": "3570.1C",
+      "title": "Range Safety",
+      "shortTitle": "Range Safety Order",
+      "category": "Safety",
+      "keywords": [
+        "range",
+        "safety",
+        "live fire",
+        "qualification",
+        "oic",
+        "rso"
+      ]
+    },
+    {
+      "id": "mco-3100-4",
+      "type": "MCO",
+      "number": "3100.4A",
+      "title": "Marine Corps Deployment Planning",
+      "shortTitle": "Deployment Order",
+      "category": "Operations",
+      "keywords": [
+        "deployment",
+        "oplan",
+        "udp",
+        "mef",
+        "sda"
+      ]
+    },
+    {
+      "id": "secnavinst-1752-4",
+      "type": "SECNAVINST",
+      "number": "1752.4C",
+      "title": "Sexual Assault Prevention and Response",
+      "shortTitle": "DON SAPR",
+      "category": "Legal",
+      "keywords": [
+        "sapr",
+        "sexual assault",
+        "response",
+        "prevention",
+        "dod"
+      ]
+    },
+    {
+      "id": "secnavinst-5300-28",
+      "type": "SECNAVINST",
+      "number": "5300.28F",
+      "title": "Military Equal Opportunity Program",
+      "shortTitle": "DON MEO",
+      "category": "Personnel",
+      "keywords": [
+        "meo",
+        "equal opportunity",
+        "discrimination",
+        "harassment"
+      ]
+    },
+    {
+      "id": "secnavinst-5510-30",
+      "type": "SECNAVINST",
+      "number": "5510.30C",
+      "title": "DON Personnel Security Program",
+      "shortTitle": "DON Personnel Security",
+      "category": "Intelligence",
+      "keywords": [
+        "personnel security",
+        "clearance",
+        "investigation",
+        "adjudication"
+      ]
+    },
+    {
+      "id": "secnavinst-5510-36",
+      "type": "SECNAVINST",
+      "number": "5510.36B",
+      "title": "DON Information Security Program",
+      "shortTitle": "DON Info Security",
+      "category": "Intelligence",
+      "keywords": [
+        "information security",
+        "classification",
+        "marking",
+        "handling",
+        "spillage"
+      ]
+    },
+    {
+      "id": "secnavinst-1920-6",
+      "type": "SECNAVINST",
+      "number": "1920.6D",
+      "title": "Administrative Separation of Officers",
+      "shortTitle": "Officer Separation",
+      "category": "Personnel",
+      "keywords": [
+        "officer",
+        "separation",
+        "resignation",
+        "discharge",
+        "board"
+      ]
+    },
+    {
+      "id": "secnavinst-1850-4",
+      "type": "SECNAVINST",
+      "number": "1850.4F",
+      "title": "Department of the Navy Disability Evaluation System",
+      "shortTitle": "DES Order",
+      "category": "Medical",
+      "keywords": [
+        "des",
+        "disability",
+        "peb",
+        "meb",
+        "medical board",
+        "evaluation"
+      ]
+    },
+    {
+      "id": "secnavinst-1412-6",
+      "type": "SECNAVINST",
+      "number": "1412.6M",
+      "title": "Officer Promotion Reports and Reports Fitness",
+      "shortTitle": "FITREP Instruction",
+      "category": "Personnel",
+      "keywords": [
+        "fitrep",
+        "fitness report",
+        "officer",
+        "evaluation",
+        "promotion"
+      ]
+    },
+    {
+      "id": "secnavinst-5720-44",
+      "type": "SECNAVINST",
+      "number": "5720.44C",
+      "title": "DON Public Affairs Policy",
+      "shortTitle": "Public Affairs",
+      "category": "Admin",
+      "keywords": [
+        "public affairs",
+        "media",
+        "release",
+        "interview",
+        "social media"
+      ]
+    },
+    {
+      "id": "secnavinst-1770-3",
+      "type": "SECNAVINST",
+      "number": "1770.3E",
+      "title": "Casualty Assistance Calls Program",
+      "shortTitle": "CACO Program",
+      "category": "Personnel",
+      "keywords": [
+        "caco",
+        "casualty",
+        "notification",
+        "assistance",
+        "nok"
+      ]
+    },
+    {
+      "id": "dod-5500-7r",
+      "type": "DoD",
+      "number": "5500.07-R",
+      "title": "Joint Ethics Regulation",
+      "shortTitle": "JER",
+      "category": "Legal",
+      "keywords": [
+        "ethics",
+        "gift",
+        "conflict of interest",
+        "financial disclosure",
+        "post employment"
+      ]
+    },
+    {
+      "id": "dod-5200-01",
+      "type": "DoD",
+      "number": "5200.01",
+      "title": "DoD Information Security Program",
+      "shortTitle": "Info Security Program",
+      "category": "Intelligence",
+      "keywords": [
+        "classification",
+        "marking",
+        "handling",
+        "cui",
+        "secret",
+        "confidential"
+      ]
+    },
+    {
+      "id": "dod-5200-02",
+      "type": "DoD",
+      "number": "5200.02",
+      "title": "DoD Personnel Security Program",
+      "shortTitle": "Personnel Security Program",
+      "category": "Intelligence",
+      "keywords": [
+        "clearance",
+        "investigation",
+        "adjudication",
+        "suitability",
+        "national security"
+      ]
+    },
+    {
+      "id": "dod-8570-01m",
+      "type": "DoD",
+      "number": "8570.01-M",
+      "title": "Information Assurance Workforce Improvement Program",
+      "shortTitle": "IA Workforce",
+      "category": "Communications",
+      "keywords": [
+        "ia",
+        "certification",
+        "security+",
+        "comptia",
+        "cissp",
+        "cyber"
+      ]
+    },
+    {
+      "id": "dod-1327-06",
+      "type": "DoD",
+      "number": "1327.06",
+      "title": "Leave and Liberty Policy",
+      "shortTitle": "DoD Leave Policy",
+      "category": "Personnel",
+      "keywords": [
+        "leave",
+        "liberty",
+        "absence",
+        "sellback",
+        "terminal"
+      ]
+    },
+    {
+      "id": "dod-1400-25",
+      "type": "DoD",
+      "number": "1400.25",
+      "title": "DoD Civilian Personnel Management",
+      "shortTitle": "Civilian Personnel",
+      "category": "Admin",
+      "keywords": [
+        "civilian",
+        "gs",
+        "wg",
+        "personnel",
+        "hiring",
+        "hr"
+      ]
+    },
+    {
+      "id": "navyregs-1137",
+      "type": "U.S. Navy Regulations",
+      "number": "Article 1137",
+      "title": "Fraternization",
+      "shortTitle": "Fraternization",
+      "category": "Legal",
+      "keywords": [
+        "fraternization",
+        "relationship",
+        "officer",
+        "enlisted",
+        "prohibited"
+      ]
+    },
+    {
+      "id": "navyregs-1104",
+      "type": "U.S. Navy Regulations",
+      "number": "Article 1104",
+      "title": "Responsibility of Seniors",
+      "shortTitle": "Senior Responsibility",
+      "category": "Legal",
+      "keywords": [
+        "senior",
+        "responsibility",
+        "authority",
+        "supervision",
+        "command"
+      ]
+    },
+    {
+      "id": "navyregs-1109",
+      "type": "U.S. Navy Regulations",
+      "number": "Article 1109",
+      "title": "Authority in a Boat",
+      "shortTitle": "Boat Authority",
+      "category": "Operations",
+      "keywords": [
+        "boat",
+        "coxswain",
+        "authority",
+        "naval vessel"
+      ]
+    },
+    {
+      "id": "navyregs-0802",
+      "type": "U.S. Navy Regulations",
+      "number": "Article 0802",
+      "title": "Authority of a Commanding Officer",
+      "shortTitle": "CO Authority",
+      "category": "Legal",
+      "keywords": [
+        "commanding officer",
+        "authority",
+        "command",
+        "responsibility"
+      ]
+    },
+    {
+      "id": "navmc-2691",
+      "type": "NAVMC",
+      "number": "2691",
+      "title": "USMC Fitness Report",
+      "shortTitle": "FITREP Form",
+      "category": "Personnel",
+      "keywords": [
+        "fitrep",
+        "fitness report",
+        "form",
+        "evaluation",
+        "navmc"
+      ]
+    },
+    {
+      "id": "navmc-10274",
+      "type": "NAVMC",
+      "number": "10274",
+      "title": "Counseling Record",
+      "shortTitle": "Counseling Form",
+      "category": "Personnel",
+      "keywords": [
+        "counseling",
+        "6105",
+        "page 11",
+        "adverse",
+        "form"
+      ]
+    },
+    {
+      "id": "navmc-118",
+      "type": "NAVMC",
+      "number": "118",
+      "title": "Chronological Record",
+      "shortTitle": "Unit Diary",
+      "category": "Admin",
+      "keywords": [
+        "unit diary",
+        "diary",
+        "muster",
+        "gains",
+        "losses",
+        "118"
+      ]
+    },
+    {
+      "id": "mco-5000-14",
+      "type": "MCO",
+      "number": "5000.14B",
+      "title": "Marine Corps Values-Based Leadership Program",
+      "shortTitle": "Ethics Order",
+      "category": "Training",
+      "keywords": [
+        "ethics",
+        "values",
+        "leadership",
+        "integrity",
+        "honor"
+      ]
+    },
+    {
+      "id": "mco-1700-27",
+      "type": "MCO",
+      "number": "1700.27B",
+      "title": "Suicide Prevention Program",
+      "shortTitle": "Suicide Prevention",
+      "category": "Medical",
+      "keywords": [
+        "suicide",
+        "prevention",
+        "mental health",
+        "intervention",
+        "awareness"
+      ]
+    },
+    {
+      "id": "mco-1700-28",
+      "type": "MCO",
+      "number": "1700.28B",
+      "title": "Transition Readiness Program",
+      "shortTitle": "TRS Order",
+      "category": "Personnel",
+      "keywords": [
+        "trs",
+        "transition",
+        "tap",
+        "separation",
+        "employment",
+        "va"
+      ]
+    },
+    {
+      "id": "mco-1700-29",
+      "type": "MCO",
+      "number": "1700.29E",
+      "title": "Marine Corps Personal and Professional Development Program",
+      "shortTitle": "PPD Order",
+      "category": "Training",
+      "keywords": [
+        "ppd",
+        "personal development",
+        "professional development",
+        "mentoring"
+      ]
+    },
+    {
+      "id": "mco-1800-1",
+      "type": "MCO",
+      "number": "1800.1A",
+      "title": "Marine Corps Reserve Administrative Management Manual",
+      "shortTitle": "MCRAMM",
+      "category": "Personnel",
+      "keywords": [
+        "reserve",
+        "iir",
+        "smcr",
+        "drill",
+        "at",
+        "mobilization"
+      ]
+    },
+    {
+      "id": "mco-3502-6",
+      "type": "MCO",
+      "number": "3502.6A",
+      "title": "Marine Corps Force-on-Force Training",
+      "shortTitle": "Force-on-Force Order",
+      "category": "Training",
+      "keywords": [
+        "force on force",
+        "simunition",
+        "blank",
+        "miles",
+        "training"
+      ]
+    },
+    {
+      "id": "mco-3504-1",
+      "type": "MCO",
+      "number": "3504.1A",
+      "title": "Marine Corps Pre-deployment Training Program",
+      "shortTitle": "PTP Order",
+      "category": "Training",
+      "keywords": [
+        "ptp",
+        "pre-deployment",
+        "workup",
+        "deployment",
+        "itx",
+        "mojave viper"
+      ]
+    },
+    {
+      "id": "mco-6200-1",
+      "type": "MCO",
+      "number": "6200.1E",
+      "title": "Marine Corps Veterinary Services",
+      "shortTitle": "Veterinary Order",
+      "category": "Medical",
+      "keywords": [
+        "veterinary",
+        "mwd",
+        "military working dog",
+        "k9",
+        "food inspection"
+      ]
+    },
+    {
+      "id": "mco-6320-6",
+      "type": "MCO",
+      "number": "6320.6",
+      "title": "Marine Corps Medical Readiness Program",
+      "shortTitle": "Medical Readiness",
+      "category": "Medical",
+      "keywords": [
+        "medical readiness",
+        "deployment health",
+        "physical",
+        "dental",
+        "immunization"
+      ]
+    },
+    {
+      "id": "mco-1520-11",
+      "type": "MCO",
+      "number": "1520.11G",
+      "title": "Marine Corps Officer Professional Development",
+      "shortTitle": "Officer PME Order",
+      "category": "Training",
+      "keywords": [
+        "officer pme",
+        "tbs",
+        "ioc",
+        "eac",
+        "war college",
+        "amphibious"
+      ]
+    },
+    {
+      "id": "opnavinst-1160-8",
+      "type": "OPNAVINST",
+      "number": "1160.8B",
+      "title": "Selective Reenlistment Bonus Program",
+      "shortTitle": "SRB Program",
+      "category": "Personnel",
+      "keywords": [
+        "srb",
+        "bonus",
+        "reenlistment",
+        "selective",
+        "zone"
+      ]
+    },
+    {
+      "id": "opnavinst-5350-4",
+      "type": "OPNAVINST",
+      "number": "5350.4D",
+      "title": "Navy Alcohol and Drug Abuse Prevention",
+      "shortTitle": "Navy DAPA",
+      "category": "Medical",
+      "keywords": [
+        "dapa",
+        "drug",
+        "alcohol",
+        "substance abuse",
+        "urinalysis"
+      ]
+    },
+    {
+      "id": "opnavinst-6110-1",
+      "type": "OPNAVINST",
+      "number": "6110.1J",
+      "title": "Physical Readiness Program",
+      "shortTitle": "Navy PRT",
+      "category": "Fitness",
+      "keywords": [
+        "prt",
+        "physical readiness",
+        "navy fitness",
+        "bca",
+        "body composition"
+      ]
+    },
+    {
+      "id": "mco-5215-1",
+      "type": "MCO",
+      "number": "5215.1L",
+      "title": "Marine Corps Directives Management Program",
+      "shortTitle": "Directives Management",
+      "category": "Admin",
+      "keywords": [
+        "directives",
+        "orders",
+        "bulletins",
+        "management",
+        "issuance"
+      ]
+    },
+    {
+      "id": "mco-1001r-1",
+      "type": "MCO",
+      "number": "1001R.1L",
+      "title": "Marine Corps Reserve Administrative Management Manual",
+      "shortTitle": "MCTFS User Manual",
+      "category": "Admin",
+      "keywords": [
+        "mctfs",
+        "reserve",
+        "administration",
+        "records",
+        "iram"
+      ]
+    },
+    {
+      "id": "mco-3000-11",
+      "type": "MCO",
+      "number": "3000.11B",
+      "title": "Marine Air Ground Task Force Staff Training Program",
+      "shortTitle": "MSTP",
+      "category": "Operations",
+      "keywords": [
+        "magtf",
+        "staff training",
+        "mstp",
+        "planning"
+      ]
+    },
+    {
+      "id": "secnav-m-5210-1",
+      "type": "SECNAV M",
+      "number": "5210.1",
+      "title": "Department of the Navy Records Management Manual",
+      "shortTitle": "Records Management Manual",
+      "category": "Admin",
+      "keywords": [
+        "records",
+        "retention",
+        "disposition",
+        "filing",
+        "recordkeeping"
+      ]
+    },
+    {
+      "id": "secnavinst-5211-5",
+      "type": "SECNAVINST",
+      "number": "5211.5F",
+      "title": "Department of the Navy Privacy Act Program",
+      "shortTitle": "Privacy Act",
+      "category": "Admin",
+      "keywords": [
+        "privacy act",
+        "pii",
+        "personal information",
+        "pa"
+      ]
+    },
+    {
+      "id": "mcbul-5216",
+      "type": "MCBul",
+      "number": "5216",
+      "title": "Correspondence Procedures",
+      "shortTitle": "Correspondence Bulletin",
+      "category": "Admin",
+      "keywords": [
+        "correspondence",
+        "naval letter",
+        "format",
+        "procedures"
+      ]
+    },
+    {
+      "id": "mcbul-1020",
+      "type": "MCBul",
+      "number": "1020",
+      "title": "Uniform Board Decisions",
+      "shortTitle": "Uniform Board",
+      "category": "Admin",
+      "keywords": [
+        "uniform",
+        "uniform board",
+        "appearance",
+        "clothing"
+      ]
+    },
+    {
+      "id": "navyregs-1990",
+      "type": "U.S. Navy Regulations",
+      "number": "1990",
+      "title": "United States Navy Regulations",
+      "shortTitle": "Navy Regs",
+      "category": "Admin",
+      "keywords": [
+        "navy regulations",
+        "authority",
+        "duties",
+        "conduct"
+      ]
+    },
+    {
+      "id": "opnavinst-5215-17",
+      "type": "OPNAVINST",
+      "number": "5215.17A",
+      "title": "Navy Directives Issuance System",
+      "shortTitle": "Directives Issuance",
+      "category": "Admin",
+      "keywords": [
+        "directives",
+        "instructions",
+        "notices",
+        "issuance"
+      ]
+    },
+    {
+      "id": "mcrp-3-0b",
+      "type": "MCRP",
+      "number": "3-0B",
+      "title": "How to Conduct Training",
+      "shortTitle": "Training Reference",
+      "category": "Training",
+      "keywords": [
+        "training",
+        "conduct",
+        "systems approach",
+        "lesson"
+      ]
+    },
+    {
+      "id": "mcwp-5-10",
+      "type": "MCWP",
+      "number": "5-10",
+      "title": "Marine Corps Planning Process",
+      "shortTitle": "MCPP",
+      "category": "Operations",
+      "keywords": [
+        "planning",
+        "mcpp",
+        "operations",
+        "orders"
+      ]
+    },
+    {
+      "id": "ref-common-a",
+      "type": "Common",
+      "number": "",
+      "title": "Reference (a)",
+      "shortTitle": "Reference (a)",
+      "category": "General",
+      "keywords": [
+        "reference",
+        "placeholder",
+        "ref a"
+      ]
+    },
+    {
+      "id": "common-basic-correspondence",
+      "type": "Common",
+      "number": "",
+      "title": "Basic Correspondence",
+      "shortTitle": "Basic Correspondence",
+      "category": "General",
+      "keywords": [
+        "basic correspondence",
+        "naval letter",
+        "placeholder"
+      ]
+    },
+    {
+      "id": "common-endorsement-1",
+      "type": "Common",
+      "number": "",
+      "title": "Endorsement 1",
+      "shortTitle": "Endorsement",
+      "category": "General",
+      "keywords": [
+        "endorsement",
+        "placeholder",
+        "routing"
+      ]
+    },
+    {
+      "id": "mco-p1080-20",
+      "type": "MCO",
+      "number": "P1080.20",
+      "title": "Marine Corps Total Force System Personnel Reporting Instructions",
+      "shortTitle": "Promotions Manual",
+      "category": "Personnel",
+      "keywords": [
+        "promotions",
+        "mctfs",
+        "personnel reporting",
+        "promotion"
+      ]
+    },
+    {
+      "id": "jagman",
+      "type": "Manual",
+      "number": "JAGMAN",
+      "title": "Manual of the Judge Advocate General",
+      "shortTitle": "JAGMAN",
+      "category": "Legal",
+      "keywords": [
+        "jagman",
+        "investigation",
+        "legal",
+        "judge advocate",
+        "jag"
+      ]
+    },
+    {
+      "id": "mco-p1100-72",
+      "type": "MCO",
+      "number": "P1100.72C",
+      "title": "Military Occupational Specialties Manual",
+      "shortTitle": "MOS Manual",
+      "category": "Personnel",
+      "keywords": [
+        "mos",
+        "occupational specialty",
+        "military occupational"
+      ]
+    },
+    {
+      "id": "mco-5300-17",
+      "type": "MCO",
+      "number": "5300.17A",
+      "title": "Marine Corps Substance Abuse Program",
+      "shortTitle": "Substance Abuse",
+      "category": "Medical",
+      "keywords": [
+        "substance abuse",
+        "alcohol",
+        "drugs",
+        "saprr",
+        "treatment"
+      ]
+    },
+    {
+      "id": "mco-5300-6",
+      "type": "MCO",
+      "number": "5300.6",
+      "title": "Marine Corps Urinalysis Program",
+      "shortTitle": "Urinalysis",
+      "category": "Medical",
+      "keywords": [
+        "urinalysis",
+        "drug testing",
+        "sweat",
+        "random testing"
+      ]
+    },
+    {
+      "id": "mco-5100-19",
+      "type": "MCO",
+      "number": "5100.19F",
+      "title": "Marine Corps Traffic Safety Program",
+      "shortTitle": "Traffic Safety",
+      "category": "Safety",
+      "keywords": [
+        "traffic safety",
+        "driving",
+        "motorcycle",
+        "pmv",
+        "safety"
+      ]
+    },
+    {
+      "id": "ucmj-art-86",
+      "type": "UCMJ",
+      "number": "Article 86",
+      "title": "Absence Without Leave",
+      "shortTitle": "AWOL",
+      "category": "Legal",
+      "keywords": [
+        "awol",
+        "unauthorized absence",
+        "ua",
+        "absence"
+      ]
+    },
+    {
+      "id": "ucmj-art-91",
+      "type": "UCMJ",
+      "number": "Article 91",
+      "title": "Insubordinate Conduct Toward Warrant Officer, NCO, or PO",
+      "shortTitle": "Insubordinate Conduct",
+      "category": "Legal",
+      "keywords": [
+        "insubordination",
+        "disrespect",
+        "nco",
+        "conduct"
+      ]
+    },
+    {
+      "id": "ucmj-art-92",
+      "type": "UCMJ",
+      "number": "Article 92",
+      "title": "Failure to Obey Order or Regulation",
+      "shortTitle": "Failure to Obey",
+      "category": "Legal",
+      "keywords": [
+        "failure to obey",
+        "order",
+        "regulation",
+        "disobey"
+      ]
+    },
+    {
+      "id": "ucmj-art-107",
+      "type": "UCMJ",
+      "number": "Article 107",
+      "title": "False Official Statements",
+      "shortTitle": "False Statement",
+      "category": "Legal",
+      "keywords": [
+        "false statement",
+        "false official",
+        "lying",
+        "integrity"
+      ]
+    },
+    {
+      "id": "ucmj-art-112a",
+      "type": "UCMJ",
+      "number": "Article 112a",
+      "title": "Wrongful Use, Possession, etc., of Controlled Substances",
+      "shortTitle": "Controlled Substances",
+      "category": "Legal",
+      "keywords": [
+        "drugs",
+        "controlled substance",
+        "wrongful use",
+        "positive test"
+      ]
+    },
+    {
+      "id": "ucmj-art-128",
+      "type": "UCMJ",
+      "number": "Article 128",
+      "title": "Assault",
+      "shortTitle": "Assault",
+      "category": "Legal",
+      "keywords": [
+        "assault",
+        "battery",
+        "violence",
+        "fight"
+      ]
+    },
+    {
+      "id": "ucmj-art-134",
+      "type": "UCMJ",
+      "number": "Article 134",
+      "title": "General Article",
+      "shortTitle": "General Article",
+      "category": "Legal",
+      "keywords": [
+        "general article",
+        "good order",
+        "discipline",
+        "service discrediting"
+      ]
+    },
+    {
+      "id": "mco-7220-52",
+      "type": "MCO",
+      "number": "7220.52F",
+      "title": "Marine Corps Indebtedness Processing Procedures",
+      "shortTitle": "Indebtedness",
+      "category": "Supply",
+      "keywords": [
+        "indebtedness",
+        "debt",
+        "pay",
+        "collection",
+        "finance"
+      ]
+    }
+  ]
+}

--- a/src/data/references.ts
+++ b/src/data/references.ts
@@ -1,0 +1,106 @@
+/**
+ * Reference library — single source of truth.
+ *
+ * Backed by `references.json` (rich schema: stable ids, type/number/title,
+ * short titles, keywords, functional categories). Replaces the two hardcoded
+ * inline arrays that used to live in ReferenceLibraryModal and
+ * FormReferenceLibraryModal. Mirrors the data-module pattern of
+ * `officeCodes.ts` / `unitDirectory.ts` (JSON data + typed accessors).
+ */
+import referencesData from './references.json';
+
+export interface Reference {
+  /** Stable id, e.g. `mco-1610-7`. Lets saved data reference a directive by
+   *  id instead of a free-text string (future auto-update-on-reissue work). */
+  id: string;
+  /** Issuing authority / series, e.g. `MCO`, `SECNAV M`, `UCMJ`, `Manual`. */
+  type: string;
+  /** Order/article number, e.g. `1610.7A`. Empty for the correspondence
+   *  quick-insert pseudo-entries (Reference (a), Endorsement 1, …). */
+  number: string;
+  title: string;
+  /** Optional colloquial name, e.g. `FITREP/PRO-CON Order`. Searchable. */
+  shortTitle?: string;
+  category: string;
+  keywords: string[];
+}
+
+interface ReferencesFile {
+  version: string;
+  lastUpdated: string;
+  categories: string[];
+  references: Reference[];
+}
+
+const data = referencesData as ReferencesFile;
+
+/** Canonical category order (drives grouping in the picker). */
+export const REFERENCE_CATEGORIES: readonly string[] = data.categories;
+
+export const ALL_REFERENCES: readonly Reference[] = data.references;
+
+/**
+ * Human-readable citation, e.g. `MCO 1610.7A - Performance Evaluation System`.
+ * `Manual`-type entries (UCMJ, MCM, JAGMAN) lead with the acronym; the
+ * correspondence quick-inserts (no number) render as their title alone.
+ */
+export function formatReference(ref: Reference): string {
+  if (!ref.number) return ref.title;
+  let head: string;
+  if (ref.type === 'Manual') {
+    head = ref.number; // UCMJ, MCM, JAGMAN — the number IS the acronym
+  } else if (ref.type === 'SECNAV M') {
+    head = `SECNAV M-${ref.number}`; // cited with a hyphen: SECNAV M-5216.5
+  } else {
+    head = `${ref.type} ${ref.number}`;
+  }
+  return ref.title ? `${head} - ${ref.title}` : head;
+}
+
+export function getReference(id: string): Reference | undefined {
+  return ALL_REFERENCES.find((r) => r.id === id);
+}
+
+/**
+ * Keyword-aware search. Every whitespace-separated token in the query must
+ * appear somewhere in the entry's searchable text (citation, type, number,
+ * title, short title, category, or keywords) — so `fitness report` matches
+ * the FITREP order via its keywords, not just a title substring. An empty
+ * query returns everything.
+ */
+export function searchReferences(query: string): Reference[] {
+  const tokens = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return [...ALL_REFERENCES];
+  return ALL_REFERENCES.filter((r) => {
+    const haystack = [
+      formatReference(r),
+      r.type,
+      r.number,
+      r.title,
+      r.shortTitle ?? '',
+      r.category,
+      ...r.keywords,
+    ]
+      .join(' ')
+      .toLowerCase();
+    return tokens.every((tok) => haystack.includes(tok));
+  });
+}
+
+/**
+ * Group references by category in canonical order, dropping empty categories.
+ * Pass the result of `searchReferences` to render filtered results grouped.
+ */
+export function getReferencesByCategory(
+  refs: readonly Reference[] = ALL_REFERENCES,
+): Record<string, Reference[]> {
+  const grouped: Record<string, Reference[]> = {};
+  for (const cat of REFERENCE_CATEGORIES) grouped[cat] = [];
+  for (const r of refs) {
+    (grouped[r.category] ??= []).push(r);
+  }
+  for (const cat of Object.keys(grouped)) {
+    if (grouped[cat].length === 0) delete grouped[cat];
+  }
+  return grouped;
+}

--- a/tests/unit/references.test.ts
+++ b/tests/unit/references.test.ts
@@ -101,25 +101,86 @@ describe('getReference / getReferencesByCategory', () => {
   });
 });
 
-// No-regression guard: every reference the two former inline arrays surfaced
-// must still be discoverable via search. Each token below is the distinctive
-// identifier from an original entry; a token that returns zero results means
-// that reference vanished from the library.
-describe('no regression vs the former inline modal arrays', () => {
-  const MUST_BE_DISCOVERABLE = [
-    // ReferenceLibraryModal (general)
-    '5215.1L', '5216.20', '5210.11F', '1650.19', '1900.16', '1001R.1L', '1020.34H',
-    '3000.11B', '3500.27C', '5580.2B', 'M-5210.1', '5216.5', '5211.5F', '5510.30C',
-    '5510.36B', 'MCBul 5216', 'MCBul 1020', 'Navy Regulations', '5215.17A', 'MCRP',
-    'MCWP', 'Reference (a)', 'Basic Correspondence', 'Endorsement 1',
-    // FormReferenceLibraryModal (counseling)
-    '1610.7A', '1070.12K', 'P1080.20', '6100.13A', '6110.3A', '5800.16A', '1752.5C',
-    '5354.1', 'JAGMAN', 'P1100.72C', '5300.17A', '5300.6', '1050.3J', '1510.118',
-    '5100.29C', '5100.19F', 'Article 86', 'Article 91', 'Article 92', 'Article 107',
-    'Article 112a', 'Article 128', 'Article 134', '7220.52F',
-  ];
+// No-regression guard: EVERY citation string the two former inline arrays
+// surfaced (verbatim below) must still be discoverable in the unified dataset.
+// The check derives the realistic search token from each original title (its
+// order identifier, or the whole quick-insert phrase) and asserts a hit — so a
+// directive dropped from the library, or silently regressed to an older
+// revision letter, fails CI.
+const FORMER_GENERAL_ARRAY = [
+  'MCO 5215.1L - Directives Management Program',
+  'MCO 5216.20 - Correspondence Manual',
+  'MCO 5210.11F - Record Management Program',
+  'MCO 1650.19K - Decorations and Awards',
+  'MCO 1900.16 - Separation and Retirement',
+  'MCO 1001R.1L - MCTFS User Manual',
+  'MCO 1020.34H - Marine Corps Uniform Regulations',
+  'MCO 3000.11B - Marine Air Ground Task Force Staff Training Program',
+  'MCO 3500.27C - Operational Risk Management',
+  'MCO 5580.2B - Law Enforcement Manual',
+  'SECNAV M-5210.1 - Department of the Navy Records Management Manual',
+  'SECNAV M-5216.5 - Department of the Navy Correspondence Manual',
+  'SECNAV M-5239.2 - DON Cybersecurity Program',
+  'SECNAVINST 5211.5F - Privacy Act',
+  'SECNAVINST 5510.30C - DON Personnel Security Program',
+  'SECNAVINST 5510.36B - DON Information Security Program',
+  'MCBul 5216 - Correspondence Procedures',
+  'MCBul 1020 - Uniform Board Decisions',
+  'U.S. Navy Regulations, 1990',
+  'OPNAVINST 5215.17A - Navy Directives Issuance System',
+  'MCRP 3-0B - How to Conduct Training',
+  'MCWP 5-10 - Marine Corps Planning Process',
+  'Reference (a)',
+  'Basic Correspondence',
+  'Endorsement 1',
+];
+const FORMER_FORM_ARRAY = [
+  'MCO 1610.7A - Performance Evaluation System',
+  'MCO 1900.16 - Separation and Retirement Manual',
+  'MCO 1070.12K - Individual Records Administration Manual',
+  'MCO P1080.20 - Marine Corps Promotions Manual',
+  'MCO 1001R.1L - MCTFS User Manual',
+  'MCO 6100.13A W/CH 1 - Marine Corps Physical Fitness and Combat Fitness Tests',
+  'MCO 6110.3A - Marine Corps Body Composition and Military Appearance Program',
+  'MCO 5800.16A - Marine Corps Manual for Legal Administration (LEGADMINMAN)',
+  'MCO 1752.5C - Sexual Assault Prevention and Response Program',
+  'MCO 5354.1F - Marine Corps Prohibited Activities and Conduct Prevention',
+  'JAGMAN - Manual of the Judge Advocate General',
+  'MCO 1020.34H - Marine Corps Uniform Regulations',
+  'MCO P1100.72C - Military Occupational Specialties Manual',
+  'MCO 5300.17A - Marine Corps Substance Abuse Program',
+  'MCO 5300.6 - Urinalysis Program',
+  'MCO 1050.3J - Regulations for Leave, Liberty, and Administrative Absence',
+  'MCO 1510.118 - Individual Training Standards',
+  'MCO 3500.27C - Operational Risk Management',
+  'MCO 5100.29C - Marine Corps Safety Program',
+  'MCO 5100.19F - Marine Corps Traffic Safety Program',
+  'UCMJ Article 86 - Absence Without Leave',
+  'UCMJ Article 91 - Insubordinate Conduct',
+  'UCMJ Article 92 - Failure to Obey Order or Regulation',
+  'UCMJ Article 107 - False Official Statements',
+  'UCMJ Article 112a - Wrongful Use of Controlled Substances',
+  'UCMJ Article 128 - Assault',
+  'UCMJ Article 134 - General Article',
+  'MCO 7220.52F - Marine Corps Indebtedness Processing Procedures',
+];
 
-  it.each(MUST_BE_DISCOVERABLE)('surfaces a result for "%s"', (token) => {
-    expect(searchReferences(token).length).toBeGreaterThan(0);
-  });
+/** The token a user would realistically type to find a given original entry. */
+function searchTokenFor(title: string): string {
+  // Quick-insert pseudo-entries with no order number: search the whole phrase.
+  if (!title.includes(' - ') && !title.includes('Article')) {
+    return title.replace(/[,()]/g, ' ').replace(/\s+/g, ' ').trim();
+  }
+  const head = title.split(' - ')[0];
+  const num = head.match(/\b([A-Z]?\d{3,5}[.-]\d+[A-Za-z]?|\d-\d+[A-Za-z]?|Article \d+[a-z]?)\b/);
+  return num ? num[1] : head.replace(/[,()]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+describe('no regression vs the former inline modal arrays', () => {
+  it.each([...FORMER_GENERAL_ARRAY, ...FORMER_FORM_ARRAY])(
+    'still surfaces "%s"',
+    (originalTitle) => {
+      expect(searchReferences(searchTokenFor(originalTitle)).length).toBeGreaterThan(0);
+    },
+  );
 });

--- a/tests/unit/references.test.ts
+++ b/tests/unit/references.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ALL_REFERENCES,
+  REFERENCE_CATEGORIES,
+  formatReference,
+  getReference,
+  getReferencesByCategory,
+  searchReferences,
+  type Reference,
+} from '@/data/references';
+
+describe('references data integrity', () => {
+  it('has unique ids', () => {
+    const ids = ALL_REFERENCES.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every entry has a title, a category in the canonical list, and keywords', () => {
+    for (const r of ALL_REFERENCES) {
+      expect(r.title, r.id).toBeTruthy();
+      expect(REFERENCE_CATEGORIES, r.id).toContain(r.category);
+      expect(Array.isArray(r.keywords), r.id).toBe(true);
+    }
+  });
+});
+
+describe('formatReference', () => {
+  const ref = (over: Partial<Reference>): Reference => ({
+    id: 'x',
+    type: 'MCO',
+    number: '1',
+    title: 't',
+    category: 'Admin',
+    keywords: [],
+    ...over,
+  });
+
+  it('renders "TYPE NUMBER - TITLE" for standard directives', () => {
+    expect(
+      formatReference(ref({ type: 'MCO', number: '1610.7A', title: 'Performance Evaluation System' })),
+    ).toBe('MCO 1610.7A - Performance Evaluation System');
+  });
+
+  it('hyphenates SECNAV manuals per citation style', () => {
+    expect(
+      formatReference(ref({ type: 'SECNAV M', number: '5216.5', title: 'Correspondence Manual' })),
+    ).toBe('SECNAV M-5216.5 - Correspondence Manual');
+  });
+
+  it('leads with the acronym for Manual-type entries', () => {
+    expect(
+      formatReference(ref({ type: 'Manual', number: 'UCMJ', title: 'Uniform Code of Military Justice' })),
+    ).toBe('UCMJ - Uniform Code of Military Justice');
+  });
+
+  it('renders UCMJ articles as "UCMJ Article N - TITLE"', () => {
+    expect(
+      formatReference(ref({ type: 'UCMJ', number: 'Article 86', title: 'Absence Without Leave' })),
+    ).toBe('UCMJ Article 86 - Absence Without Leave');
+  });
+
+  it('renders no-number pseudo-entries as their title alone', () => {
+    expect(formatReference(ref({ type: 'Common', number: '', title: 'Endorsement 1' }))).toBe('Endorsement 1');
+  });
+});
+
+describe('searchReferences', () => {
+  it('returns everything for an empty query', () => {
+    expect(searchReferences('').length).toBe(ALL_REFERENCES.length);
+    expect(searchReferences('   ').length).toBe(ALL_REFERENCES.length);
+  });
+
+  it('matches on keywords, not just the title', () => {
+    // "fitrep" appears only in mco-1610-7's keywords, not its title.
+    const hits = searchReferences('fitrep');
+    expect(hits.some((r) => r.id === 'mco-1610-7')).toBe(true);
+    expect(hits.every((r) => !r.title.toLowerCase().includes('fitrep'))).toBe(true);
+  });
+
+  it('requires every whitespace-separated token to match (AND semantics)', () => {
+    const hits = searchReferences('fitness report');
+    expect(hits.some((r) => r.id === 'mco-1610-7')).toBe(true);
+    // A token that matches nothing collapses the result set.
+    expect(searchReferences('fitrep zzzznope')).toHaveLength(0);
+  });
+
+  it('finds an added UCMJ article by its offense keyword', () => {
+    expect(searchReferences('awol').some((r) => r.id === 'ucmj-art-86')).toBe(true);
+  });
+});
+
+describe('getReference / getReferencesByCategory', () => {
+  it('resolves a known id and returns undefined for an unknown one', () => {
+    expect(getReference('mco-1610-7')?.number).toBe('1610.7A');
+    expect(getReference('nope')).toBeUndefined();
+  });
+
+  it('groups in canonical category order and drops empty categories', () => {
+    const grouped = getReferencesByCategory(searchReferences('awol')); // Legal only
+    expect(Object.keys(grouped)).toEqual(['Legal']);
+  });
+});
+
+// No-regression guard: every reference the two former inline arrays surfaced
+// must still be discoverable via search. Each token below is the distinctive
+// identifier from an original entry; a token that returns zero results means
+// that reference vanished from the library.
+describe('no regression vs the former inline modal arrays', () => {
+  const MUST_BE_DISCOVERABLE = [
+    // ReferenceLibraryModal (general)
+    '5215.1L', '5216.20', '5210.11F', '1650.19', '1900.16', '1001R.1L', '1020.34H',
+    '3000.11B', '3500.27C', '5580.2B', 'M-5210.1', '5216.5', '5211.5F', '5510.30C',
+    '5510.36B', 'MCBul 5216', 'MCBul 1020', 'Navy Regulations', '5215.17A', 'MCRP',
+    'MCWP', 'Reference (a)', 'Basic Correspondence', 'Endorsement 1',
+    // FormReferenceLibraryModal (counseling)
+    '1610.7A', '1070.12K', 'P1080.20', '6100.13A', '6110.3A', '5800.16A', '1752.5C',
+    '5354.1', 'JAGMAN', 'P1100.72C', '5300.17A', '5300.6', '1050.3J', '1510.118',
+    '5100.29C', '5100.19F', 'Article 86', 'Article 91', 'Article 92', 'Article 107',
+    'Article 112a', 'Article 128', 'Article 134', '7220.52F',
+  ];
+
+  it.each(MUST_BE_DISCOVERABLE)('surfaces a result for "%s"', (token) => {
+    expect(searchReferences(token).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #55.

Both reference pickers now share one component (\`ReferenceLibraryPicker\`) backed by a single dataset (\`src/data/references.json\`, 135 entries with stable ids, keywords, and functional categories). Removes the two duplicated inline arrays.

**What changed**
- \`ReferenceLibraryModal\` (top bar) and \`FormReferenceLibraryModal\` (6105 counseling) are now thin wrappers over the shared picker
- Keyword search beyond title substring — `fitrep` → FITREP order, `awol` → UCMJ Art. 86
- Stable ids per directive (`mco-1610-7`, …) for future id-based references
- Reconciled the two former arrays into the dataset (28 entries the recovered JSON was missing were added), so nothing regresses

**Verification**
- 61 new unit tests incl. a no-regression guard asserting every entry either modal used to surface is still discoverable; full suite 1488 pass; lint + build clean
- Live: general picker renders (13 categories, correct citations), keyword search + empty state work, zero console errors

Out of scope (per the issue): id-based storage in the references field, and authoritative reference-data sourcing.