### PR TITLE
chore(lint): add eslint-plugin-security

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,11 +2,48 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import security from 'eslint-plugin-security'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  // dist = build output; public/lib = vendored/generated runtime bundles
+  // (pdf.js worker, swiftlatex, texlive, wasi shim, generated latex-templates)
+  // — third-party/minified, not hand-maintained source.
+  globalIgnores(['dist', 'public/lib/**']),
+  // Security linting across app + Node build scripts. The value here is the
+  // low-noise sink rules that DON'T currently fire but guard future code:
+  // eval-with-expression, child-process, non-literal-require,
+  // pseudoRandomBytes, buffer-noassert, disable-mustache-escape, etc. Four
+  // rules are turned off below as noise/redundant (see rationale inline).
+  security.configs.recommended,
+  {
+    rules: {
+      // Fires on nearly every `obj[key]` / `arr[i]` access (~98% false
+      // positive here). Real prototype-pollution sinks are caught by review.
+      'security/detect-object-injection': 'off',
+      // Every fs call in this repo is build-time tooling (scripts/*, tests)
+      // over trusted, code-derived paths — the browser app has no fs and takes
+      // no untrusted filenames. All hits were false positives.
+      'security/detect-non-literal-fs-filename': 'off',
+      // ReDoS is covered authoritatively by CodeQL `js/redos` (runs in CI —
+      // it's what hardened the signature-field regex in PR #69). safe-regex
+      // additionally flags bounded, non-exploitable patterns; all current hits
+      // were reviewed safe, so this rule is redundant noise on top of CodeQL.
+      'security/detect-unsafe-regex': 'off',
+      // Our only RegExp built from user input (FindReplaceModal) escapes every
+      // metacharacter first; the rest clone internal constant regexes. The
+      // rule can't see the escape, so it only nags on safe usage.
+      'security/detect-non-literal-regexp': 'off',
+    },
+  },
+  {
+    // The fuzz helper embeds bidirectional-control characters on purpose (they
+    // are the test input for our Trojan-Source handling), not a source-code
+    // smuggling risk. Keep the rule on everywhere else.
+    files: ['tests/**'],
+    rules: { 'security/detect-bidi-characters': 'off' },
+  },
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.2",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.2",
+      "version": "1.2.5",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -65,6 +65,7 @@
         "eslint": "^10.3.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "eslint-plugin-security": "^4.0.1",
         "fake-indexeddb": "^6.2.5",
         "fast-check": "^4.7.0",
         "globals": "^17.6.0",
@@ -7449,6 +7450,22 @@
         "eslint": "^9 || ^10"
       }
     },
+    "node_modules/eslint-plugin-security": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-4.0.1.tgz",
+      "integrity": "sha512-/lZCkOxPOWaf1jXAqgICrS8St3BMBccIPvhOSUYuV6VCr1o5nFVG998FnTLt6w2Nxb8Uo0nM8fzmnhp+GY/aEg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
@@ -10521,6 +10538,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -10777,6 +10804,16 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint": "^10.3.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "eslint-plugin-security": "^4.0.1",
     "fake-indexeddb": "^6.2.5",
     "fast-check": "^4.7.0",
     "globals": "^17.6.0",


### PR DESCRIPTION
Enables `eslint-plugin-security` and tunes it to a low-noise ruleset, so the existing lint gate now also enforces security hygiene.

**Kept on (10 low-false-positive sink rules):** `detect-eval-with-expression`, `detect-child-process`, `detect-non-literal-require`, `detect-pseudoRandomBytes`, `detect-buffer-noassert`, `detect-new-buffer`, `detect-disable-mustache-escape`, `detect-no-csrf-before-method-override`, `detect-possible-timing-attacks`, `detect-bidi-characters`. None currently fire — they guard future code.

**Turned off (documented in config), after reviewing every hit:**
- `detect-object-injection` — fired on ~2,800 ordinary `obj[key]` accesses (~98% FP)
- `detect-non-literal-fs-filename` — all hits are trusted build-time tooling; the browser app has no `fs`
- `detect-unsafe-regex` — reviewed all as bounded/safe; ReDoS is already covered by CodeQL `js/redos` in CI (which hardened the signature-field regex in PR #69)
- `detect-non-literal-regexp` — our only user-input RegExp escapes every metachar first; the rest clone internal constants

Also ignores vendored/generated bundles under `public/lib/**`.

**Verification:** reviewed all 66 non-object-injection findings (no real vulns); lint clean; `npm audit` 0 vulnerabilities; 1493 tests pass; build clean. Baseline stays at zero so the gate keeps enforcing it.