### PR TITLE
fix(backup): back up everything, not just documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.6] — 2026-07-03
+
+### Fixed
+
+- "Back up all documents" was silently incomplete: it saved only your
+  documents, so restoring a backup on another machine lost your profiles
+  and saved signatures, snippets, user templates, and in-progress NAVMC
+  form fields — each lives in its own store. The action (now **"Back up
+  everything"**) writes a full-account bundle covering all of them, and
+  restore merges non-destructively so re-importing an older backup can't
+  overwrite newer local work. Legacy documents-only backup files still
+  restore.
+
 ## [1.2.5] — 2026-07-02
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.5",
+  "version": "1.2.6",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline",

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -27,7 +27,8 @@ import {
 import { useUIStore } from '@/stores/uiStore';
 import { useDocumentStore } from '@/stores/documentStore';
 import { useFormStore } from '@/stores/formStore';
-import { useDocumentsStore, exportLibrary, importLibrary } from '@/stores/documentsStore';
+import { useDocumentsStore } from '@/stores/documentsStore';
+import { buildBackup, restoreBackup, summarizeRestore } from '@/lib/backup';
 import { useBackupStore } from '@/stores/backupStore';
 import { useHistoryStore } from '@/stores/historyStore';
 import { uint8ArrayToBase64, base64ToUint8Array, arrayBufferToUint8Array } from '@/lib/encoding';
@@ -572,19 +573,21 @@ export function Header({
   // one) — a safety net against browser-storage eviction.
   const handleExportLibrary = useCallback(async () => {
     try {
-      const json = await exportLibrary();
+      // Full-account bundle: documents + profiles/signatures + snippets +
+      // templates + live NAVMC forms — not just documents.
+      const json = await buildBackup();
       const blob = new Blob([json], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `dondocs-library-${new Date().toISOString().split('T')[0]}.json`;
+      a.download = `dondocs-backup-${new Date().toISOString().split('T')[0]}.json`;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
-      flashSaveStatus('Backed up!');
+      flashSaveStatus('Backed up everything!');
     } catch (err) {
-      console.error('Failed to export library:', err);
+      console.error('Failed to export backup:', err);
       flashSaveStatus('Backup failed');
     }
   }, [flashSaveStatus]);
@@ -595,12 +598,13 @@ export function Header({
     const reader = new FileReader();
     reader.onload = async (e) => {
       try {
-        const { imported, skipped } = await importLibrary(e.target?.result as string);
-        const kept = skipped > 0 ? ` · kept ${skipped} newer` : '';
-        flashSaveStatus(`Imported ${imported} document${imported === 1 ? '' : 's'}${kept}`);
+        // Branches on file kind: full backups restore everything, legacy
+        // docs-only files still restore documents. Merges non-destructively.
+        const result = await restoreBackup(e.target?.result as string);
+        flashSaveStatus(summarizeRestore(result));
       } catch (err) {
-        console.error('Failed to import library:', err);
-        flashSaveStatus('Import failed');
+        console.error('Failed to restore backup:', err);
+        flashSaveStatus('Restore failed');
       }
     };
     reader.readAsText(file);
@@ -819,7 +823,7 @@ export function Header({
               </DropdownMenuItem>
               <DropdownMenuItem onClick={handleExportLibrary}>
                 <FileDown className="h-4 w-4 mr-2" />
-                Back up all documents
+                Back up everything
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => libraryInputRef.current?.click()}>
                 <FileUp className="h-4 w-4 mr-2" />

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1,0 +1,203 @@
+/**
+ * Full-account backup: one downloadable file that captures EVERYTHING a user
+ * has, not just their documents.
+ *
+ * The original "Back up all documents" file (`exportLibrary`, kind
+ * `dondocs-library` v1) serialized only the IndexedDB document registry — so a
+ * restore on a new machine silently lost the user's profiles + signatures,
+ * saved snippets, user templates, and in-progress NAVMC form fields (each lives
+ * in its own persisted store). This module produces a versioned bundle
+ * (`dondocs-backup` v2) that includes all of them, and restores them
+ * NON-DESTRUCTIVELY so re-importing an old backup can never clobber newer local
+ * work.
+ *
+ * Everything here is a local browser operation (JSON build + merge into
+ * localStorage/IndexedDB) — no network, air-gap safe.
+ */
+import type { Profile } from '@/types/document';
+import { exportLibrary, importLibrary } from '@/stores/documentsStore';
+import { useProfileStore } from '@/stores/profileStore';
+import { useFormStore } from '@/stores/formStore';
+import { useSnippetsStore, type Snippet } from '@/stores/snippetsStore';
+import { useUserTemplatesStore, type UserTemplate } from '@/stores/userTemplatesStore';
+
+export const BACKUP_KIND = 'dondocs-backup';
+export const BACKUP_VERSION = 2;
+const LIBRARY_KIND = 'dondocs-library'; // legacy docs-only file
+
+export interface BackupBundle {
+  kind: typeof BACKUP_KIND;
+  version: number;
+  exportedAt: number;
+  documents: unknown[];
+  profiles: { profiles: Record<string, Profile>; selectedProfile: string | null };
+  forms: { navmc10274: unknown; navmc11811: unknown };
+  snippets: Snippet[];
+  userTemplates: Record<string, UserTemplate>;
+}
+
+export interface RestoreResult {
+  documents: { imported: number; skipped: number };
+  profilesAdded: number;
+  snippetsAdded: number;
+  templatesAdded: number;
+  formsRestored: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Pure merge helpers (unit-tested; no store/IDB access)
+// ---------------------------------------------------------------------------
+
+/**
+ * Non-destructive record merge keyed by object key: adds entries from `backup`
+ * whose key is absent locally, and NEVER overwrites an existing local entry.
+ * This is the fix for the old `importProfiles` shallow spread, which let a
+ * restored backup silently clobber a profile you'd edited since.
+ */
+export function mergeRecord<T>(
+  current: Record<string, T>,
+  backup: Record<string, T> | undefined | null,
+): { merged: Record<string, T>; added: number } {
+  const merged = { ...current };
+  let added = 0;
+  if (backup && typeof backup === 'object') {
+    for (const [key, value] of Object.entries(backup)) {
+      if (!(key in merged)) {
+        merged[key] = value;
+        added++;
+      }
+    }
+  }
+  return { merged, added };
+}
+
+/** Non-destructive array merge by `id`: appends only backup items whose id is new. */
+export function mergeById<T extends { id: string }>(
+  current: T[],
+  backup: T[] | undefined | null,
+): { merged: T[]; added: number } {
+  if (!Array.isArray(backup)) return { merged: current, added: 0 };
+  const have = new Set(current.map((x) => x.id));
+  const add = backup.filter((x) => x && typeof x.id === 'string' && !have.has(x.id));
+  return { merged: add.length ? [...current, ...add] : current, added: add.length };
+}
+
+/** Parse + shape-check a backup file; returns the discriminated kind. */
+export function classifyBackup(json: string): { kind: string; parsed: Record<string, unknown> } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("That file isn't valid JSON");
+  }
+  const kind = (parsed as { kind?: unknown })?.kind;
+  if (kind !== BACKUP_KIND && kind !== LIBRARY_KIND) {
+    throw new Error('Not a DonDocs backup file');
+  }
+  return { kind: kind as string, parsed: parsed as Record<string, unknown> };
+}
+
+// ---------------------------------------------------------------------------
+// Build / restore (store-wired)
+// ---------------------------------------------------------------------------
+
+/** Serialize the entire account to a single JSON backup string. */
+export async function buildBackup(): Promise<string> {
+  // Reuse the document exporter — it throws if the registry is unreadable, so
+  // a broken DB can't produce a half-empty backup that looks complete.
+  const libraryJson = await exportLibrary();
+  const { docs } = JSON.parse(libraryJson) as { docs: unknown[] };
+
+  const profile = useProfileStore.getState();
+  const form = useFormStore.getState();
+  const bundle: BackupBundle = {
+    kind: BACKUP_KIND,
+    version: BACKUP_VERSION,
+    exportedAt: Date.now(),
+    documents: docs,
+    profiles: { profiles: profile.profiles, selectedProfile: profile.selectedProfile },
+    forms: { navmc10274: form.navmc10274, navmc11811: form.navmc11811 },
+    snippets: useSnippetsStore.getState().snippets,
+    userTemplates: useUserTemplatesStore.getState().templates,
+  };
+  return JSON.stringify(bundle);
+}
+
+/**
+ * Restore a backup file. Branches on `kind` (not version) so legacy docs-only
+ * `dondocs-library` files keep working. Collections merge non-destructively;
+ * the single live NAVMC form buffer is replaced (an explicit restore should
+ * bring back the backed-up form fields).
+ */
+export async function restoreBackup(json: string): Promise<RestoreResult> {
+  const { kind, parsed } = classifyBackup(json);
+
+  // Legacy docs-only file → delegate to the conflict-aware document merge.
+  if (kind === LIBRARY_KIND) {
+    const documents = await importLibrary(json);
+    return { documents, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false };
+  }
+
+  // Documents: importLibrary expects `{ docs }`; the v2 bundle stores them under
+  // `documents`. Reuse its newer-wins merge + safety guards.
+  const documents = Array.isArray(parsed.documents)
+    ? await importLibrary(JSON.stringify({ docs: parsed.documents }))
+    : { imported: 0, skipped: 0 };
+
+  // Profiles (+ signatures): non-destructive merge; adopt a selectedProfile only
+  // if we currently have none.
+  let profilesAdded = 0;
+  const backupProfiles = (parsed.profiles as BackupBundle['profiles'] | undefined)?.profiles;
+  if (backupProfiles) {
+    useProfileStore.setState((s) => {
+      const { merged, added } = mergeRecord(s.profiles, backupProfiles);
+      profilesAdded = added;
+      const backupSelected = (parsed.profiles as BackupBundle['profiles']).selectedProfile;
+      return {
+        profiles: merged,
+        selectedProfile: s.selectedProfile ?? (typeof backupSelected === 'string' ? backupSelected : null),
+      };
+    });
+  }
+
+  // Snippets: add by id.
+  let snippetsAdded = 0;
+  useSnippetsStore.setState((s) => {
+    const { merged, added } = mergeById(s.snippets, parsed.snippets as Snippet[] | undefined);
+    snippetsAdded = added;
+    return { snippets: merged };
+  });
+
+  // User templates: add by id.
+  let templatesAdded = 0;
+  useUserTemplatesStore.setState((s) => {
+    const { merged, added } = mergeRecord(s.templates, parsed.userTemplates as Record<string, UserTemplate> | undefined);
+    templatesAdded = added;
+    return { templates: merged };
+  });
+
+  // Live NAVMC form buffer: single state, replaced when the backup carries it.
+  let formsRestored = false;
+  const forms = parsed.forms as BackupBundle['forms'] | undefined;
+  if (forms && (forms.navmc10274 || forms.navmc11811)) {
+    useFormStore.setState((s) => ({
+      navmc10274: (forms.navmc10274 as typeof s.navmc10274) ?? s.navmc10274,
+      navmc11811: (forms.navmc11811 as typeof s.navmc11811) ?? s.navmc11811,
+    }));
+    formsRestored = true;
+  }
+
+  return { documents, profilesAdded, snippetsAdded, templatesAdded, formsRestored };
+}
+
+/** One-line human summary of a restore, for the save-status toast. */
+export function summarizeRestore(r: RestoreResult): string {
+  const parts: string[] = [];
+  parts.push(`${r.documents.imported} doc${r.documents.imported === 1 ? '' : 's'}`);
+  if (r.profilesAdded) parts.push(`${r.profilesAdded} profile${r.profilesAdded === 1 ? '' : 's'}`);
+  if (r.snippetsAdded) parts.push(`${r.snippetsAdded} snippet${r.snippetsAdded === 1 ? '' : 's'}`);
+  if (r.templatesAdded) parts.push(`${r.templatesAdded} template${r.templatesAdded === 1 ? '' : 's'}`);
+  if (r.formsRestored) parts.push('form fields');
+  const kept = r.documents.skipped > 0 ? ` · kept ${r.documents.skipped} newer` : '';
+  return `Restored ${parts.join(', ')}${kept}`;
+}

--- a/tests/unit/backup.test.ts
+++ b/tests/unit/backup.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mergeRecord,
+  mergeById,
+  classifyBackup,
+  summarizeRestore,
+  BACKUP_KIND,
+} from '@/lib/backup';
+
+describe('mergeRecord (non-destructive)', () => {
+  it('adds absent keys and NEVER overwrites an existing one', () => {
+    const current = { a: { v: 'local-A' }, b: { v: 'local-B' } };
+    const backup = { a: { v: 'backup-A' }, c: { v: 'backup-C' } };
+    const { merged, added } = mergeRecord(current, backup);
+    expect(added).toBe(1); // only c is new
+    expect(merged.a.v).toBe('local-A'); // local wins the collision — no clobber
+    expect(merged.b.v).toBe('local-B');
+    expect(merged.c.v).toBe('backup-C');
+  });
+
+  it('handles missing/empty backup', () => {
+    expect(mergeRecord({ a: 1 }, undefined)).toEqual({ merged: { a: 1 }, added: 0 });
+    expect(mergeRecord({ a: 1 }, {})).toEqual({ merged: { a: 1 }, added: 0 });
+  });
+});
+
+describe('mergeById (non-destructive)', () => {
+  it('appends only items whose id is new', () => {
+    const current = [{ id: '1', t: 'local' }];
+    const backup = [{ id: '1', t: 'backup' }, { id: '2', t: 'new' }];
+    const { merged, added } = mergeById(current, backup);
+    expect(added).toBe(1);
+    expect(merged).toHaveLength(2);
+    expect(merged.find((x) => x.id === '1')!.t).toBe('local'); // no clobber
+    expect(merged.find((x) => x.id === '2')!.t).toBe('new');
+  });
+
+  it('ignores a non-array backup and returns the original reference', () => {
+    const current = [{ id: '1' }];
+    const out = mergeById(current, undefined);
+    expect(out.added).toBe(0);
+    expect(out.merged).toBe(current);
+  });
+});
+
+describe('classifyBackup', () => {
+  it('accepts the v2 bundle and the legacy library file', () => {
+    expect(classifyBackup(JSON.stringify({ kind: BACKUP_KIND })).kind).toBe('dondocs-backup');
+    expect(classifyBackup(JSON.stringify({ kind: 'dondocs-library', docs: [] })).kind).toBe('dondocs-library');
+  });
+
+  it('rejects foreign JSON and non-JSON', () => {
+    expect(() => classifyBackup(JSON.stringify({ kind: 'something-else' }))).toThrow(/Not a DonDocs backup/);
+    expect(() => classifyBackup('{not json')).toThrow(/valid JSON/);
+  });
+});
+
+describe('summarizeRestore', () => {
+  it('lists only the buckets that changed', () => {
+    expect(
+      summarizeRestore({ documents: { imported: 3, skipped: 1 }, profilesAdded: 2, snippetsAdded: 0, templatesAdded: 1, formsRestored: true }),
+    ).toBe('Restored 3 docs, 2 profiles, 1 template, form fields · kept 1 newer');
+    expect(
+      summarizeRestore({ documents: { imported: 1, skipped: 0 }, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false }),
+    ).toBe('Restored 1 doc');
+  });
+});


### PR DESCRIPTION
Fixes a silent data-loss bug: the "Back up all documents" file serialized **only** the IndexedDB documents, so a restore on a new machine lost the user's **profiles + saved signatures, snippets, user templates, and in-progress NAVMC form fields** — each lives in its own persisted store.

## What changed
- **New `src/lib/backup.ts`** — `buildBackup()` writes a versioned full bundle (`kind: "dondocs-backup"`, v2): documents + profiles/signatures + live NAVMC forms + snippets + user templates. Reuses `exportLibrary`'s guard that refuses to write when the doc registry is unreadable (no half-empty backups).
- **`restoreBackup()` branches on file `kind`** — legacy docs-only files (`dondocs-library` v1) still restore. Collections merge **non-destructively** (add-missing; local wins collisions), which also **fixes the `importProfiles` silent-overwrite** so restoring an old backup can't clobber a profile you've since edited. The single live NAVMC form buffer is replaced (expected on an explicit restore).
- **Header menu:** "Back up all documents" → **"Back up everything"**; restore now reports what came back ("Restored 5 docs, 2 profiles, 1 template…").

## Verification
- **Pure merge helpers unit-tested** (7 tests) — non-clobbering guarantee, id-merge, kind-branching, legacy-file acceptance.
- **Full round-trip verified live in the app:** the bundle carries every store (incl. the signature `data`); after editing an existing profile and restoring, the local edit **survives** (no clobber) and the deleted snippet **comes back**.
- 1500 tests pass; typecheck + lint clean; air-gap guard clean (pure local JSON, no network).

## Out of scope (follow-up)
File System Access **auto-backup** stays docs-only here (making it full-bundle would create a store import cycle). Its file still restores fine; a full-bundle auto-backup is a clean follow-up.