### PR TITLE
feat(backup): persist enclosure attachments and include them in the full backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.7] — 2026-07-03
+
+### Added
+
+- Enclosure attachments now persist. The PDF you attach to an enclosure used
+  to live only in memory on the open document — a reload dropped it (you had
+  to re-attach) and a full backup couldn't carry it. Attached files are now
+  stored in a new IndexedDB `attachments` store, streamed back into the
+  document on load, and embedded in the **"Back up everything"** bundle, so a
+  restore on another machine brings the enclosure files back too. Restore adds
+  only attachments the local database doesn't already have, so re-importing a
+  backup never duplicates data. The IndexedDB schema bumps to v2 with a purely
+  additive upgrade (existing documents are untouched).
+
 ## [1.2.6] — 2026-07-03
 
 ### Fixed

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -9,13 +9,16 @@ happens when writes fail.
 
 ### IndexedDB — the source of truth for documents
 
-Database `dondocs` (version 1), two object stores. All access goes through
-`src/lib/documentsDb.ts`; nothing else touches IndexedDB directly.
+Database `dondocs` (version 2), three object stores. All access goes through
+`src/lib/documentsDb.ts`; nothing else touches IndexedDB directly. The v1→v2
+upgrade is purely additive — it creates the `attachments` store and leaves
+existing records untouched.
 
 | Store | Contents |
 |-------|----------|
 | `documents` (keyPath `id`) | One record per document: `{ id, meta, session }`. `meta` is the Recents row (title, docType, updatedAt, pinned, user-set name); `session` is the full serialized document. |
 | `app` (key/value) | `currentId` (resume pointer), `backupFileHandle` (the synced-backup `FileSystemFileHandle` — handles are structured-cloneable), `legacyMigratedIds` (migration ledger), and `snap:<docId>` — per-document version-history snapshots, capped at the 10 most recent. |
+| `attachments` (keyPath `id`) | Enclosure file bytes: `{ id, name, type, size, data }` (`data` is the raw `ArrayBuffer`). A serialized enclosure keeps only a `fileRef` (id + name/size/type) into this store, so the blob loads once and never bloats a document record. Bytes are written on attach (`src/lib/attachments.ts`) and streamed back into the live document by `rehydrateEnclosureFiles`. Ids are random (not content-addressed): `crypto.subtle` needs a secure origin an air-gapped `http://` deployment may lack, so there is no cross-enclosure dedup and no GC yet — a removed enclosure leaves its blob behind until the store is cleared. |
 
 Two contracts in `documentsDb.ts` matter more than the rest:
 
@@ -127,10 +130,16 @@ Recents re-sort), and every load path into the live editor
 
 ## Backups
 
-**Manual** (`Back up all documents`): serializes the in-memory registry — the
-exact list the user sees — to a JSON download. Restore merges per record;
-when the same id exists on both sides, the newer `updatedAt` wins, so restoring
-an old backup can't overwrite newer work.
+**Manual** (`Back up everything`, `src/lib/backup.ts`): a full-account JSON
+download (kind `dondocs-backup`) covering every store, not just documents —
+the in-memory registry, profiles + signatures, saved snippets, user templates,
+the live NAVMC form fields, and the enclosure file bytes those documents
+reference (base64-embedded, pulled from the `attachments` store). Restore is
+non-destructive: documents merge per record with newer `updatedAt` winning;
+profiles/snippets/templates add only missing entries (local always wins a
+collision); attachments add only ids not already present. A legacy docs-only
+`dondocs-library` file still restores. So an old backup can never overwrite
+newer local work.
 
 **Synced backup file** (Chromium desktop): the user picks a file once; the
 `FileSystemFileHandle` persists in IndexedDB and survives restarts. Every

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.6",
+  "version": "1.2.7",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ import { BackupNotice } from '@/components/BackupNotice';
 import { probeStorageHealth } from '@/lib/documentsDb';
 const marineCodersLogo = `${import.meta.env.BASE_URL}attachments/marine-coders-logo.svg`;
 import { useUIStore } from '@/stores/uiStore';
-import { useDocumentStore, getSavedSession } from '@/stores/documentStore';
+import { useDocumentStore, getSavedSession, rehydrateEnclosureFiles } from '@/stores/documentStore';
 import { useFormStore, FORMS_PERSIST_KEY } from '@/stores/formStore';
 import { lastWriteFailed } from '@/lib/compressedStorage';
 import { useHistoryStore } from '@/stores/historyStore';
@@ -519,6 +519,10 @@ function App() {
     setCompileLog(null);
 
     try {
+      // If the document was just restored, its enclosure bytes may still be
+      // streaming back from the attachments store; make sure they're present
+      // before the pipeline reads file.data (no-op once already hydrated).
+      await rehydrateEnclosureFiles();
       // Read the full store via getState() at compile time; the debounce dep
       // array already handles when to re-compile, so the state here is current.
       const currentStore = useDocumentStore.getState();
@@ -770,6 +774,9 @@ function App() {
     preOpenedWindow?: Window | null,
     onProgress?: (phase: DownloadProgressPhase) => void,
   ): Promise<boolean> => {
+    // Ensure any just-restored enclosure bytes are back before the export
+    // pipeline reads file.data (no-op once already hydrated).
+    await rehydrateEnclosureFiles();
     // Snapshot fresh state at download time via getState().
     const currentStore = useDocumentStore.getState();
     const { texFiles, enclosures: generatedEnclosures, includeHyperlinks, signatureImage, referenceUrls } = generateAllLatexFiles(currentStore);

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/ui/accordion';
 import { HelpTip } from '@/components/ui/help-tip';
 import { useDocumentStore } from '@/stores/documentStore';
+import { persistAttachment } from '@/lib/attachments';
 import type { Enclosure, EnclosurePageStyle } from '@/types/document';
 import { DOC_TYPE_CONFIG } from '@/types/document';
 
@@ -223,12 +224,16 @@ export function EnclosuresManager() {
 
   const handleAttachFile = useCallback(async (index: number, file: File) => {
     const data = await file.arrayBuffer();
+    // Persist the bytes so the enclosure survives a reload and rides along in a
+    // backup; keep the in-memory copy for immediate export either way.
+    const fileRef = await persistAttachment({ name: file.name, size: file.size, type: file.type }, data);
     updateEnclosure(index, {
       file: {
         name: file.name,
         size: file.size,
         data,
       },
+      fileRef,
     });
   }, [updateEnclosure]);
 
@@ -236,11 +241,12 @@ export function EnclosuresManager() {
     // Extract filename without extension for the title
     const title = file.name.replace(/\.pdf$/i, '');
     const data = await file.arrayBuffer();
+    const fileRef = await persistAttachment({ name: file.name, size: file.size, type: file.type }, data);
     addEnclosure(title, {
       name: file.name,
       size: file.size,
       data,
-    });
+    }, fileRef);
   }, [addEnclosure]);
 
   // Drag and drop state
@@ -356,7 +362,7 @@ export function EnclosuresManager() {
                       index={index}
                       onUpdateTitle={(title) => updateEnclosure(index, { title })}
                       onAttachFile={(file) => handleAttachFile(index, file)}
-                      onRemoveFile={() => updateEnclosure(index, { file: undefined })}
+                      onRemoveFile={() => updateEnclosure(index, { file: undefined, fileRef: undefined })}
                       onRemove={() => removeEnclosure(index)}
                       onUpdatePageStyle={(pageStyle) => updateEnclosure(index, { pageStyle })}
                       onUpdateCoverPage={(hasCoverPage) => updateEnclosure(index, { hasCoverPage })}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -25,7 +25,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { useUIStore } from '@/stores/uiStore';
-import { useDocumentStore } from '@/stores/documentStore';
+import { useDocumentStore, persistUnsavedEnclosures } from '@/stores/documentStore';
 import { useFormStore } from '@/stores/formStore';
 import { useDocumentsStore } from '@/stores/documentsStore';
 import { buildBackup, restoreBackup, summarizeRestore } from '@/lib/backup';
@@ -556,6 +556,11 @@ export function Header({
         // Register the import as its own Recents entry under a fresh id rather
         // than overwriting the previously-open document.
         useDocumentsStore.getState().openLoadedAsNew();
+
+        // The draft's enclosure bytes arrived inline; persist them to the
+        // attachments store so they survive a reload and a full backup, just
+        // like a file attached through the UI.
+        void persistUnsavedEnclosures();
 
         flashSaveStatus('Imported!');
       } catch (err) {

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -1,0 +1,75 @@
+/**
+ * Enclosure attachment persistence.
+ *
+ * Enclosure file bytes used to live only in memory on the open document, so a
+ * reload dropped them (the serialized session kept a bare `hasFile` flag and the
+ * user had to re-attach) and a backup could never carry them. This module stores
+ * those bytes in the IndexedDB `attachments` store and hands back a small
+ * {@link FileRef} the session can persist. On load the bytes are streamed back
+ * in; a full backup pulls exactly the blobs its documents reference.
+ *
+ * Ids are random, not a content hash: `crypto.subtle` (SHA-256) is unavailable
+ * on a non-secure origin, which an air-gapped `http://` deployment may well be —
+ * and the system never needs the id to be content-derived. `crypto.getRandomValues`
+ * has no secure-context requirement, so id generation works everywhere. The
+ * trade-off is no cross-enclosure dedup (the same file attached twice is stored
+ * twice); acceptable for a handful of enclosures, and a later content-addressed
+ * scheme can migrate in without changing the on-disk shape.
+ *
+ * All local browser operations — no network, air-gap safe.
+ */
+import type { FileRef } from '@/types/document';
+import {
+  idbPutAttachment,
+  idbGetAttachment,
+  idbGetAllAttachments,
+  type StoredAttachment,
+} from '@/lib/documentsDb';
+
+/** 16 random bytes, hex — collision-free for this scale without needing SubtleCrypto. */
+export function newAttachmentId(): string {
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    crypto.getRandomValues(bytes);
+  } else {
+    // Last-resort fallback for exotic environments without WebCrypto at all.
+    for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  let hex = '';
+  for (const b of bytes) hex += b.toString(16).padStart(2, '0');
+  return `att_${hex}`;
+}
+
+export interface AttachmentMeta {
+  name: string;
+  size: number;
+  type: string;
+}
+
+/**
+ * Store `data` under a fresh id and return the reference to persist in the
+ * enclosure. On a failed write it still returns a ref (so the in-memory file
+ * keeps working this session) — the enclosure just won't survive a reload.
+ */
+export async function persistAttachment(meta: AttachmentMeta, data: ArrayBuffer): Promise<FileRef> {
+  const id = newAttachmentId();
+  const rec: StoredAttachment = { id, name: meta.name, type: meta.type, size: meta.size, data };
+  await idbPutAttachment(rec);
+  return { id, name: meta.name, size: meta.size, type: meta.type };
+}
+
+/** Load an attachment's bytes by id; null if missing or unreadable. */
+export async function loadAttachment(id: string): Promise<ArrayBuffer | null> {
+  const rec = await idbGetAttachment(id);
+  return rec?.data ?? null;
+}
+
+/** All stored attachments; null when the read failed (distinct from empty). */
+export async function loadAllAttachments(): Promise<StoredAttachment[] | null> {
+  return idbGetAllAttachments();
+}
+
+/** Persist an attachment record verbatim (used by backup restore). */
+export async function putAttachmentRecord(rec: StoredAttachment): Promise<boolean> {
+  return idbPutAttachment(rec);
+}

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -20,10 +20,23 @@ import { useProfileStore } from '@/stores/profileStore';
 import { useFormStore } from '@/stores/formStore';
 import { useSnippetsStore, type Snippet } from '@/stores/snippetsStore';
 import { useUserTemplatesStore, type UserTemplate } from '@/stores/userTemplatesStore';
+import { idbGetAttachment, idbPutAttachment, type StoredAttachment } from '@/lib/documentsDb';
+import { uint8ArrayToBase64, base64ToUint8Array, arrayBufferToUint8Array } from '@/lib/encoding';
 
 export const BACKUP_KIND = 'dondocs-backup';
-export const BACKUP_VERSION = 2;
+// v3 adds `attachments` (enclosure file bytes). Restore branches on `kind`, not
+// version, so a v2 bundle (no attachments) still restores cleanly.
+export const BACKUP_VERSION = 3;
 const LIBRARY_KIND = 'dondocs-library'; // legacy docs-only file
+
+/** An enclosure blob embedded in the bundle; `data` is base64 of the raw bytes. */
+export interface BackupAttachment {
+  id: string;
+  name: string;
+  type: string;
+  size: number;
+  data: string;
+}
 
 export interface BackupBundle {
   kind: typeof BACKUP_KIND;
@@ -34,6 +47,7 @@ export interface BackupBundle {
   forms: { navmc10274: unknown; navmc11811: unknown };
   snippets: Snippet[];
   userTemplates: Record<string, UserTemplate>;
+  attachments: BackupAttachment[];
 }
 
 export interface RestoreResult {
@@ -42,6 +56,7 @@ export interface RestoreResult {
   snippetsAdded: number;
   templatesAdded: number;
   formsRestored: boolean;
+  attachmentsAdded: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -82,6 +97,25 @@ export function mergeById<T extends { id: string }>(
   return { merged: add.length ? [...current, ...add] : current, added: add.length };
 }
 
+/**
+ * Every distinct enclosure attachment id referenced by a set of document
+ * records, so a backup embeds exactly the blobs its documents point at (no
+ * orphaned bytes from since-removed enclosures). Tolerant of the loose
+ * `unknown[]` shape that comes back from a parsed library file.
+ */
+export function collectAttachmentIds(docs: unknown[]): string[] {
+  const ids = new Set<string>();
+  for (const doc of docs) {
+    const enclosures = (doc as { session?: { enclosures?: unknown } })?.session?.enclosures;
+    if (!Array.isArray(enclosures)) continue;
+    for (const enc of enclosures) {
+      const id = (enc as { fileRef?: { id?: unknown } })?.fileRef?.id;
+      if (typeof id === 'string' && id) ids.add(id);
+    }
+  }
+  return [...ids];
+}
+
 /** Parse + shape-check a backup file; returns the discriminated kind. */
 export function classifyBackup(json: string): { kind: string; parsed: Record<string, unknown> } {
   let parsed: unknown;
@@ -108,6 +142,22 @@ export async function buildBackup(): Promise<string> {
   const libraryJson = await exportLibrary();
   const { docs } = JSON.parse(libraryJson) as { docs: unknown[] };
 
+  // Enclosure file bytes: pull exactly the blobs the backed-up documents point
+  // at, base64-encoded to ride inside the single JSON file (the same encoding
+  // the single-draft export already uses for enclosures).
+  const attachments: BackupAttachment[] = [];
+  for (const id of collectAttachmentIds(docs)) {
+    const rec = await idbGetAttachment(id);
+    if (!rec) continue; // a missing blob just means that enclosure won't restore its file
+    attachments.push({
+      id: rec.id,
+      name: rec.name,
+      type: rec.type,
+      size: rec.size,
+      data: uint8ArrayToBase64(arrayBufferToUint8Array(rec.data)),
+    });
+  }
+
   const profile = useProfileStore.getState();
   const form = useFormStore.getState();
   const bundle: BackupBundle = {
@@ -119,6 +169,7 @@ export async function buildBackup(): Promise<string> {
     forms: { navmc10274: form.navmc10274, navmc11811: form.navmc11811 },
     snippets: useSnippetsStore.getState().snippets,
     userTemplates: useUserTemplatesStore.getState().templates,
+    attachments,
   };
   return JSON.stringify(bundle);
 }
@@ -135,7 +186,7 @@ export async function restoreBackup(json: string): Promise<RestoreResult> {
   // Legacy docs-only file → delegate to the conflict-aware document merge.
   if (kind === LIBRARY_KIND) {
     const documents = await importLibrary(json);
-    return { documents, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false };
+    return { documents, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false, attachmentsAdded: 0 };
   }
 
   // Documents: importLibrary expects `{ docs }`; the v2 bundle stores them under
@@ -187,7 +238,26 @@ export async function restoreBackup(json: string): Promise<RestoreResult> {
     formsRestored = true;
   }
 
-  return { documents, profilesAdded, snippetsAdded, templatesAdded, formsRestored };
+  // Enclosure attachments: content is immutable per id, so add any the local DB
+  // doesn't already have and leave existing ones untouched (idempotent re-import).
+  let attachmentsAdded = 0;
+  const backupAttachments = parsed.attachments;
+  if (Array.isArray(backupAttachments)) {
+    for (const a of backupAttachments as BackupAttachment[]) {
+      if (!a || typeof a.id !== 'string' || typeof a.data !== 'string') continue;
+      if (await idbGetAttachment(a.id)) continue; // already have these bytes
+      const rec: StoredAttachment = {
+        id: a.id,
+        name: typeof a.name === 'string' ? a.name : '',
+        type: typeof a.type === 'string' ? a.type : '',
+        size: typeof a.size === 'number' ? a.size : 0,
+        data: base64ToUint8Array(a.data).buffer as ArrayBuffer,
+      };
+      if (await idbPutAttachment(rec)) attachmentsAdded++;
+    }
+  }
+
+  return { documents, profilesAdded, snippetsAdded, templatesAdded, formsRestored, attachmentsAdded };
 }
 
 /** One-line human summary of a restore, for the save-status toast. */
@@ -197,6 +267,7 @@ export function summarizeRestore(r: RestoreResult): string {
   if (r.profilesAdded) parts.push(`${r.profilesAdded} profile${r.profilesAdded === 1 ? '' : 's'}`);
   if (r.snippetsAdded) parts.push(`${r.snippetsAdded} snippet${r.snippetsAdded === 1 ? '' : 's'}`);
   if (r.templatesAdded) parts.push(`${r.templatesAdded} template${r.templatesAdded === 1 ? '' : 's'}`);
+  if (r.attachmentsAdded) parts.push(`${r.attachmentsAdded} attachment${r.attachmentsAdded === 1 ? '' : 's'}`);
   if (r.formsRestored) parts.push('form fields');
   const kept = r.documents.skipped > 0 ? ` · kept ${r.documents.skipped} newer` : '';
   return `Restored ${parts.join(', ')}${kept}`;

--- a/src/lib/documentsDb.ts
+++ b/src/lib/documentsDb.ts
@@ -15,9 +15,12 @@ export interface StoredDocument {
 }
 
 const DB_NAME = 'dondocs';
-const DB_VERSION = 1;
+// v2 adds the `attachments` store (enclosure file bytes). The upgrade is purely
+// additive — existing `documents`/`app` records are untouched.
+const DB_VERSION = 2;
 const DOCS_STORE = 'documents';
 const APP_STORE = 'app'; // key/value store; currently just { key:'currentId', value }
+const ATTACHMENTS_STORE = 'attachments'; // enclosure file blobs, keyed by content-free id
 
 const hasIndexedDb = typeof indexedDB !== 'undefined';
 
@@ -38,6 +41,7 @@ function openDb(): Promise<IDBDatabase> {
       const db = req.result;
       if (!db.objectStoreNames.contains(DOCS_STORE)) db.createObjectStore(DOCS_STORE, { keyPath: 'id' });
       if (!db.objectStoreNames.contains(APP_STORE)) db.createObjectStore(APP_STORE, { keyPath: 'key' });
+      if (!db.objectStoreNames.contains(ATTACHMENTS_STORE)) db.createObjectStore(ATTACHMENTS_STORE, { keyPath: 'id' });
     };
     req.onsuccess = () => {
       const db = req.result;
@@ -340,5 +344,66 @@ export async function idbDeleteSnapshots(docId: string): Promise<void> {
     await run(APP_STORE, 'readwrite', (s) => s.delete(`snap:${docId}`));
   } catch (err) {
     debug.error('DocumentsDb', 'deleteSnapshots failed', err);
+  }
+}
+
+// ── Enclosure attachments ────────────────────────────────────────────────────
+// Enclosure file bytes, stored once and referenced by id from a document's
+// serialized enclosures (see src/lib/attachments.ts). Kept in their own store so
+// the (potentially large) blobs never bloat a document record's read/write, and
+// so a backup can pull exactly the blobs its documents reference.
+
+export interface StoredAttachment {
+  id: string;
+  name: string;
+  type: string;
+  size: number;
+  data: ArrayBuffer;
+}
+
+/** Confirms the blob is committed; false on any failure (callers keep the
+ *  in-memory copy either way, so a failed persist just means "not durable"). */
+export async function idbPutAttachment(rec: StoredAttachment): Promise<boolean> {
+  if (!hasIndexedDb) return false;
+  maybeRequestPersist();
+  try {
+    await run(ATTACHMENTS_STORE, 'readwrite', (s) => s.put(rec));
+    return true;
+  } catch (err) {
+    debug.error('DocumentsDb', 'putAttachment failed', err);
+    return false;
+  }
+}
+
+export async function idbGetAttachment(id: string): Promise<StoredAttachment | null> {
+  if (!hasIndexedDb) return null;
+  try {
+    const rec = await run<StoredAttachment | undefined>(ATTACHMENTS_STORE, 'readonly', (s) => s.get(id));
+    return rec ?? null;
+  } catch (err) {
+    debug.error('DocumentsDb', 'getAttachment failed', err);
+    return null;
+  }
+}
+
+// Returns [] for a genuinely empty store and null when the read FAILED — a
+// backup must be able to tell "no attachments" from "couldn't read them" so it
+// never writes a bundle that silently drops every enclosure's bytes.
+export async function idbGetAllAttachments(): Promise<StoredAttachment[] | null> {
+  if (!hasIndexedDb) return [];
+  try {
+    return await run<StoredAttachment[]>(ATTACHMENTS_STORE, 'readonly', (s) => s.getAll());
+  } catch (err) {
+    debug.error('DocumentsDb', 'getAllAttachments failed', err);
+    return null;
+  }
+}
+
+export async function idbDeleteAttachment(id: string): Promise<void> {
+  if (!hasIndexedDb) return;
+  try {
+    await run(ATTACHMENTS_STORE, 'readwrite', (s) => s.delete(id));
+  } catch (err) {
+    debug.error('DocumentsDb', 'deleteAttachment failed', err);
   }
 }

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -1,7 +1,8 @@
 import { create } from 'zustand';
 import { format, parse, isValid } from 'date-fns';
-import type { Reference, Enclosure, Paragraph, CopyTo, Distribution, DocumentData, DocumentMode, DocumentCategory, FormType } from '@/types/document';
+import type { Reference, Enclosure, FileRef, Paragraph, CopyTo, Distribution, DocumentData, DocumentMode, DocumentCategory, FormType } from '@/types/document';
 import { DOC_TYPE_CONFIG } from '@/types/document';
+import { loadAttachment, persistAttachment } from '@/lib/attachments';
 import { useHistoryStore } from './historyStore';
 import type { DocumentSnapshot } from './historyStore';
 import { useUIStore } from './uiStore';
@@ -24,7 +25,10 @@ export interface SerializedSession {
   formType: FormType;
   formData: Partial<DocumentData>;
   references: Reference[];
-  enclosures: Array<Omit<Enclosure, 'file'> & { hasFile?: boolean }>;
+  // `file` bytes live in the attachments store; `fileRef` is the durable handle
+  // that rehydrates them on load. `hasFile` stays for legacy sessions written
+  // before fileRef existed (they had bytes in memory but nothing to recover).
+  enclosures: Array<Omit<Enclosure, 'file'> & { hasFile?: boolean; fileRef?: FileRef }>;
   paragraphs: Paragraph[];
   copyTos: CopyTo[];
   distributions: Distribution[];
@@ -106,7 +110,7 @@ export interface DocumentState {
   reorderReferences: (fromIndex: number, toIndex: number) => void;
 
   // Actions - Enclosures
-  addEnclosure: (title: string, file?: Enclosure['file']) => void;
+  addEnclosure: (title: string, file?: Enclosure['file'], fileRef?: FileRef) => void;
   updateEnclosure: (index: number, updates: Partial<Enclosure>) => void;
   removeEnclosure: (index: number) => void;
   reorderEnclosures: (fromIndex: number, toIndex: number) => void;
@@ -359,8 +363,8 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
   }),
 
   // Enclosures
-  addEnclosure: (title, file) => set((state) => ({
-    enclosures: [...state.enclosures, { title, file }],
+  addEnclosure: (title, file, fileRef) => set((state) => ({
+    enclosures: [...state.enclosures, { title, file, fileRef }],
   })),
 
   updateEnclosure: (index, updates) => set((state) => ({
@@ -761,6 +765,7 @@ function saveSessionToStorage(state: DocumentState): void {
         hasCoverPage: enc.hasCoverPage,
         coverPageDescription: enc.coverPageDescription,
         hasFile: !!enc.file,
+        fileRef: enc.fileRef,
       })),
       paragraphs: state.paragraphs,
       copyTos: state.copyTos,
@@ -853,7 +858,8 @@ export function restoreSession(): boolean {
         pageStyle: enc.pageStyle,
         hasCoverPage: enc.hasCoverPage,
         coverPageDescription: enc.coverPageDescription,
-        // File data is not restored - user will need to re-attach
+        fileRef: enc.fileRef,
+        // Bytes are streamed back in asynchronously below (rehydrateEnclosureFiles).
         file: undefined,
       })),
       paragraphs: migratePortionMarkings(session.paragraphs),
@@ -861,6 +867,7 @@ export function restoreSession(): boolean {
       distributions: session.distributions || [],
     });
 
+    void rehydrateEnclosureFiles();
     debug.log('Store', 'Session restored from localStorage');
     return true;
   } catch (err) {
@@ -899,6 +906,7 @@ export function serializeSession(state: DocumentState): SerializedSession {
       hasCoverPage: enc.hasCoverPage,
       coverPageDescription: enc.coverPageDescription,
       hasFile: !!enc.file,
+      fileRef: enc.fileRef,
     })),
     paragraphs: state.paragraphs,
     copyTos: state.copyTos,
@@ -929,13 +937,100 @@ export function loadSharedSession(session: SerializedSession): void {
       pageStyle: enc.pageStyle,
       hasCoverPage: enc.hasCoverPage,
       coverPageDescription: enc.coverPageDescription,
+      fileRef: enc.fileRef,
+      // Bytes are streamed back in asynchronously below (rehydrateEnclosureFiles).
       file: undefined,
     })),
     paragraphs: migratePortionMarkings(session.paragraphs ?? []),
     copyTos: session.copyTos ?? [],
     distributions: session.distributions ?? [],
   });
+  void rehydrateEnclosureFiles();
   debug.log('Store', 'Shared session applied');
+}
+
+/**
+ * Streams persisted enclosure bytes back into the live document. A restored
+ * session carries a `fileRef` per attached enclosure but no `file` (the bytes
+ * live in the IndexedDB attachments store, not the session JSON); this fetches
+ * each and grafts it back in.
+ *
+ * Matched by `fileRef.id`, never by index, and only fills an enclosure whose
+ * `file` is still empty — so a user who edited/reordered/removed enclosures
+ * between load and hydrate is never clobbered. Fully best-effort: any failure is
+ * swallowed, leaving the enclosure in the pre-existing "re-attach" state.
+ *
+ * Returns once every referenced blob has been resolved, so callers that must
+ * export (which reads `file.data`) can await a complete document.
+ */
+export async function rehydrateEnclosureFiles(): Promise<void> {
+  const pending = useDocumentStore
+    .getState()
+    .enclosures.filter((e) => e.fileRef && !e.file)
+    .map((e) => e.fileRef!.id);
+  if (pending.length === 0) return;
+
+  const wanted = new Set(pending);
+  const loaded = new Map<string, { name: string; size: number; data: ArrayBuffer }>();
+  await Promise.all(
+    [...wanted].map(async (id) => {
+      try {
+        const data = await loadAttachment(id);
+        if (data) {
+          // Prefer the ref's own name/size (survives even if two enclosures share bytes).
+          const ref = useDocumentStore.getState().enclosures.find((e) => e.fileRef?.id === id)?.fileRef;
+          loaded.set(id, { name: ref?.name ?? '', size: ref?.size ?? data.byteLength, data });
+        }
+      } catch (err) {
+        debug.error('Store', 'Failed to rehydrate enclosure file', err);
+      }
+    })
+  );
+  if (loaded.size === 0) return;
+
+  useDocumentStore.setState((state) => ({
+    enclosures: state.enclosures.map((e) => {
+      if (e.file || !e.fileRef) return e; // don't overwrite live edits
+      const got = loaded.get(e.fileRef.id);
+      return got ? { ...e, file: got } : e;
+    }),
+  }));
+  debug.log('Store', 'Enclosure files rehydrated', { count: loaded.size });
+}
+
+/**
+ * Persists any enclosure that carries live bytes but no durable `fileRef` — the
+ * case for a draft imported from JSON, whose file bytes arrived inline. Gives
+ * each a `fileRef` so it survives a reload and rides along in a full backup,
+ * matching the persist-on-attach path. Matched by array index against the live
+ * state at write time so an intervening edit is never clobbered.
+ */
+export async function persistUnsavedEnclosures(): Promise<void> {
+  const snapshot = useDocumentStore.getState().enclosures;
+  const work = snapshot
+    .map((e, index) => ({ e, index }))
+    .filter(({ e }) => e.file && !e.fileRef);
+  if (work.length === 0) return;
+
+  for (const { e, index } of work) {
+    if (!e.file) continue;
+    try {
+      const ref = await persistAttachment(
+        { name: e.file.name, size: e.file.size, type: '' },
+        e.file.data
+      );
+      useDocumentStore.setState((state) => {
+        const cur = state.enclosures[index];
+        // Only stamp the ref if this slot still holds the same, still-unref'd file.
+        if (!cur?.file || cur.fileRef || cur.file !== e.file) return {};
+        const enclosures = state.enclosures.slice();
+        enclosures[index] = { ...cur, fileRef: ref };
+        return { enclosures };
+      });
+    } catch (err) {
+      debug.error('Store', 'Failed to persist imported enclosure', err);
+    }
+  }
 }
 
 /**

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -26,6 +26,16 @@ export interface Reference {
 
 export type EnclosurePageStyle = 'border' | 'fullpage' | 'fit';
 
+// A durable pointer to enclosure file bytes stored in the IndexedDB `attachments`
+// store. Persisted in the serialized session so an enclosure's file survives a
+// reload (and travels in a full backup), instead of being dropped to a re-attach.
+export interface FileRef {
+  id: string; // key into the attachments store
+  name: string;
+  size: number;
+  type: string; // MIME type ('' when the browser didn't provide one)
+}
+
 export interface Enclosure {
   title: string;
   file?: {
@@ -33,6 +43,7 @@ export interface Enclosure {
     size: number;
     data: ArrayBuffer;
   };
+  fileRef?: FileRef; // durable handle to `file`'s bytes; set once the file is persisted
   pageStyle?: EnclosurePageStyle; // 'border' = 85% with border, 'fullpage' = full page, 'fit' = fit to margins
   hasCoverPage?: boolean; // If true, add a cover page before the enclosure content
   coverPageDescription?: string; // Optional description text for the cover page

--- a/tests/unit/attachments.test.ts
+++ b/tests/unit/attachments.test.ts
@@ -1,0 +1,46 @@
+// A real (in-memory) IndexedDB must exist before documentsDb evaluates its
+// module-load `hasIndexedDb` probe. Must be the first import.
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'vitest';
+import { newAttachmentId, persistAttachment, loadAttachment, loadAllAttachments } from '@/lib/attachments';
+
+const bytes = (values: number[]): ArrayBuffer => new Uint8Array(values).buffer;
+
+describe('newAttachmentId', () => {
+  it('is prefixed, hex, and unique across calls', () => {
+    const a = newAttachmentId();
+    const b = newAttachmentId();
+    expect(a).toMatch(/^att_[0-9a-f]{32}$/);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('persistAttachment → loadAttachment (fake-indexeddb)', () => {
+  it('round-trips the exact bytes and returns a faithful ref', async () => {
+    const data = bytes([1, 2, 3, 4, 250]);
+    const ref = await persistAttachment({ name: 'encl.pdf', size: 5, type: 'application/pdf' }, data);
+
+    expect(ref).toMatchObject({ name: 'encl.pdf', size: 5, type: 'application/pdf' });
+    expect(ref.id).toMatch(/^att_/);
+
+    const loaded = await loadAttachment(ref.id);
+    expect(loaded).not.toBeNull();
+    expect([...new Uint8Array(loaded!)]).toEqual([1, 2, 3, 4, 250]);
+  });
+
+  it('returns null for an unknown id', async () => {
+    expect(await loadAttachment('att_does_not_exist')).toBeNull();
+  });
+
+  it('stores each attachment under its own id (no clobber)', async () => {
+    const r1 = await persistAttachment({ name: 'a', size: 1, type: '' }, bytes([9]));
+    const r2 = await persistAttachment({ name: 'b', size: 1, type: '' }, bytes([8]));
+    expect(r1.id).not.toBe(r2.id);
+
+    const all = await loadAllAttachments();
+    expect(all).not.toBeNull();
+    const byId = new Map(all!.map((a) => [a.id, a]));
+    expect([...new Uint8Array(byId.get(r1.id)!.data)]).toEqual([9]);
+    expect([...new Uint8Array(byId.get(r2.id)!.data)]).toEqual([8]);
+  });
+});

--- a/tests/unit/backup.test.ts
+++ b/tests/unit/backup.test.ts
@@ -3,6 +3,7 @@ import {
   mergeRecord,
   mergeById,
   classifyBackup,
+  collectAttachmentIds,
   summarizeRestore,
   BACKUP_KIND,
 } from '@/lib/backup';
@@ -55,13 +56,36 @@ describe('classifyBackup', () => {
   });
 });
 
+describe('collectAttachmentIds', () => {
+  const doc = (ids: (string | undefined)[]) => ({
+    session: { enclosures: ids.map((id) => (id ? { title: 't', fileRef: { id } } : { title: 't' })) },
+  });
+
+  it('gathers every distinct fileRef id across documents', () => {
+    const ids = collectAttachmentIds([doc(['a', 'b']), doc(['b', 'c'])]);
+    expect(new Set(ids)).toEqual(new Set(['a', 'b', 'c'])); // deduped across docs
+  });
+
+  it('ignores enclosures without a fileRef and malformed shapes', () => {
+    expect(collectAttachmentIds([doc([undefined, 'x'])])).toEqual(['x']);
+    expect(collectAttachmentIds([{}, { session: {} }, { session: { enclosures: 'nope' } }])).toEqual([]);
+    expect(collectAttachmentIds([])).toEqual([]);
+  });
+});
+
 describe('summarizeRestore', () => {
   it('lists only the buckets that changed', () => {
     expect(
-      summarizeRestore({ documents: { imported: 3, skipped: 1 }, profilesAdded: 2, snippetsAdded: 0, templatesAdded: 1, formsRestored: true }),
+      summarizeRestore({ documents: { imported: 3, skipped: 1 }, profilesAdded: 2, snippetsAdded: 0, templatesAdded: 1, formsRestored: true, attachmentsAdded: 0 }),
     ).toBe('Restored 3 docs, 2 profiles, 1 template, form fields · kept 1 newer');
     expect(
-      summarizeRestore({ documents: { imported: 1, skipped: 0 }, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false }),
+      summarizeRestore({ documents: { imported: 1, skipped: 0 }, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false, attachmentsAdded: 0 }),
     ).toBe('Restored 1 doc');
+  });
+
+  it('reports restored attachments', () => {
+    expect(
+      summarizeRestore({ documents: { imported: 2, skipped: 0 }, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false, attachmentsAdded: 3 }),
+    ).toBe('Restored 2 docs, 3 attachments');
   });
 });


### PR DESCRIPTION
## Why

Enclosure file bytes lived **only in memory** on the open document. Two consequences:

1. A reload dropped them — the enclosure showed as attached (`hasFile`) but the bytes were gone, so the user had to re-attach before every export.
2. `Back up everything` (shipped in 1.2.6) couldn't carry them, so a restore on another machine brought back the document but lost every attached PDF.

This closes the one remaining gap flagged when the full-account backup landed.

## What

**Persistence (new `attachments` IndexedDB store, DB v1→v2, additive upgrade):**
- Attached bytes are written to the store on attach (`src/lib/attachments.ts`) and on draft import; the serialized enclosure keeps only a small `fileRef` (id + name/size/type) into it, so the blob loads once and never bloats a document record.
- On load, `rehydrateEnclosureFiles` streams the bytes back into the live document — matched by `fileRef.id`, never clobbering a live edit. The export/compile pipeline awaits it before reading `file.data`.

**Backup (bundle v3):**
- `buildBackup` embeds exactly the blobs its documents reference, base64-encoded (the same encoding the single-draft export already uses).
- `restoreBackup` adds only attachment ids the local DB doesn't already have, so re-importing a backup is idempotent and never duplicates data. Restore still branches on `kind`, so a v2 bundle and a legacy docs-only file restore cleanly.

**Air-gap safety:** attachment ids are random (`crypto.getRandomValues`), not a content hash — `crypto.subtle` requires a secure origin that an air-gapped `http://` deployment may not have. Trade-off is no cross-enclosure dedup and no GC yet (documented in `docs/STORAGE.md`). All operations remain client-only; no network.

## Verification

- `npm run build` (tsc + vite + `check-no-cdn` OK), full suite **1507 passing**, lint clean.
- New unit tests: attachment lib round-trip (fake-indexeddb) and pure backup helpers (`collectAttachmentIds`, `summarizeRestore`).
- Live browser round-trip on the dev server:
  - attach → bytes in IDB, `fileRef` in the serialized session;
  - build backup → attachment present, base64 decodes to the original bytes;
  - **wipe the attachment → restore → exact bytes recovered**;
  - fresh-load enclosure (`fileRef`, no bytes) → `rehydrateEnclosureFiles` repopulates `file`; a fileRef-less enclosure is left untouched.

## Notes / follow-ups

- No GC/refcount yet: a removed or replaced enclosure leaves its blob in the store until storage is cleared. Backups stay lean regardless (they only embed *referenced* blobs). A content-addressed scheme could add dedup + safe GC later without changing the on-disk shape.