### PR TITLE
feat(backup): mirror the full-account bundle to the synced backup file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.8] — 2026-07-03
+
+### Fixed
+
+- The synced auto-backup file (Chromium desktop) was still docs-only. While
+  the manual **"Back up everything"** download became a full-account bundle,
+  the file that auto-mirrors after every save kept writing just documents — so
+  anyone relying on it for cross-machine backup still lost profiles and
+  signatures, snippets, user templates, in-progress NAVMC form fields, and
+  enclosure files on restore. The mirror now writes the same complete
+  `dondocs-backup` bundle, so a restore from it brings back everything. A
+  failed account read still skips the write, so an incomplete bundle can't
+  overwrite a good backup file.
+
 ## [1.2.7] — 2026-07-03
 
 ### Added

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -143,14 +143,19 @@ newer local work.
 
 **Synced backup file** (Chromium desktop): the user picks a file once; the
 `FileSystemFileHandle` persists in IndexedDB and survives restarts. Every
-registry save mirrors the whole library to that file (1.5s debounce). Browsers
-require a fresh user gesture to re-grant write access after a restart —
-surfaced as "Reconnect auto-backup" in the Documents menu.
+registry save mirrors the **full-account bundle** — the same `dondocs-backup`
+`buildBackup()` produces for the manual download, including enclosure bytes —
+to that file (1.5s debounce), so a restore from it brings back everything, not
+just documents. (Each write re-serializes the account; with large enclosures
+that base64 pass runs on every debounced save — acceptable off the critical
+path, and a future optimization could diff attachments.) Browsers require a
+fresh user gesture to re-grant write access after a restart — surfaced as
+"Reconnect auto-backup" in the Documents menu.
 
 Backup failure semantics:
 
-- A failed registry read **skips the write** — an empty library is never
-  mirrored over a good backup file, and "last backed up" is not advanced.
+- A failed account read **skips the write** — an incomplete/empty bundle is
+  never mirrored over a good backup file, and "last backed up" is not advanced.
 - A failed file write flips the status to `error`, shown in the Documents menu
   with a retry; later saves keep retrying, and a success self-heals back to
   `connected`. Permission loss shows `needs-permission` instead.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.7",
+  "version": "1.2.8",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline",

--- a/src/stores/backupStore.ts
+++ b/src/stores/backupStore.ts
@@ -1,10 +1,10 @@
 import { create } from 'zustand';
 import {
-  idbGetAllDocuments,
   idbGetBackupHandle,
   idbSetBackupHandle,
   idbClearBackupHandle,
 } from '@/lib/documentsDb';
+import { buildBackup } from '@/lib/backup';
 import { debug } from '@/lib/debug';
 
 /**
@@ -14,11 +14,16 @@ import { debug } from '@/lib/debug';
  * file, so it's always the latest copy — drop it in a synced folder for
  * cross-machine backup, all without a server.
  *
+ * The mirror is a full-account bundle (the same one "Back up everything"
+ * downloads): documents, profiles + signatures, snippets, user templates, the
+ * live NAVMC form fields, and enclosure file bytes. A restore from this file
+ * therefore brings back everything, not just documents.
+ *
  * Chromium-desktop only. Elsewhere the status is 'unsupported' and the manual
- * "Back up all documents" export remains the fallback. Browsers require a fresh
+ * "Back up everything" export remains the fallback. Browsers require a fresh
  * user gesture to re-grant write access after a full restart ('needs-permission').
  * 'error' = the file can't be written (moved/deleted/locked/disk-full) or the
- * registry can't be read — surfaced instead of silently letting the mirror go
+ * account can't be read — surfaced instead of silently letting the mirror go
  * stale; later saves keep retrying and a success flips back to 'connected'.
  */
 export type BackupStatus = 'off' | 'connected' | 'needs-permission' | 'error' | 'unsupported';
@@ -41,14 +46,21 @@ async function requestPerm(handle: FileSystemFileHandle): Promise<PermState> {
   return h.requestPermission ? h.requestPermission({ mode: 'readwrite' }) : 'granted';
 }
 
-// Same shape exportLibrary() writes, built here to avoid importing documentsStore
-// (which imports this module) — a leaf dependency on documentsDb instead.
-// Returns null when the registry can't be read: mirroring a failed read would
-// overwrite the user's one external safety copy with an empty library.
-async function buildLibraryJson(): Promise<string | null> {
-  const records = await idbGetAllDocuments();
-  if (records === null) return null;
-  return JSON.stringify({ kind: 'dondocs-library', version: 1, docs: records });
+// The full-account bundle to mirror. buildBackup() throws when the account can't
+// be read (e.g. an unreadable registry) — we convert that to null so the caller
+// SKIPS the write: mirroring a failed read would overwrite the user's one
+// external safety copy with an incomplete/empty file.
+//
+// Runtime-only import cycle (backupStore → backup → documentsStore → backupStore):
+// every edge is called from inside a function, never at module init, so the
+// modules initialize cleanly.
+async function buildBackupJson(): Promise<string | null> {
+  try {
+    return await buildBackup();
+  } catch (err) {
+    debug.error('Backup', 'account read failed — skipped backup write', err);
+    return null;
+  }
 }
 
 async function writeToHandle(handle: FileSystemFileHandle, json: string): Promise<void> {
@@ -97,8 +109,8 @@ export const useBackupStore = create<BackupState>((set, get) => ({
         showSaveFilePicker: (o: unknown) => Promise<FileSystemFileHandle>;
       }).showSaveFilePicker;
       const handle = await picker({
-        suggestedName: 'dondocs-library.json',
-        types: [{ description: 'DonDocs library', accept: { 'application/json': ['.json'] } }],
+        suggestedName: 'dondocs-backup.json',
+        types: [{ description: 'DonDocs backup', accept: { 'application/json': ['.json'] } }],
       });
       handleRef = handle;
       await idbSetBackupHandle(handle);
@@ -139,11 +151,10 @@ export const useBackupStore = create<BackupState>((set, get) => ({
         set({ status: 'needs-permission' });
         return;
       }
-      const json = await buildLibraryJson();
+      const json = await buildBackupJson();
       if (json === null) {
-        // Registry read failed — keep the existing backup file intact and do NOT
+        // Account read failed — keep the existing backup file intact and do NOT
         // advance lastBackupAt; claiming success here would be a lie.
-        debug.error('Backup', 'library read failed — skipped backup write');
         set({ status: 'error' });
         return;
       }

--- a/tests/unit/backup.roundtrip.test.ts
+++ b/tests/unit/backup.roundtrip.test.ts
@@ -1,0 +1,180 @@
+// End-to-end proof that a full-account backup saves EVERYTHING and restores it:
+// documents, profiles (INCLUDING the uploaded signature image), snippets, user
+// templates, in-progress NAVMC form fields, and enclosure file bytes. Populates
+// every persisted store, builds a real backup, WIPES every store + IndexedDB,
+// then restores from the bundle and asserts each piece came back byte-for-byte.
+//
+// This is the regression guard for "backup is silently lossy" — if any store is
+// ever dropped from buildBackup/restoreBackup, exactly one assertion here fails.
+
+// A real (in-memory) IndexedDB must exist before documentsDb evaluates. First import.
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { buildBackup, restoreBackup } from '@/lib/backup';
+import { persistAttachment, loadAttachment } from '@/lib/attachments';
+import {
+  idbGetAllDocuments,
+  idbDeleteDocument,
+  idbGetAllAttachments,
+  idbDeleteAttachment,
+} from '@/lib/documentsDb';
+import { useProfileStore } from '@/stores/profileStore';
+import { useSnippetsStore } from '@/stores/snippetsStore';
+import { useUserTemplatesStore } from '@/stores/userTemplatesStore';
+import { useFormStore } from '@/stores/formStore';
+import { useDocumentsStore } from '@/stores/documentsStore';
+import { useUIStore } from '@/stores/uiStore';
+import type { Profile } from '@/types/document';
+import type { SerializedSession } from '@/stores/documentStore';
+
+const session = (over: Partial<SerializedSession> = {}): SerializedSession => ({
+  documentMode: 'compliant',
+  documentCategory: 'correspondence',
+  docType: 'naval_letter',
+  formType: 'navmc_10274',
+  formData: {},
+  references: [],
+  enclosures: [],
+  paragraphs: [],
+  copyTos: [],
+  distributions: [],
+  timestamp: 1,
+  ...over,
+});
+
+// A distinctive base64 "signature image" — the exact field silently lost before
+// the full-account backup existed. Must survive the JSON round-trip intact.
+const SIGNATURE_B64 = btoa('SIGNATURE-IMAGE-BYTES-þÿ');
+
+const testProfile: Profile = {
+  unitLine1: '1st Battalion, 5th Marines',
+  unitLine2: '1st Marine Division',
+  unitAddress: 'BOX 555, CAMP PENDLETON CA 92055',
+  ssic: '5216',
+  from: 'Commanding Officer, 1st Bn, 5th Mar',
+  sigFirst: 'John',
+  sigMiddle: 'Q',
+  sigLast: 'Doe',
+  sigRank: 'LtCol',
+  sigTitle: 'Commanding Officer',
+  signatureType: 'image',
+  signatureImage: { name: 'sig.png', size: 42, data: SIGNATURE_B64 },
+};
+
+async function wipeEverything(): Promise<void> {
+  useProfileStore.setState({ profiles: {}, selectedProfile: null });
+  useSnippetsStore.setState({ snippets: [] });
+  useUserTemplatesStore.setState({ templates: {} });
+  useFormStore.setState((s) => ({
+    navmc10274: { ...s.navmc10274, ssicFileNo: 'WIPED' },
+    navmc11811: { ...s.navmc11811 },
+  }));
+  useDocumentsStore.setState({ docs: {}, currentId: null, hydrated: true });
+  for (const a of (await idbGetAllAttachments()) ?? []) await idbDeleteAttachment(a.id);
+  for (const d of (await idbGetAllDocuments()) ?? []) await idbDeleteDocument(d.id);
+}
+
+describe('full-account backup round-trip (saves EVERYTHING)', () => {
+  beforeEach(() => {
+    useUIStore.setState({ storageHealth: 'ok' }); // exportLibrary refuses on 'unreadable'
+  });
+
+  it('backs up and restores every store — documents, profiles+signature, snippets, templates, forms, enclosures', async () => {
+    // ── Populate every persisted store with distinctive data ──────────────────
+    const sigBytes = new Uint8Array([1, 2, 3, 4, 250, 128, 0, 77]);
+    const fileRef = await persistAttachment(
+      { name: 'orders.pdf', size: sigBytes.length, type: 'application/pdf' },
+      sigBytes.buffer
+    );
+
+    useProfileStore.setState({ profiles: { 'Test CO': testProfile }, selectedProfile: 'Test CO' });
+    useSnippetsStore.setState({ snippets: [{ id: 'snip-1', name: 'IAW opener', text: 'In accordance with reference (a)...' }] });
+    useUserTemplatesStore.setState({
+      templates: { 'tpl-1': { id: 'tpl-1', name: 'My Template', docType: 'naval_letter', createdAt: 123, session: session() } },
+    });
+    useFormStore.setState((s) => ({
+      navmc10274: { ...s.navmc10274, ssicFileNo: 'SSIC-10274-MARKER', supplementalInfo: 'counseling text' },
+      navmc11811: { ...s.navmc11811 },
+    }));
+    useDocumentsStore.setState({
+      hydrated: true,
+      currentId: 'doc-1',
+      docs: {
+        'doc-1': {
+          meta: { id: 'doc-1', title: 'Test Letter', docType: 'naval_letter', updatedAt: 1000 },
+          session: session({
+            formData: { subject: 'PROMOTION RECOMMENDATION' },
+            enclosures: [{ title: 'Reference Orders', hasFile: true, fileRef }],
+          }),
+        },
+      },
+    });
+
+    // ── Build the backup, then confirm the bundle actually carries each store ──
+    const json = await buildBackup();
+    const bundle = JSON.parse(json);
+    expect(bundle.kind).toBe('dondocs-backup');
+    expect(bundle.documents).toHaveLength(1);
+    expect(bundle.profiles.profiles['Test CO'].signatureImage.data).toBe(SIGNATURE_B64);
+    expect(bundle.snippets).toHaveLength(1);
+    expect(Object.keys(bundle.userTemplates)).toContain('tpl-1');
+    expect(bundle.forms.navmc10274.ssicFileNo).toBe('SSIC-10274-MARKER');
+    expect(bundle.attachments).toHaveLength(1);
+    expect(bundle.attachments[0].id).toBe(fileRef.id);
+
+    // ── Wipe every store + IndexedDB (simulate a brand-new machine) ───────────
+    await wipeEverything();
+    expect(useProfileStore.getState().profiles).toEqual({});
+    expect(useSnippetsStore.getState().snippets).toEqual([]);
+    expect(useUserTemplatesStore.getState().templates).toEqual({});
+    expect(await loadAttachment(fileRef.id)).toBeNull();
+    expect(await idbGetAllDocuments()).toEqual([]);
+
+    // ── Restore, then assert EVERYTHING came back ─────────────────────────────
+    const result = await restoreBackup(json);
+
+    // documents
+    expect(result.documents.imported).toBe(1);
+    expect(useDocumentsStore.getState().docs['doc-1']?.meta.title).toBe('Test Letter');
+
+    // profiles — including the uploaded signature image, byte-for-byte
+    expect(result.profilesAdded).toBe(1);
+    const restoredProfile = useProfileStore.getState().profiles['Test CO'];
+    expect(restoredProfile).toBeDefined();
+    expect(restoredProfile.sigLast).toBe('Doe');
+    expect(restoredProfile.signatureImage?.data).toBe(SIGNATURE_B64);
+    expect(useProfileStore.getState().selectedProfile).toBe('Test CO');
+
+    // snippets
+    expect(result.snippetsAdded).toBe(1);
+    expect(useSnippetsStore.getState().snippets.find((s) => s.id === 'snip-1')?.text).toContain('In accordance');
+
+    // user templates
+    expect(result.templatesAdded).toBe(1);
+    expect(useUserTemplatesStore.getState().templates['tpl-1']?.name).toBe('My Template');
+
+    // NAVMC form fields (replaced wholesale on restore — overwrites the WIPED marker)
+    expect(result.formsRestored).toBe(true);
+    expect(useFormStore.getState().navmc10274.ssicFileNo).toBe('SSIC-10274-MARKER');
+
+    // enclosure attachment bytes
+    expect(result.attachmentsAdded).toBe(1);
+    const restoredBytes = await loadAttachment(fileRef.id);
+    expect(restoredBytes).not.toBeNull();
+    expect([...new Uint8Array(restoredBytes!)]).toEqual([...sigBytes]);
+  });
+
+  it('restore is non-destructive: newer local profile edits are never clobbered', async () => {
+    // Back up a profile, then locally EDIT it, then restore the old backup.
+    useProfileStore.setState({ profiles: { 'Test CO': testProfile }, selectedProfile: 'Test CO' });
+    useDocumentsStore.setState({ hydrated: true, docs: {}, currentId: null });
+    const json = await buildBackup();
+
+    // Local edit after the backup was taken.
+    useProfileStore.setState((s) => ({ profiles: { 'Test CO': { ...s.profiles['Test CO'], sigTitle: 'EDITED LOCALLY' } } }));
+
+    const result = await restoreBackup(json);
+    expect(result.profilesAdded).toBe(0); // collision → no add
+    expect(useProfileStore.getState().profiles['Test CO'].sigTitle).toBe('EDITED LOCALLY'); // local wins
+  });
+});

--- a/tests/unit/backupStore.statemachine.test.ts
+++ b/tests/unit/backupStore.statemachine.test.ts
@@ -9,11 +9,17 @@ const setHandle = vi.fn(async () => true);
 const clearHandle = vi.fn(async () => {});
 
 vi.mock('@/lib/documentsDb', () => ({
-  idbGetAllDocuments: vi.fn(async () => []),
   idbGetBackupHandle: vi.fn(async () => backupHandle),
   idbSetBackupHandle: (...a: unknown[]) => setHandle(...(a as [])),
   idbClearBackupHandle: (...a: unknown[]) => clearHandle(...(a as [])),
 }));
+
+// The mirror content comes from buildBackup(); mock it so the state-machine test
+// stays about permissions/writes, decoupled from what a real backup contains.
+const buildBackup = vi.fn(async () =>
+  JSON.stringify({ kind: 'dondocs-backup', version: 3, documents: [], attachments: [] })
+);
+vi.mock('@/lib/backup', () => ({ buildBackup: () => buildBackup() }));
 
 interface FakeHandle {
   name: string;
@@ -84,6 +90,30 @@ describe('backupStore permission state machine', () => {
     expect(picker).toHaveBeenCalledTimes(1);
     expect(store.getState().status).toBe('connected');
     expect(handle.writes).toHaveLength(1); // seeded on connect
+  });
+
+  it('mirrors a full-account backup bundle, not a docs-only library', async () => {
+    const handle = makeHandle('granted');
+    const store = await loadStore(vi.fn(async () => handle));
+    await store.getState().setupBackup();
+    expect(buildBackup).toHaveBeenCalled();
+    expect(JSON.parse(handle.writes[0]).kind).toBe('dondocs-backup'); // not 'dondocs-library'
+  });
+
+  it('skips the write (and keeps the file intact) when the account can not be read', async () => {
+    const handle = makeHandle('granted');
+    const store = await loadStore(vi.fn(async () => handle));
+    await store.getState().setupBackup(); // connected + one seed write
+    const seededWrites = handle.writes.length;
+    const before = store.getState().lastBackupAt;
+
+    // buildBackup throws (e.g. unreadable registry): mirroring now would overwrite
+    // the one external safety copy with an incomplete file — so we must not write.
+    buildBackup.mockRejectedValueOnce(new Error('registry unreadable'));
+    await store.getState().writeNow();
+    expect(store.getState().status).toBe('error');
+    expect(handle.writes).toHaveLength(seededWrites); // no overwrite
+    expect(store.getState().lastBackupAt).toBe(before); // no fake success stamp
   });
 
   it('writeNow flips to needs-permission when permission was revoked between saves', async () => {


### PR DESCRIPTION
## Why

This closes the last gap in the backup story. Over the past PRs the **manual** backup became complete:
- #114 — "Back up everything" covers documents + profiles/signatures + snippets + templates + NAVMC form fields
- #115 — plus enclosure file bytes

But the **synced auto-backup** (Chromium File System Access — the file that auto-mirrors after every save, meant to be dropped in a synced folder for cross-machine backup) was still writing a **docs-only** `dondocs-library` bundle. So a user relying on it as their one external safety copy would restore it on a new machine and still lose everything but their documents — the exact "silently lossy backup" class we've been fixing.

## What

- The mirror now writes the same `buildBackup()` full-account bundle the manual download produces, including enclosure bytes. A restore from the synced file brings back everything.
- `buildBackup()` throws when the account can't be read (e.g. an unreadable registry); that's converted to a **skipped write** — an incomplete bundle never overwrites a good backup file, and "last backed up" isn't advanced. Write-fault / permission-loss handling is unchanged.
- New-setup files are suggested as `dondocs-backup.json` (was `dondocs-library.json`). Existing synced files keep their name and upgrade in place on the next save.
- The `backupStore → backup → documentsStore → backupStore` import cycle is **runtime-only** — every edge is called from inside a function, never at module init — so modules initialize cleanly (verified live: all three load with functions defined).

No new restore path needed: the manual "load backup" already routes through `restoreBackup`, which handles both `dondocs-backup` bundles and legacy `dondocs-library` files.

## Trade-off (documented)

Each synced write re-serializes the whole account, so with large enclosures the base64 pass runs on every debounced (1.5s) save. It's off the critical path (async, fire-and-forget) and enclosures are typically small/few; a future optimization could diff attachments. Completeness of the one external safety copy wins here.

## Verification

- `npm run build` clean (incl. `check-no-cdn` air-gap guard), full suite **1509 passing**, lint clean.
- `backupStore.statemachine.test.ts` updated: mocks `buildBackup`; adds coverage that the mirror writes a `dondocs-backup` (not `dondocs-library`) bundle, and that a build failure skips the write with no fake success stamp / no overwrite.
- Live: confirmed the runtime import cycle loads cleanly and the app boots without a TDZ/init error.