### PR TITLE
test(preview): stabilize the flaky PreviewPanel lazy-load waits

### DIFF
--- a/tests/component/PreviewPanel.test.tsx
+++ b/tests/component/PreviewPanel.test.tsx
@@ -58,17 +58,24 @@ beforeEach(() => {
   useUIStore.setState({ isMobile: false, previewVisible: true });
 });
 
+// The viewer is lazy-loaded (React.lazy), so the `doc:` node only mounts after
+// the dynamic import resolves. Under a saturated CI/parallel test pool that can
+// take longer than waitFor's 1s default, which flaked these waits; a generous
+// ceiling removes the race without slowing the happy path (waitFor still returns
+// the instant the node appears).
+const LAZY_TIMEOUT = { timeout: 5000 };
+
 describe('PreviewPanel — compile-error reporting', () => {
   it('a failure AFTER a successful compile banners over the stale document', async () => {
     renderPanel({ pdfUrl: 'blob:test/ok', error: 'Undefined control sequence \\badmacro' });
 
     // The banner announces the failure (role=alert reaches screen readers)…
-    const alert = await screen.findByRole('alert');
+    const alert = await screen.findByRole('alert', undefined, LAZY_TIMEOUT);
     expect(alert.textContent).toContain('Compile failed — preview is out of date');
     expect(alert.textContent).toContain('Undefined control sequence');
 
     // …while the last good document stays visible underneath, not blanked.
-    await waitFor(() => expect(screen.getByTestId('doc:blob:test/ok')).toBeTruthy());
+    await waitFor(() => expect(screen.getByTestId('doc:blob:test/ok')).toBeTruthy(), LAZY_TIMEOUT);
   });
 
   it('a failure with NO document yet shows the centered error state', () => {
@@ -85,7 +92,7 @@ describe('PreviewPanel — compile-error reporting', () => {
 
   it('no error, no banner — the viewer renders clean', async () => {
     renderPanel({ pdfUrl: 'blob:test/clean' });
-    await waitFor(() => expect(screen.getByTestId('doc:blob:test/clean')).toBeTruthy());
+    await waitFor(() => expect(screen.getByTestId('doc:blob:test/clean')).toBeTruthy(), LAZY_TIMEOUT);
     expect(screen.queryByRole('alert')).toBeNull();
   });
 });


### PR DESCRIPTION
## Why

`tests/component/PreviewPanel.test.tsx` flaked under full-suite parallel load — it failed 3-for-3 local full runs (different cases each time), while passing in isolation. Not a product bug; a test-timing issue surfaced while verifying the backup work.

## Root cause

Two cases `waitFor` the `doc:` node, which is rendered by the **lazy-loaded** PdfViewer (`React.lazy`). That node only mounts after the dynamic import resolves. On a saturated parallel test pool the import + render can exceed `waitFor`'s **1s default**, so the wait times out — exactly why different `doc:`-waiting cases failed on different runs.

## Fix

Give those lazy-load waits a generous **5s ceiling** (`findByRole` / `waitFor`). `waitFor` still resolves the instant the node appears, so the happy path is unchanged — only the timeout budget grows. Test-only change; no product code touched.

## Verification

- PreviewPanel passes in isolation, and the **full suite passed twice consecutively** (80 files / 1511 tests) where it previously failed 3-for-3.
- Lint clean.