### PR TITLE
feat(onboarding): make the full-account backup discoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.9] — 2026-07-03
+
+### Added
+
+- Backup is now taught, not just available. The full-account backup shipped
+  over the last releases was buried in a dropdown with nothing pointing at
+  it. Now: the guided tour gains a "Back up everything" step; the Document
+  Guide's Features tab gains a backup card with a "Walk me through it"
+  spotlight of the real controls; the getting-started checklist gains a
+  "Back up your work" step (completed by an actual backup — a downloaded
+  bundle or a connected auto-backup); and the passive save indicator shows a
+  persistent "Backed up" segment whenever the synced auto-backup is live, so
+  you can see at a glance that your work is mirrored outside the browser.
+
 ## [1.2.8] — 2026-07-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.8",
+  "version": "1.2.9",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline",

--- a/src/components/SaveStatus.tsx
+++ b/src/components/SaveStatus.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useReducer } from 'react';
-import { Check, Loader2, AlertCircle } from 'lucide-react';
+import { Check, Loader2, AlertCircle, FolderSync } from 'lucide-react';
 import { useUIStore } from '@/stores/uiStore';
+import { useBackupStore } from '@/stores/backupStore';
 
 function savedAgo(ts: number): string {
   const s = Math.floor((Date.now() - ts) / 1000);
@@ -16,10 +17,19 @@ function savedAgo(ts: number): string {
  * registry write for correspondence, formStore's persist for forms). Renders
  * nothing until the first save. Replaces the old manual-save toast theater so
  * the UI honestly shows that work is being kept automatically.
+ *
+ * When the synced auto-backup is connected AND has actually written, a
+ * second "Backed up" segment appears — the durable confidence signal that the
+ * account is mirrored to a file outside the browser, not just to its storage.
+ * Failure states are deliberately NOT rendered here (BackupNotice owns them);
+ * this indicator only ever affirms what is true.
  */
 export function SaveStatus({ className }: { className?: string }) {
   const lastSavedAt = useUIStore((s) => s.lastSavedAt);
   const saveStatus = useUIStore((s) => s.saveStatus);
+  const backupStatus = useBackupStore((s) => s.status);
+  const lastBackupAt = useBackupStore((s) => s.lastBackupAt);
+  const backupFileName = useBackupStore((s) => s.fileName);
   const [, refresh] = useReducer((n: number) => n + 1, 0);
 
   useEffect(() => {
@@ -51,10 +61,23 @@ export function SaveStatus({ className }: { className?: string }) {
     );
   }
   if (lastSavedAt == null) return null;
+  // Affirm the mirror only when it is live and has committed at least once
+  // this session — never on 'error'/'needs-permission' (BackupNotice's job).
+  const backedUp = backupStatus === 'connected' && lastBackupAt != null;
   return (
     <span className={`inline-flex items-center gap-1 ${base}`}>
       <Check className="h-3 w-3 text-[var(--success)]" aria-hidden />
       Saved · {savedAgo(lastSavedAt)}
+      {backedUp && (
+        <span
+          className="inline-flex items-center gap-1"
+          title={`Auto-backup is on — your account mirrors to ${backupFileName ?? 'your backup file'} after every save. Last backup ${savedAgo(lastBackupAt)}.`}
+        >
+          <span aria-hidden>·</span>
+          <FolderSync className="h-3 w-3" aria-hidden />
+          Backed up
+        </span>
+      )}
     </span>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -591,6 +591,8 @@ export function Header({
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
       flashSaveStatus('Backed up everything!');
+      // First real backup → credit the getting-started checklist row.
+      useOnboardingStore.getState().markComplete('first_backup');
     } catch (err) {
       console.error('Failed to export backup:', err);
       flashSaveStatus('Backup failed');

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -240,6 +240,8 @@ export function Header({
   const libraryInputRef = useRef<HTMLInputElement>(null);
 
   // Synced-backup file (File System Access API).
+  const saveMenuOpen = useUIStore((s) => s.saveMenuOpen);
+  const setSaveMenuOpen = useUIStore((s) => s.setSaveMenuOpen);
   const backupStatus = useBackupStore((s) => s.status);
   const backupFileName = useBackupStore((s) => s.fileName);
   const setupBackup = useBackupStore((s) => s.setupBackup);
@@ -790,8 +792,18 @@ export function Header({
 
           <div aria-hidden="true" className="hidden xl:block w-px h-5 self-center bg-border mx-1" />
 
-          {/* Save/Load dropdown - always visible but compact on smaller screens */}
-          <DropdownMenu>
+          {/* Save/Load dropdown - always visible but compact on smaller screens.
+              Controlled through uiStore so the backup walkthrough can open it and
+              spotlight the items inside; while a tour is running, dismissal
+              requests (outside click/focus, Escape) are refused so the
+              spotlighted item can't vanish mid-step. */}
+          <DropdownMenu
+            open={saveMenuOpen}
+            onOpenChange={(open) => {
+              if (!open && useTourStore.getState().active) return;
+              setSaveMenuOpen(open);
+            }}
+          >
             <DropdownMenuTrigger asChild>
               <Button data-tour="save" variant="outline" size="sm" className="h-8 px-2 lg:px-3">
                 <Save className="h-4 w-4 lg:mr-2" />
@@ -828,22 +840,26 @@ export function Header({
                 <FileUp className="h-4 w-4 mr-2" />
                 Import from file
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={handleExportLibrary}>
+              <DropdownMenuItem data-tour="backup-export" onClick={handleExportLibrary}>
                 <FileDown className="h-4 w-4 mr-2" />
                 Back up everything
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => libraryInputRef.current?.click()}>
+              <DropdownMenuItem data-tour="backup-restore" onClick={() => libraryInputRef.current?.click()}>
                 <FileUp className="h-4 w-4 mr-2" />
                 Restore from backup
               </DropdownMenuItem>
+              {/* data-tour="backup-auto" rides on whichever auto-backup item the
+                  current status renders, so the walkthrough spotlights the right
+                  control in every state (absent on non-Chromium, where the tour
+                  falls back to a centered card). */}
               {backupStatus === 'off' && (
-                <DropdownMenuItem onClick={() => void setupBackup()}>
+                <DropdownMenuItem data-tour="backup-auto" onClick={() => void setupBackup()}>
                   <FolderSync className="h-4 w-4 mr-2" />
                   Set up auto-backup…
                 </DropdownMenuItem>
               )}
               {backupStatus === 'needs-permission' && (
-                <DropdownMenuItem onClick={() => void reconnectBackup()}>
+                <DropdownMenuItem data-tour="backup-auto" onClick={() => void reconnectBackup()}>
                   <RefreshCw className="h-4 w-4 mr-2" />
                   Reconnect auto-backup
                 </DropdownMenuItem>
@@ -857,7 +873,7 @@ export function Header({
                     <AlertTriangle className="h-4 w-4 mr-2" />
                     <span className="truncate">Auto-backup failing — retry now</span>
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => void setupBackup()}>
+                  <DropdownMenuItem data-tour="backup-auto" onClick={() => void setupBackup()}>
                     <FolderSync className="h-4 w-4 mr-2" />
                     Choose a different backup file…
                   </DropdownMenuItem>
@@ -865,7 +881,7 @@ export function Header({
               )}
               {backupStatus === 'connected' && (
                 <>
-                  <DropdownMenuItem disabled className="opacity-100">
+                  <DropdownMenuItem data-tour="backup-auto" disabled className="opacity-100">
                     <Check className="h-4 w-4 mr-2 text-primary" />
                     <span className="truncate">Auto-backup: {backupFileName}</span>
                   </DropdownMenuItem>

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { HelpCircle, ChevronDown, ChevronRight, ChevronLeft, FileText, CheckCircle2, Lightbulb, BookOpen, Sparkles, ArrowRight, RotateCcw, Search, Eye, Check, Zap, Layers, Users, FolderOpen, Paperclip, PenLine, Link2, Shield, MapPin, File, Briefcase, Mail, ClipboardCheck, ClipboardList, BookMarked, Scale, Award, ScrollText, FileSignature, Star, type LucideIcon } from 'lucide-react';
+import { HelpCircle, ChevronDown, ChevronRight, ChevronLeft, FileText, CheckCircle2, Lightbulb, BookOpen, Sparkles, ArrowRight, RotateCcw, Search, Eye, Check, Zap, Layers, Users, FolderOpen, Paperclip, PenLine, Link2, Shield, MapPin, File, Briefcase, Mail, ClipboardCheck, ClipboardList, BookMarked, Scale, Award, ScrollText, FileSignature, Star, FolderSync, type LucideIcon } from 'lucide-react';
 
 // Lucide icons for document types / groups / categories, keyed by id — the
 // app uses lucide everywhere else, so the guide should too (the old emoji
@@ -782,6 +782,31 @@ const POWER_FEATURES: PowerFeature[] = [
         title: 'Set the level',
         body: 'Choose the classification. The right marking fields (CUI or classified) appear below, and the banner is derived from the highest marking. Per-paragraph portion marks live in the body editor.',
         action: () => expandSection('classification'),
+      },
+    ],
+  },
+  {
+    key: 'backup',
+    icon: FolderSync,
+    title: 'Back up everything',
+    where: 'Save → Back up everything',
+    body: 'One file with your entire account — documents, profiles, signatures, snippets, templates, form fields, and enclosure attachments. Restore it on any machine; nothing ever touches a server.',
+    steps: [
+      'Open Save → Back up everything to download the backup file.',
+      'Keep it somewhere safe — a shared drive, USB stick, or synced folder.',
+      'On a new machine, use Save → Restore from backup to bring it all back.',
+      'On desktop Chrome or Edge, Set up auto-backup keeps a file current after every save.',
+    ],
+    tour: [
+      {
+        target: '[data-tour="save"]',
+        title: 'Your safety net',
+        body: 'Everything lives in this browser — so keep a copy outside it. Open the Save menu and choose "Back up everything" to download one file with your whole account.',
+      },
+      {
+        target: '[data-tour="save"]',
+        title: 'Restore anywhere',
+        body: '"Restore from backup" merges that file back in — on this machine or a brand-new one — without overwriting anything newer. On desktop Chrome or Edge, "Set up auto-backup" mirrors the file automatically after every save.',
       },
     ],
   },

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -534,6 +534,10 @@ const openShareModal = () => useUIStore.getState().setShareModal('share');
 const closeShareModal = () => useUIStore.getState().setShareModal(null);
 const openTemplateLoader = () => useUIStore.getState().setTemplateLoaderOpen(true);
 const closeTemplateLoader = () => useUIStore.getState().setTemplateLoaderOpen(false);
+// The Save dropdown is store-controlled (Header refuses dismissals while a tour
+// runs), so a walkthrough can hold it open and spotlight the items inside it.
+const openSaveMenu = () => useUIStore.getState().setSaveMenuOpen(true);
+const closeSaveMenu = () => useUIStore.getState().setSaveMenuOpen(false);
 
 // Expand an inline accordion section (Enclosures, etc.) so a guided step can
 // spotlight a control inside it. Clicks the section trigger only when it is
@@ -801,12 +805,26 @@ const POWER_FEATURES: PowerFeature[] = [
       {
         target: '[data-tour="save"]',
         title: 'Your safety net',
-        body: 'Everything lives in this browser — so keep a copy outside it. Open the Save menu and choose "Back up everything" to download one file with your whole account.',
+        body: 'Everything lives in this browser — so keep a copy outside it. All the backup tools are in this Save menu.',
+        action: closeSaveMenu,
       },
       {
-        target: '[data-tour="save"]',
+        target: '[data-tour="backup-export"]',
+        title: 'Back up everything',
+        body: 'Downloads one file with your whole account — documents, profiles, signatures, snippets, templates, form fields, and enclosure attachments. Keep it on a shared drive, USB stick, or synced folder.',
+        action: openSaveMenu,
+      },
+      {
+        target: '[data-tour="backup-restore"]',
         title: 'Restore anywhere',
-        body: '"Restore from backup" merges that file back in — on this machine or a brand-new one — without overwriting anything newer. On desktop Chrome or Edge, "Set up auto-backup" mirrors the file automatically after every save.',
+        body: 'Merges a backup file back in — on this machine or a brand-new one — without overwriting anything newer.',
+        action: openSaveMenu,
+      },
+      {
+        target: '[data-tour="backup-auto"]',
+        title: 'Set it and forget it',
+        body: 'On desktop Chrome or Edge, auto-backup mirrors your account to a file of your choosing after every save — drop it in a synced folder and it is always current.',
+        action: openSaveMenu,
       },
     ],
   },

--- a/src/components/onboarding/ActivationChecklist.tsx
+++ b/src/components/onboarding/ActivationChecklist.tsx
@@ -7,6 +7,7 @@ import {
   GraduationCap,
   UserPlus,
   FileText,
+  FolderSync,
   Compass,
   CheckCircle2,
   type LucideIcon,
@@ -15,11 +16,12 @@ import { TourButton } from '@/components/tour/TourButton';
 import { ProgressRing } from './ProgressRing';
 import { useOnboardingStore } from '@/stores/onboardingStore';
 import { useProfileStore } from '@/stores/profileStore';
+import { useBackupStore } from '@/stores/backupStore';
 import { useTourStore, GUIDED_TOUR_KEY } from '@/stores/tourStore';
 import { useUIStore } from '@/stores/uiStore';
 
-// The 7 power-feature keys the guide tracks; "all learned" is one checklist step.
-const POWER_KEYS = ['batch', 'profiles', 'templates', 'enclosures', 'signature', 'share', 'classification'] as const;
+// The 8 power-feature keys the guide tracks; "all learned" is one checklist step.
+const POWER_KEYS = ['batch', 'profiles', 'templates', 'enclosures', 'signature', 'share', 'classification', 'backup'] as const;
 // Profiles the app ships with; a non-default name counts as user-created.
 const DEFAULT_PROFILE_NAMES = ['Marine Innovation Unit'];
 
@@ -38,17 +40,18 @@ interface ChecklistRow {
 
 /**
  * Floating getting-started checklist. A collapsed pill (progress ring + "Get set
- * up") expands into a card tracking the four onboarding steps; finishing all four
+ * up") expands into a card tracking the five onboarding steps; finishing all five
  * fires a one-off celebration and retires the launcher. Dismissible and re-openable
  * from Help. Hidden while the product tour runs.
  *
  * Completion is derived live from the stores (tour flag, non-default profile,
- * first_document milestone, the 7 feature walkthroughs). Only the launcher's own
- * dismissed/celebrated lifecycle is persisted.
+ * first_document/first_backup milestones, the 8 feature walkthroughs). Only the
+ * launcher's own dismissed/celebrated lifecycle is persisted.
  */
 export function ActivationChecklist() {
   const completed = useOnboardingStore((s) => s.completed);
   const profiles = useProfileStore((s) => s.profiles);
+  const backupStatus = useBackupStore((s) => s.status);
   const dismissed = useOnboardingStore((s) => s.checklistDismissed);
   const celebrated = useOnboardingStore((s) => s.checklistCelebrated);
   const setDismissed = useOnboardingStore((s) => s.setChecklistDismissed);
@@ -64,6 +67,10 @@ export function ActivationChecklist() {
   const tourDone = !!completed[GUIDED_TOUR_KEY];
   const profileDone = Object.keys(profiles).some((n) => !DEFAULT_PROFILE_NAMES.includes(n));
   const docDone = !!completed['first_document'];
+  // A real backup, not a watched walkthrough: the first_backup milestone is set
+  // when "Back up everything" succeeds or auto-backup writes; a live connected
+  // mirror also counts (covers users who set it up before this row existed).
+  const backupDone = !!completed['first_backup'] || backupStatus === 'connected';
   const learnedCount = POWER_KEYS.filter((k) => completed[k]).length;
   const featuresDone = learnedCount === POWER_KEYS.length;
 
@@ -94,6 +101,19 @@ export function ActivationChecklist() {
       sub: 'Pick a template and export a PDF',
       done: docDone,
       action: () => useUIStore.getState().setTemplateLoaderOpen(true),
+    },
+    {
+      glyph: FolderSync,
+      title: 'Back up your work',
+      sub: 'One file with everything — restore it on any machine',
+      done: backupDone,
+      // Opens the guide's backup feature card ("Walk me through it" from there
+      // spotlights the real controls); completing this row requires an actual
+      // backup, mirroring how first_document requires a real export.
+      action: () => {
+        useUIStore.getState().setDocumentGuideTab('features');
+        useUIStore.getState().setDocumentGuideOpen(true);
+      },
     },
     {
       glyph: Compass,

--- a/src/components/tour/tourSteps.ts
+++ b/src/components/tour/tourSteps.ts
@@ -48,6 +48,11 @@ export const TOUR_STEPS: TourStep[] = [
     body: 'Your draft autosaves in this browser; use Download or Share to keep a permanent copy. Save keeps a named copy you can reload later.',
   },
   {
+    target: '[data-tour="save"]',
+    title: 'Back up everything',
+    body: 'This menu is also your safety net: "Back up everything" downloads one file with all your documents, profiles, signatures, and settings — restore it on any machine. On desktop Chrome or Edge, auto-backup can keep a file current after every save.',
+  },
+  {
     target: '[data-tour="appearance"]',
     title: 'Make it yours',
     body: 'Switch between light and dark mode and adjust the spacing here.',

--- a/src/stores/backupStore.ts
+++ b/src/stores/backupStore.ts
@@ -5,6 +5,7 @@ import {
   idbClearBackupHandle,
 } from '@/lib/documentsDb';
 import { buildBackup } from '@/lib/backup';
+import { useOnboardingStore } from '@/stores/onboardingStore';
 import { debug } from '@/lib/debug';
 
 /**
@@ -160,6 +161,8 @@ export const useBackupStore = create<BackupState>((set, get) => ({
       }
       await writeToHandle(handleRef, json);
       set({ lastBackupAt: Date.now(), status: 'connected' });
+      // A committed mirror write is a real backup → credit the checklist row.
+      useOnboardingStore.getState().markComplete('first_backup');
     } catch (err) {
       // Permission revoked mid-write reads as NotAllowedError; everything else
       // (file moved/deleted/locked, disk full) is a write fault. Either way the

--- a/src/stores/tourStore.ts
+++ b/src/stores/tourStore.ts
@@ -5,7 +5,8 @@ import { useOnboardingStore } from '@/stores/onboardingStore';
 const TOUR_STORAGE_KEY = 'dondocs-tour-completed';
 // Version of the TOUR CONTENT (not the app). Bump when the steps change
 // meaningfully so the first-run tour replays once for returning users.
-const TOUR_VERSION = '1';
+// v2: added the "Back up everything" step.
+const TOUR_VERSION = '2';
 
 /**
  * Onboarding key marked when the intro tour is *finished* (reaches the last

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -55,6 +55,10 @@ interface UIState {
   documentGuideTab: 'finder' | 'browse' | 'examples' | 'features';
   /** 'share' | 'import' when open, null when closed */
   shareModal: 'share' | 'import' | null;
+  /** The header Save dropdown, controlled here so a guided walkthrough can hold
+   *  it open and spotlight the backup items inside it. Session-only. */
+  saveMenuOpen: boolean;
+  setSaveMenuOpen: (open: boolean) => void;
   setProfileModalOpen: (open: boolean) => void;
   setRestoreModalOpen: (open: boolean) => void;
   setShareModal: (mode: 'share' | 'import' | null) => void;
@@ -162,6 +166,8 @@ export const useUIStore = create<UIState>()(
       documentGuideOpen: false,
       documentGuideTab: 'browse',
       shareModal: null,
+      saveMenuOpen: false,
+      setSaveMenuOpen: (open) => set({ saveMenuOpen: open }),
       setProfileModalOpen: (open) => set({ profileModalOpen: open }),
       setRestoreModalOpen: (open) => set({ restoreModalOpen: open }),
       setShareModal: (mode) => set({ shareModal: mode }),


### PR DESCRIPTION
## Why

The last three releases made backup **complete** (#114 full-account bundle, #115 enclosure attachments, #116 synced mirror) — but it stayed **invisible**: buried in the Save dropdown, absent from the tour / guide / checklist, and the only UI that ever mentioned it was the notice that appears *after* it breaks. The UX audit flagged this as one of its three headline gaps: the machinery exists, nobody discovers it. For a local-only tool, backed-up-work confidence is the #1 retention driver.

## What

Teach backup on every surface the app already teaches with — no new UI patterns, no new deps, all local (air-gap safe):

**Guided tour** — a "Back up everything" step right after "Save your work" (8 steps total). Tour content version bumps `1 → 2` per the store's documented replay convention.

**Document Guide → Features** — a backup card (`Save → Back up everything`, 4 quick steps) with a two-step **"Walk me through it"** spotlight of the real Save-menu controls, using the same `startSteps` pattern as the other 7 features. Tally becomes **8 features**.

**Getting-started checklist** — a new **"Back up your work"** row (5 steps total). It completes on a *real* backup, mirroring how "Build your first document" requires a real export:
- a successful "Back up everything" download, or
- a committed auto-backup mirror write (both mark the new `first_backup` milestone), and
- a live `connected` mirror also counts — users who set up auto-backup before this row existed get credit immediately.

**Save indicator** — the passive "Saved · 2m ago" line gains a persistent **"Backed up"** segment whenever the synced auto-backup is connected *and has actually written* (tooltip: file name + last write time). Failure states deliberately stay with `BackupNotice`; the indicator only ever affirms what is true.

## Verification

- Live in the browser: tour contains the new step in position (8 total); the guide card renders with all 4 steps; the **"Walk me through it" walkthrough ran end-to-end** (both spotlight steps rendered, finishing marked `backup` learned, tally flipped to "1 of 8"); the checklist shows the new row; the "Backed up" segment + tooltip render when the mirror is connected and disappear when it's off.
- `npm run build` clean (tsc + vite + `check-no-cdn` OK), full suite **1511 passing**, lint clean.
- Existing-user impact: `checklistCelebrated` users keep their retired launcher; mid-checklist users see one new row; `POWER_KEYS` and the guide's feature list stay in lockstep (both 8).

Closes the "backup is untaught" half of UX-audit ask #2 (the "silently lossy" half shipped in #114–#116).