### PR TITLE
fix(errors): crash screen follows the app's light/dark scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.10] — 2026-07-03
+
+### Fixed
+
+- The crash-recovery screen ("Something went wrong") now follows the app's
+  light/dark scheme instead of always rendering a bright white page — it
+  still uses only inline styles (so it works even when a CSS regression is
+  what crashed), but reads the active scheme off the document. Its
+  "Reset and reload" confirmation is now an in-app inline prompt instead of
+  the browser's native dialog, which followed the OS theme rather than the
+  app's.
+
 ## [1.2.9] — 2026-07-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.9",
+  "version": "1.2.10",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline",

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -17,19 +17,36 @@ interface ErrorBoundaryState {
   errorInfo: ErrorInfo | null;
   detailsOpen: boolean;
   copyStatus: CopyStatus;
+  /** "Reset and reload" asks for confirmation inline (no native confirm(), which
+   *  follows the OS theme, not the app's, and reads as a foreign white popup). */
+  confirmingReset: boolean;
+}
+
+/** The app's dark class on <html> is the single source of truth for the active
+ *  scheme — index.html sets it pre-paint from the saved theme, falling back to
+ *  the OS preference — so the crash screen can honor it without touching any of
+ *  the (possibly crashed) CSS. */
+function isDarkMode(): boolean {
+  try {
+    return document.documentElement.classList.contains('dark');
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Top-level error boundary. Catches render-phase exceptions below it and shows a
  * recovery UI instead of a white screen. The recovery UI uses inline styles only,
- * since richer components could be part of what crashed.
+ * since richer components could be part of what crashed — but the palette is
+ * chosen per the active light/dark scheme so the crash screen doesn't blast a
+ * white page at a dark-mode user.
  *
  * Recovery options:
  *  - Copy session: copy the auto-saved JSON to the clipboard before a wipe.
  *  - Reload: replays the same render against the same state (helps only a
  *    transient crash) but is cheap.
  *  - Reset & reload: clear the persisted session, for when it's what crashes on
- *    rehydrate.
+ *    rehydrate. Confirmed inline, not via window.confirm.
  */
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = {
@@ -37,6 +54,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     errorInfo: null,
     detailsOpen: false,
     copyStatus: 'idle',
+    confirmingReset: false,
   };
   // Pending copy-status reset timer, cleared on unmount or a superseding click to
   // avoid a setState-on-unmounted warning.
@@ -98,10 +116,18 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     window.location.reload();
   };
 
-  handleResetAndReload = async (): Promise<void> => {
-    if (!window.confirm('This will erase your auto-saved draft and reload. Continue?')) {
-      return;
-    }
+  /** First click arms the inline confirmation strip; the strip's button calls
+   *  performResetAndReload. No window.confirm — a native dialog follows the OS
+   *  theme rather than the app's and can't be styled. */
+  handleResetAndReload = (): void => {
+    this.setState({ confirmingReset: true });
+  };
+
+  handleCancelReset = (): void => {
+    this.setState({ confirmingReset: false });
+  };
+
+  performResetAndReload = async (): Promise<void> => {
     try {
       // init() resumes from the IndexedDB registry before reading these
       // localStorage keys, so clearing localStorage alone left the crashing doc to
@@ -130,40 +156,83 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   };
 
   render(): ReactNode {
-    const { error, errorInfo, detailsOpen, copyStatus } = this.state;
+    const { error, errorInfo, detailsOpen, copyStatus, confirmingReset } = this.state;
 
     if (!error) {
       return this.props.children;
     }
 
-    // Inline styles only, in case a CSS regression is what crashed the app.
+    // Inline styles only, in case a CSS regression is what crashed the app —
+    // but honor the active light/dark scheme (read off <html>, not off the
+    // possibly-broken stylesheet) so the crash screen matches the app.
+    const dark = isDarkMode();
+    const c = dark
+      ? {
+          pageBg: '#0b1120',
+          pageFg: '#e2e8f0',
+          cardBg: '#111827',
+          cardBorder: '#2b3648',
+          muted: '#94a3b8',
+          btnBg: '#1e293b',
+          btnBorder: '#475569',
+          btnFg: '#e2e8f0',
+          primaryBg: '#e2e8f0',
+          primaryFg: '#0f172a',
+          danger: '#f87171',
+          errBg: '#2a1215',
+          errBorder: '#7f1d1d',
+          errFg: '#fca5a5',
+          codeBg: '#0b1120',
+          codeBorder: '#334155',
+          shadow: '0 1px 3px rgba(0,0,0,0.4), 0 4px 12px rgba(0,0,0,0.5)',
+        }
+      : {
+          pageBg: '#f8fafc',
+          pageFg: '#0f172a',
+          cardBg: '#ffffff',
+          cardBorder: '#e2e8f0',
+          muted: '#475569',
+          btnBg: '#ffffff',
+          btnBorder: '#cbd5e1',
+          btnFg: '#0f172a',
+          primaryBg: '#0f172a',
+          primaryFg: '#ffffff',
+          danger: '#dc2626',
+          errBg: '#fef2f2',
+          errBorder: '#fecaca',
+          errFg: '#991b1b',
+          codeBg: '#f1f5f9',
+          codeBorder: '#e2e8f0',
+          shadow: '0 1px 3px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.06)',
+        };
+
     const containerStyle: React.CSSProperties = {
       minHeight: '100vh',
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
       padding: '24px',
-      backgroundColor: '#f8fafc',
-      color: '#0f172a',
+      backgroundColor: c.pageBg,
+      color: c.pageFg,
       fontFamily: 'system-ui, -apple-system, sans-serif',
     };
 
     const cardStyle: React.CSSProperties = {
       maxWidth: '640px',
       width: '100%',
-      backgroundColor: '#ffffff',
-      border: '1px solid #e2e8f0',
+      backgroundColor: c.cardBg,
+      border: `1px solid ${c.cardBorder}`,
       borderRadius: '8px',
       padding: '24px',
-      boxShadow: '0 1px 3px rgba(0,0,0,0.04), 0 4px 12px rgba(0,0,0,0.06)',
+      boxShadow: c.shadow,
     };
 
     const buttonStyle: React.CSSProperties = {
       padding: '8px 14px',
       borderRadius: '6px',
-      border: '1px solid #cbd5e1',
-      backgroundColor: '#ffffff',
-      color: '#0f172a',
+      border: `1px solid ${c.btnBorder}`,
+      backgroundColor: c.btnBg,
+      color: c.btnFg,
       fontSize: '14px',
       fontWeight: 500,
       cursor: 'pointer',
@@ -171,21 +240,21 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
     const primaryButtonStyle: React.CSSProperties = {
       ...buttonStyle,
-      backgroundColor: '#0f172a',
-      color: '#ffffff',
-      borderColor: '#0f172a',
+      backgroundColor: c.primaryBg,
+      color: c.primaryFg,
+      borderColor: c.primaryBg,
     };
 
     const dangerButtonStyle: React.CSSProperties = {
       ...buttonStyle,
-      borderColor: '#dc2626',
-      color: '#dc2626',
+      borderColor: c.danger,
+      color: c.danger,
     };
 
     const codeStyle: React.CSSProperties = {
       display: 'block',
-      backgroundColor: '#f1f5f9',
-      border: '1px solid #e2e8f0',
+      backgroundColor: c.codeBg,
+      border: `1px solid ${c.codeBorder}`,
       borderRadius: '4px',
       padding: '12px',
       fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
@@ -203,20 +272,20 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
           <h1 style={{ fontSize: '20px', fontWeight: 600, margin: '0 0 8px 0' }}>
             Something went wrong
           </h1>
-          <p style={{ margin: '0 0 16px 0', color: '#475569', fontSize: '14px', lineHeight: 1.5 }}>
+          <p style={{ margin: '0 0 16px 0', color: c.muted, fontSize: '14px', lineHeight: 1.5 }}>
             DonDocs hit an error it couldn't recover from. Your auto-saved draft is
             still in this browser — you can copy it to your clipboard before reloading.
           </p>
 
           <div
             style={{
-              backgroundColor: '#fef2f2',
-              border: '1px solid #fecaca',
+              backgroundColor: c.errBg,
+              border: `1px solid ${c.errBorder}`,
               borderRadius: '6px',
               padding: '12px',
               marginBottom: '16px',
               fontSize: '13px',
-              color: '#991b1b',
+              color: c.errFg,
               wordBreak: 'break-word',
             }}
           >
@@ -260,6 +329,37 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             </button>
           </div>
 
+          {confirmingReset && (
+            <div
+              style={{
+                border: `1px solid ${c.danger}`,
+                borderRadius: '6px',
+                padding: '12px',
+                marginBottom: '16px',
+                fontSize: '13px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                flexWrap: 'wrap',
+              }}
+            >
+              <span style={{ flex: '1 1 220px' }}>
+                This erases your auto-saved draft and reloads. Copy it first if you
+                want to keep it.
+              </span>
+              <button
+                type="button"
+                onClick={this.performResetAndReload}
+                style={{ ...buttonStyle, backgroundColor: c.danger, borderColor: c.danger, color: dark ? '#0f172a' : '#ffffff' }}
+              >
+                Erase and reload
+              </button>
+              <button type="button" onClick={this.handleCancelReset} style={buttonStyle}>
+                Cancel
+              </button>
+            </div>
+          )}
+
           <button
             type="button"
             onClick={this.toggleDetails}
@@ -268,7 +368,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
               border: 'none',
               padding: '4px 0',
               backgroundColor: 'transparent',
-              color: '#475569',
+              color: c.muted,
               fontSize: '13px',
             }}
             aria-expanded={detailsOpen}
@@ -278,13 +378,13 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
           {detailsOpen && (
             <div style={{ marginTop: '12px' }}>
-              <div style={{ fontSize: '12px', color: '#475569', marginBottom: '4px' }}>
+              <div style={{ fontSize: '12px', color: c.muted, marginBottom: '4px' }}>
                 Stack trace
               </div>
               <code style={codeStyle}>{String(error.stack ?? '(no stack available)')}</code>
               {errorInfo?.componentStack && (
                 <>
-                  <div style={{ fontSize: '12px', color: '#475569', margin: '12px 0 4px 0' }}>
+                  <div style={{ fontSize: '12px', color: c.muted, margin: '12px 0 4px 0' }}>
                     Component stack
                   </div>
                   <code style={codeStyle}>{String(errorInfo.componentStack)}</code>

--- a/tests/component/ErrorBoundary.test.tsx
+++ b/tests/component/ErrorBoundary.test.tsx
@@ -119,11 +119,10 @@ describe('ErrorBoundary', () => {
     expect(await screen.findByText('Copy failed')).toBeInTheDocument();
   });
 
-  it('"Reset and reload" clears BOTH session keys after confirmation (audit #6)', async () => {
+  it('"Reset and reload" clears BOTH session keys after the inline confirmation (audit #6)', async () => {
     const user = userEvent.setup();
     localStorage.setItem(STORAGE_KEYS.DOCUMENT_SESSION, 'compressed-session');
     localStorage.setItem(STORAGE_KEYS.DOCUMENT, 'manual-draft');
-    window.confirm = vi.fn().mockReturnValue(true);
     const reload = vi.fn();
     Object.defineProperty(window, 'location', {
       value: { ...window.location, reload },
@@ -136,17 +135,23 @@ describe('ErrorBoundary', () => {
         <Bomb />
       </ErrorBoundary>
     );
+    // Two-step flow: the first click only ARMS the in-app confirmation strip
+    // (no native window.confirm — it follows the OS theme, not the app's) and
+    // must not erase anything by itself.
     await user.click(screen.getByRole('button', { name: /erase saved draft and reload/i }));
+    expect(localStorage.getItem(STORAGE_KEYS.DOCUMENT_SESSION)).toBe('compressed-session');
+    expect(reload).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Erase and reload' }));
 
     expect(localStorage.getItem(STORAGE_KEYS.DOCUMENT_SESSION)).toBeNull();
     expect(localStorage.getItem(STORAGE_KEYS.DOCUMENT)).toBeNull();
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
-  it('"Reset and reload" is a no-op when the user cancels the confirm', async () => {
+  it('"Reset and reload" is a no-op when the user cancels the inline confirm', async () => {
     const user = userEvent.setup();
     localStorage.setItem(STORAGE_KEYS.DOCUMENT_SESSION, 'compressed-session');
-    window.confirm = vi.fn().mockReturnValue(false);
     const reload = vi.fn();
     Object.defineProperty(window, 'location', {
       value: { ...window.location, reload },
@@ -160,9 +165,28 @@ describe('ErrorBoundary', () => {
       </ErrorBoundary>
     );
     await user.click(screen.getByRole('button', { name: /erase saved draft and reload/i }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(localStorage.getItem(STORAGE_KEYS.DOCUMENT_SESSION)).toBe('compressed-session');
     expect(reload).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: 'Erase and reload' })).not.toBeInTheDocument();
+  });
+
+  it('matches the active color scheme instead of always rendering light', () => {
+    // Dark class on <html> is how the app applies dark mode (set pre-paint by
+    // index.html); the crash screen must follow it, not blast a white page.
+    document.documentElement.classList.add('dark');
+    try {
+      render(
+        <ErrorBoundary>
+          <Bomb />
+        </ErrorBoundary>
+      );
+      const page = screen.getByRole('alert');
+      expect(page.style.backgroundColor).toBe('#0b1120'); // dark, not #f8fafc
+    } finally {
+      document.documentElement.classList.remove('dark');
+    }
   });
 
   it('toggles the stack-trace details on demand', async () => {


### PR DESCRIPTION
## Why

User-reported: hitting a crash in dark mode blasts a **bright white page** — the top-level error boundary's recovery UI ("Something went wrong") always rendered a hardcoded light palette. Its "Reset and reload" confirmation was a native `window.confirm`, which follows the OS theme rather than the app's — a second mismatched white popup on the same screen.

## What

- **Theme-aware inline palette.** The fallback keeps its inline-styles-only constraint (its whole point is surviving a CSS regression) but now picks a light or dark palette from the `dark` class on `<html>` — set pre-paint by `index.html` from the saved theme with an OS fallback, so it's authoritative even when the stylesheet is what crashed. Dark renders `#0b1120` page / `#111827` card / dark red error chip / themed buttons.
- **Inline reset confirmation.** `window.confirm` is replaced with a dependency-free inline strip: the first click arms "This erases your auto-saved draft and reloads…" with **Erase and reload** / **Cancel**. Arming alone erases nothing.

## Verification

- Live: mounted the boundary around a deliberately-throwing component in the running app — dark renders the dark palette (screenshot-confirmed cohesive), light preserves the original palette exactly; confirm flow arms/cancels correctly.
- Tests: the two reset tests rewritten for the two-step flow (including that arming alone must NOT erase — the old cancel test passed by accident), plus a new regression test that dark mode renders the dark palette. ErrorBoundary suite 9/9, full suite 1512 passing, tsc + lint clean.
- Version 1.2.10 + CHANGELOG.

## Notes

- Stacked on #118 (its 1.2.9 bump precedes this one); GitHub will retarget this PR to `main` automatically when #118 merges.
- Out of scope: ~10 other native `alert()` calls across the app share the OS-theme mismatch — tracked for a separate cleanup.