### PR TITLE
feat(pwa): in-app install flow — prompt capture, device guide, banner, checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.12] — 2026-07-03
+
+### Added
+
+- DonDocs can now invite you to install it. Installing was always possible
+  but the app never offered: Help (and the mobile menu) gain an
+  **"Install app"** entry, a slim dismissible strip suggests installing where
+  it's actually possible (never a dead button — snoozes for two weeks, gone
+  forever once installed), and the getting-started checklist gains an
+  "Install the app" step. On Chrome/Edge the native install dialog opens
+  directly; everywhere else a short guide shows the exact steps for the
+  device — including iOS's Share → Add to Home Screen, which Safari never
+  offers on its own. The Android install splash now matches the app canvas
+  instead of flashing white. Everything is on-device; no network calls.
+
 ## [1.2.11] — 2026-07-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.11",
+  "version": "1.2.12",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import { LogViewerModal } from '@/components/modals/LogViewerModal';
 import { EnclosureErrorModal } from '@/components/modals/EnclosureErrorModal';
 import { ShareModal } from '@/components/modals/ShareModal';
 import { UpdatePromptModal } from '@/components/modals/UpdatePromptModal';
+import { InstallAppModal } from '@/components/modals/InstallAppModal';
 import { DownloadProgressModal } from '@/components/modals/DownloadProgressModal';
 import { CompileErrorModal } from '@/components/modals/CompileErrorModal';
 import {
@@ -43,6 +44,7 @@ import { parseShareUrl } from '@/lib/shareCrypto';
 import { BrowserCompatibilityNotice } from '@/components/BrowserCompatibilityNotice';
 import { StorageNotice } from '@/components/StorageNotice';
 import { BackupNotice } from '@/components/BackupNotice';
+import { InstallNotice } from '@/components/InstallNotice';
 import { probeStorageHealth } from '@/lib/documentsDb';
 const marineCodersLogo = `${import.meta.env.BASE_URL}attachments/marine-coders-logo.svg`;
 import { useUIStore } from '@/stores/uiStore';
@@ -79,7 +81,7 @@ import {
   PanelRight,
 } from 'lucide-react';
 import { useLogStore } from '@/stores/logStore';
-import { useLatexEngine, useServiceWorker } from '@/hooks';
+import { useLatexEngine, useServiceWorker, useInstallPrompt } from '@/hooks';
 import { usePandocIdlePrefetch } from '@/hooks/usePandocIdlePrefetch';
 import { generateAllLatexFiles, type GeneratedFiles } from '@/services/latex/generator';
 import { generateFlatLatex } from '@/services/latex/flat-generator';
@@ -244,6 +246,8 @@ function App() {
   const addLogDirect = useLogStore((s) => s.addLogDirect);
   const { isReady, compile, waitForReady, error: engineError } = useLatexEngine();
   const { showUpdatePrompt, confirmUpdate, dismissUpdatePrompt } = useServiceWorker();
+  // Capture beforeinstallprompt / appinstalled + seed standalone detection.
+  useInstallPrompt();
 
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [formPdfUrl, setFormPdfUrl] = useState<string | null>(null);
@@ -1821,6 +1825,7 @@ ${texFiles['body.tex'] || '% No body content'}
 
       <StorageNotice />
       <BackupNotice />
+      <InstallNotice />
 
       <div className="flex flex-1 overflow-hidden">
         {/* Document workspace (desktop). Sits beside the main editor so the
@@ -1940,6 +1945,7 @@ ${texFiles['body.tex'] || '% No body content'}
         onConfirm={confirmUpdate}
         onDismiss={dismissUpdatePrompt}
       />
+      <InstallAppModal />
       <DownloadProgressModal
         phase={downloadProgress}
         onClose={() => setDownloadProgress(null)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,9 +79,11 @@ import {
   Users,
   MoonStar,
   PanelRight,
+  MonitorDown,
 } from 'lucide-react';
 import { useLogStore } from '@/stores/logStore';
-import { useLatexEngine, useServiceWorker, useInstallPrompt } from '@/hooks';
+import { useLatexEngine, useServiceWorker, useInstallPrompt, promptInstall } from '@/hooks';
+import { useInstallStore } from '@/stores/installStore';
 import { usePandocIdlePrefetch } from '@/hooks/usePandocIdlePrefetch';
 import { generateAllLatexFiles, type GeneratedFiles } from '@/services/latex/generator';
 import { generateFlatLatex } from '@/services/latex/flat-generator';
@@ -248,6 +250,7 @@ function App() {
   const { showUpdatePrompt, confirmUpdate, dismissUpdatePrompt } = useServiceWorker();
   // Capture beforeinstallprompt / appinstalled + seed standalone detection.
   useInstallPrompt();
+  const isInstalled = useInstallStore((s) => s.isInstalled);
 
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [formPdfUrl, setFormPdfUrl] = useState<string | null>(null);
@@ -1701,6 +1704,17 @@ ${texFiles['body.tex'] || '% No body content'}
           icon: Link2,
           onRun: () => useUIStore.getState().setShareModal('import'),
         },
+        // Hidden once running as an installed app.
+        ...(!isInstalled
+          ? [
+              {
+                id: 'install-app',
+                label: 'Install app…',
+                icon: MonitorDown,
+                onRun: () => void promptInstall(),
+              },
+            ]
+          : []),
       ],
     });
 
@@ -1786,7 +1800,7 @@ ${texFiles['body.tex'] || '% No body content'}
     groups.push({ label: 'Insert', items: insertItems });
 
     return groups;
-  }, [outlineSections, allDocs, currentDocId]);
+  }, [outlineSections, allDocs, currentDocId, isInstalled]);
 
   return (
     <TooltipProvider>

--- a/src/components/InstallNotice.tsx
+++ b/src/components/InstallNotice.tsx
@@ -1,0 +1,60 @@
+import { useSyncExternalStore } from 'react';
+import { MonitorDown, X } from 'lucide-react';
+import { useInstallStore } from '@/stores/installStore';
+import { promptInstall, isInstallRelevant } from '@/hooks/useInstallPrompt';
+
+// The clock never pushes updates; snooze changes arrive via the zustand
+// re-render, which re-creates the snapshot closure below.
+const subscribeNever = () => () => {};
+
+/**
+ * Slim, dismissible install strip (the StorageNotice pattern). This is the
+ * affordance that carries MOBILE — the Help dropdown holding the "Install app"
+ * item is desktop-only — so it renders only where installing is actually
+ * possible (a captured Chromium prompt, or iOS's manual path), never as a dead
+ * suggestion. Dismissing snoozes it for ~14 days (persisted); installing
+ * retires it for good.
+ */
+export function InstallNotice() {
+  const canInstall = useInstallStore((s) => s.canInstall);
+  const isInstalled = useInstallStore((s) => s.isInstalled);
+  const dismissedUntil = useInstallStore((s) => s.dismissedUntil);
+  const snooze = useInstallStore((s) => s.snoozeBanner);
+  // Render must stay pure, so the Date.now comparison goes through
+  // useSyncExternalStore (the sanctioned escape hatch for reading a mutable
+  // external value — here, the clock — during render).
+  const snoozed = useSyncExternalStore(
+    subscribeNever,
+    () => dismissedUntil != null && Date.now() < dismissedUntil
+  );
+
+  if (snoozed || !isInstallRelevant(canInstall, isInstalled)) return null;
+
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-2 border-b border-border bg-muted/50 px-4 py-1 text-xs text-foreground"
+    >
+      <MonitorDown className="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden />
+      <p className="min-w-0 flex-1">
+        Install DonDocs for offline, one-tap access.{' '}
+        <span className="text-muted-foreground">No app store — it installs from this page.</span>
+      </p>
+      <button
+        type="button"
+        onClick={() => void promptInstall()}
+        className="shrink-0 rounded border border-border px-2 py-0.5 font-medium outline-none transition-colors hover:bg-accent focus-visible:ring-[3px] focus-visible:ring-ring/50"
+      >
+        Install
+      </button>
+      <button
+        type="button"
+        onClick={() => snooze()}
+        aria-label="Dismiss install suggestion"
+        className="shrink-0 rounded p-0.5 text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect, type ChangeEvent, type ReactNode } from 'react';
-import { Moon, Sun, Download, FileText, Braces, RefreshCw, Bug, Save, RotateCcw, Shield, HelpCircle, Info, Layers, Search, Keyboard, Menu, FileDown, FileUp, ScrollText, SlidersHorizontal, Minimize2, Maximize2, Check, Settings, Undo2, Redo2, Eraser, Compass, PanelRight, PanelRightClose, Link2, FileInput, X, Zap, Loader2, Lightbulb, FolderOpen, Rocket, FolderSync, AlertTriangle } from 'lucide-react';
+import { Moon, Sun, Download, FileText, Braces, RefreshCw, Bug, Save, RotateCcw, Shield, HelpCircle, Info, Layers, Search, Keyboard, Menu, FileDown, FileUp, ScrollText, SlidersHorizontal, Minimize2, Maximize2, Check, Settings, Undo2, Redo2, Eraser, Compass, PanelRight, PanelRightClose, Link2, FileInput, X, Zap, Loader2, Lightbulb, FolderOpen, Rocket, FolderSync, AlertTriangle, MonitorDown } from 'lucide-react';
 import { GithubIcon } from '@/components/icons/GithubIcon';
 import { Button } from '@/components/ui/button';
 import { Kbd } from '@/components/ui/kbd';
@@ -30,6 +30,8 @@ import { useFormStore } from '@/stores/formStore';
 import { useDocumentsStore } from '@/stores/documentsStore';
 import { buildBackup, restoreBackup, summarizeRestore } from '@/lib/backup';
 import { useBackupStore } from '@/stores/backupStore';
+import { useInstallStore } from '@/stores/installStore';
+import { promptInstall } from '@/hooks/useInstallPrompt';
 import { useHistoryStore } from '@/stores/historyStore';
 import { uint8ArrayToBase64, base64ToUint8Array, arrayBufferToUint8Array } from '@/lib/encoding';
 import { STORAGE_KEYS } from '@/lib/constants';
@@ -242,6 +244,7 @@ export function Header({
   // Synced-backup file (File System Access API).
   const saveMenuOpen = useUIStore((s) => s.saveMenuOpen);
   const setSaveMenuOpen = useUIStore((s) => s.setSaveMenuOpen);
+  const isInstalled = useInstallStore((s) => s.isInstalled);
   const backupStatus = useBackupStore((s) => s.status);
   const backupFileName = useBackupStore((s) => s.fileName);
   const setupBackup = useBackupStore((s) => s.setupBackup);
@@ -1025,6 +1028,12 @@ export function Header({
                   Getting started
                 </DropdownMenuItem>
               )}
+              {!isInstalled && (
+                <DropdownMenuItem onClick={() => void promptInstall()}>
+                  <MonitorDown className="h-4 w-4 mr-2" />
+                  Install app
+                </DropdownMenuItem>
+              )}
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => setNistModalOpen(true)}>
                 <Shield className="h-4 w-4 mr-2" />
@@ -1182,6 +1191,12 @@ export function Header({
                 <DropdownMenuItem onClick={reopenChecklist}>
                   <Rocket className="h-4 w-4 mr-2" />
                   Getting started
+                </DropdownMenuItem>
+              )}
+              {!isInstalled && (
+                <DropdownMenuItem onClick={() => void promptInstall()}>
+                  <MonitorDown className="h-4 w-4 mr-2" />
+                  Install app
                 </DropdownMenuItem>
               )}
               <DropdownMenuItem onClick={() => setNistModalOpen(true)}>

--- a/src/components/modals/InstallAppModal.tsx
+++ b/src/components/modals/InstallAppModal.tsx
@@ -1,0 +1,162 @@
+/**
+ * Install instructions modal — the fallback whenever the native install prompt
+ * isn't available (promptInstall() fires the native dialog directly when it
+ * is). Content branches on the device, because every platform installs
+ * differently and several (iOS!) never fire `beforeinstallprompt`:
+ *
+ *  - in-app browser (FB/IG/etc.) → escape to a real browser first
+ *  - iOS Safari                  → Share → Add to Home Screen → Add
+ *  - iOS Chrome/Firefox          → installs only from Safari; open there
+ *  - Android Chromium            → browser menu → "Add to Home screen"
+ *  - desktop Chromium            → install icon in the address bar / menu
+ *  - macOS Safari                → File → Add to Dock
+ *  - elsewhere (Firefox desktop) → honest "not supported here"
+ *
+ * All static in-app text + inline SVG — no network, air-gap safe.
+ */
+import { MonitorDown, Compass } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { useInstallStore } from '@/stores/installStore';
+import { useDeviceInfo } from '@/utils/device';
+
+/** iOS Safari's share glyph (square with an up arrow), inline so the step
+ *  reads visually without fetching anything. */
+function ShareGlyph() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="inline h-4 w-4 align-text-bottom text-primary"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 3v12" />
+      <path d="M8 7l4-4 4 4" />
+      <path d="M5 11v8a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-8" />
+    </svg>
+  );
+}
+
+function Steps({ items }: { items: React.ReactNode[] }) {
+  return (
+    <ol className="space-y-2.5">
+      {items.map((step, i) => (
+        <li key={i} className="flex items-start gap-2.5 text-sm">
+          <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium tabular-nums">
+            {i + 1}
+          </span>
+          <span className="leading-snug">{step}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export function InstallAppModal() {
+  const open = useInstallStore((s) => s.installModalOpen);
+  const setOpen = useInstallStore((s) => s.setInstallModalOpen);
+  const d = useDeviceInfo();
+
+  let body: React.ReactNode;
+  if (d.isInAppBrowser) {
+    body = (
+      <Steps
+        items={[
+          <>Tap the <strong>⋮</strong> or share button in this app&apos;s browser.</>,
+          <>Choose <strong>{d.isIOS ? 'Open in Safari' : 'Open in Chrome'}</strong>.</>,
+          <>Then install from there — on {d.isIOS ? 'iOS: Share → Add to Home Screen' : 'Android: menu → Add to Home screen'}.</>,
+        ]}
+      />
+    );
+  } else if (d.isIOS && d.isRealSafari) {
+    body = (
+      <Steps
+        items={[
+          <>Tap the <strong>Share</strong> button <ShareGlyph /> in Safari&apos;s toolbar.</>,
+          <>Scroll down and tap <strong>Add to Home Screen</strong>.</>,
+          <>Tap <strong>Add</strong>. DonDocs opens full-screen from its own icon, ready offline.</>,
+        ]}
+      />
+    );
+  } else if (d.isIOS) {
+    body = (
+      <div className="space-y-3">
+        <p className="text-sm">
+          On iPhone and iPad, apps install from <strong>Safari</strong> only.
+        </p>
+        <Steps
+          items={[
+            <>Open this page in <strong>Safari</strong>.</>,
+            <>Tap the <strong>Share</strong> button <ShareGlyph />, then <strong>Add to Home Screen</strong>.</>,
+            <>Tap <strong>Add</strong>.</>,
+          ]}
+        />
+      </div>
+    );
+  } else if (d.isAndroid) {
+    body = (
+      <Steps
+        items={[
+          <>Open the browser&apos;s <strong>⋮</strong> menu.</>,
+          <>Tap <strong>Add to Home screen</strong> (or <strong>Install app</strong>).</>,
+          <>Confirm. DonDocs opens full-screen from its own icon, ready offline.</>,
+        ]}
+      />
+    );
+  } else if (d.isChrome || d.isEdge) {
+    body = (
+      <Steps
+        items={[
+          <>Look for the <strong>install icon</strong> <MonitorDown className="inline h-4 w-4 align-text-bottom text-primary" aria-hidden /> at the right end of the address bar.</>,
+          <>Or open the browser menu and choose <strong>Install DonDocs…</strong> (sometimes under &quot;Cast, save and share&quot;).</>,
+          <>Confirm. DonDocs opens in its own window, ready offline.</>,
+        ]}
+      />
+    );
+  } else if (d.isSafari) {
+    body = (
+      <Steps
+        items={[
+          <>In Safari&apos;s menu bar, choose <strong>File → Add to Dock…</strong></>,
+          <>Confirm. DonDocs opens from your Dock in its own window.</>,
+        ]}
+      />
+    );
+  } else {
+    body = (
+      <p className="text-sm text-muted-foreground">
+        This browser doesn&apos;t support installing web apps. Open DonDocs in
+        Chrome, Edge, or Safari to install it — or keep using it right here;
+        everything works the same in a tab.
+      </p>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-md w-[calc(100vw-2rem)]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Compass className="h-5 w-5 text-primary shrink-0" aria-hidden />
+            Install DonDocs
+          </DialogTitle>
+          <DialogDescription>
+            Installs straight from this page — no app store, no account, and
+            nothing leaves your device. You get a real app icon and one-tap
+            offline access.
+          </DialogDescription>
+        </DialogHeader>
+        {body}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/onboarding/ActivationChecklist.tsx
+++ b/src/components/onboarding/ActivationChecklist.tsx
@@ -8,6 +8,7 @@ import {
   UserPlus,
   FileText,
   FolderSync,
+  MonitorDown,
   Compass,
   CheckCircle2,
   type LucideIcon,
@@ -17,6 +18,8 @@ import { ProgressRing } from './ProgressRing';
 import { useOnboardingStore } from '@/stores/onboardingStore';
 import { useProfileStore } from '@/stores/profileStore';
 import { useBackupStore } from '@/stores/backupStore';
+import { useInstallStore } from '@/stores/installStore';
+import { promptInstall, isInstallRelevant } from '@/hooks/useInstallPrompt';
 import { useTourStore, GUIDED_TOUR_KEY } from '@/stores/tourStore';
 import { useUIStore } from '@/stores/uiStore';
 
@@ -52,6 +55,8 @@ export function ActivationChecklist() {
   const completed = useOnboardingStore((s) => s.completed);
   const profiles = useProfileStore((s) => s.profiles);
   const backupStatus = useBackupStore((s) => s.status);
+  const canInstall = useInstallStore((s) => s.canInstall);
+  const isInstalled = useInstallStore((s) => s.isInstalled);
   const dismissed = useOnboardingStore((s) => s.checklistDismissed);
   const celebrated = useOnboardingStore((s) => s.checklistCelebrated);
   const setDismissed = useOnboardingStore((s) => s.setChecklistDismissed);
@@ -115,6 +120,20 @@ export function ActivationChecklist() {
         useUIStore.getState().setDocumentGuideOpen(true);
       },
     },
+    // Only where installing is actually possible (captured prompt, iOS's
+    // manual path, or already done) — a platform that can't install must not
+    // carry a forever-incomplete step that blocks the celebration.
+    ...(isInstalled || isInstallRelevant(canInstall, isInstalled)
+      ? [
+          {
+            glyph: MonitorDown,
+            title: 'Install the app',
+            sub: 'One-tap offline access from its own icon',
+            done: isInstalled,
+            action: () => void promptInstall(),
+          } satisfies ChecklistRow,
+        ]
+      : []),
     {
       glyph: Compass,
       title: 'Explore the power features',

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,4 @@ export { useLatexEngine } from './useLatexEngine';
 export { useStatusMessage } from './useStatusMessage';
 export { useServiceWorker } from './useServiceWorker';
 export { useReducedMotion } from './useReducedMotion';
+export { useInstallPrompt, promptInstall, isInstallRelevant } from './useInstallPrompt';

--- a/src/hooks/useInstallPrompt.ts
+++ b/src/hooks/useInstallPrompt.ts
@@ -1,0 +1,94 @@
+import { useEffect } from 'react';
+import { useInstallStore, type BeforeInstallPromptEvent } from '@/stores/installStore';
+import { getDeviceInfo } from '@/utils/device';
+import { debug } from '@/lib/debug';
+
+/**
+ * Owns the install-to-device listeners; mount ONCE in App (next to
+ * useServiceWorker). Captures Chromium's `beforeinstallprompt` (with
+ * preventDefault, which also suppresses Chrome's own mini-infobar so the app
+ * controls when to ask), tracks `appinstalled`, and seeds the installed state
+ * from the display mode.
+ *
+ * IMPORTANT: `beforeinstallprompt` fires far less than expected — never on
+ * Safari/iOS/Firefox and often not on locked-down enterprise Chrome/Edge
+ * (NMCI!). `canInstall` is false more often than true, so install UI must
+ * never render a dead button: promptInstall() falls back to the instructions
+ * modal whenever there is no captured prompt.
+ *
+ * Every API here is a local browser API — no network, air-gap safe.
+ */
+
+/** Running as an installed app right now (Chromium standalone / iOS standalone). */
+export function isStandalone(): boolean {
+  try {
+    return (
+      window.matchMedia('(display-mode: standalone)').matches ||
+      // iOS Safari's pre-standard flag for Add-to-Home-Screen apps.
+      (navigator as unknown as { standalone?: boolean }).standalone === true
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function useInstallPrompt(): void {
+  useEffect(() => {
+    const store = useInstallStore.getState();
+    store.setInstalled(isStandalone());
+
+    const onBeforeInstallPrompt = (e: Event) => {
+      e.preventDefault();
+      useInstallStore.getState().setDeferredPrompt(e as BeforeInstallPromptEvent);
+      debug.log('Install', 'beforeinstallprompt captured');
+    };
+    const onAppInstalled = () => {
+      useInstallStore.getState().setInstalled(true);
+      debug.log('Install', 'appinstalled');
+    };
+
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+    window.addEventListener('appinstalled', onAppInstalled);
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+      window.removeEventListener('appinstalled', onAppInstalled);
+    };
+  }, []);
+}
+
+/**
+ * The one entry point every install control calls. With a captured prompt →
+ * fire the native install dialog (single-use; cleared afterwards either way).
+ * Without one (iOS, Firefox, enterprise policy, already dismissed by the
+ * browser) → open the device-branched instructions modal instead.
+ */
+export async function promptInstall(): Promise<void> {
+  const { deferredPrompt, setDeferredPrompt, setInstallModalOpen } = useInstallStore.getState();
+  if (!deferredPrompt) {
+    setInstallModalOpen(true);
+    return;
+  }
+  try {
+    await deferredPrompt.prompt();
+    const choice = await deferredPrompt.userChoice;
+    debug.log('Install', 'native prompt outcome', choice);
+  } catch (err) {
+    // A consumed/stale event throws; fall back to instructions rather than dead-end.
+    debug.error('Install', 'native prompt failed', err);
+    useInstallStore.getState().setInstallModalOpen(true);
+  } finally {
+    // The event is single-use regardless of outcome.
+    setDeferredPrompt(null);
+  }
+}
+
+/** Whether any install affordance should show at all: hidden once installed,
+ *  and on platforms with neither a prompt nor a manual path worth teaching. */
+export function isInstallRelevant(canInstall: boolean, isInstalled: boolean): boolean {
+  if (isInstalled) return false;
+  if (canInstall) return true;
+  const d = getDeviceInfo();
+  // iOS always has the manual Add-to-Home-Screen path; other prompt-less
+  // platforms (desktop Firefox…) have no PWA install story worth a banner.
+  return d.isIOS;
+}

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -10,3 +10,4 @@ export { useHistoryStore, type DocumentSnapshot } from './historyStore';
 export { useLogStore, type LogEntry } from './logStore';
 export { useProfileStore } from './profileStore';
 export { useUIStore, type DensityMode, type ColorScheme } from './uiStore';
+export { useInstallStore } from './installStore';

--- a/src/stores/installStore.ts
+++ b/src/stores/installStore.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { safeLocalStorage } from '@/lib/compressedStorage';
+
+/**
+ * Install-to-device state. Chromium's `beforeinstallprompt` event is captured
+ * here (useInstallPrompt owns the listeners) so an in-app "Install" control can
+ * fire the native prompt on demand — the event is single-use, live-only, and
+ * non-serializable, so it must NEVER enter storage. Only the banner snooze is
+ * persisted.
+ *
+ * Everything here is a local browser API — no network, air-gap safe.
+ */
+
+/** Chromium's non-standard install event (not in lib.dom). */
+export type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+};
+
+interface InstallState {
+  /** Captured live event — cleared after use (it can only prompt once). */
+  deferredPrompt: BeforeInstallPromptEvent | null;
+  /** A captured prompt is available → the native install dialog can be shown. */
+  canInstall: boolean;
+  /** Running as an installed app (standalone display-mode / iOS standalone). */
+  isInstalled: boolean;
+  /** Passive banner snooze (epoch ms); persisted so a dismissal survives reloads. */
+  dismissedUntil: number | null;
+  /** The device-branched instructions modal (iOS / no-prompt fallback). */
+  installModalOpen: boolean;
+  setDeferredPrompt: (e: BeforeInstallPromptEvent | null) => void;
+  setInstalled: (v: boolean) => void;
+  snoozeBanner: (days?: number) => void;
+  setInstallModalOpen: (open: boolean) => void;
+}
+
+export const useInstallStore = create<InstallState>()(
+  persist(
+    (set) => ({
+      deferredPrompt: null,
+      canInstall: false,
+      isInstalled: false,
+      dismissedUntil: null,
+      installModalOpen: false,
+      setDeferredPrompt: (e) => set({ deferredPrompt: e, canInstall: e !== null }),
+      setInstalled: (v) =>
+        set(v ? { isInstalled: true, deferredPrompt: null, canInstall: false } : { isInstalled: v }),
+      snoozeBanner: (days = 14) => set({ dismissedUntil: Date.now() + days * 24 * 60 * 60 * 1000 }),
+      setInstallModalOpen: (open) => set({ installModalOpen: open }),
+    }),
+    {
+      name: 'dondocs-install',
+      storage: createJSONStorage(() => safeLocalStorage),
+      // ONLY the snooze — the live event object and derived flags must never persist.
+      partialize: (s) => ({ dismissedUntil: s.dismissedUntil }),
+    }
+  )
+);

--- a/tests/unit/installPrompt.test.ts
+++ b/tests/unit/installPrompt.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Device detection is the only environment-dependent input to the gating
+// logic; drive it per-test.
+const deviceInfo = { isIOS: false };
+vi.mock('@/utils/device', () => ({
+  getDeviceInfo: () => deviceInfo,
+}));
+
+import { useInstallStore, type BeforeInstallPromptEvent } from '@/stores/installStore';
+import { promptInstall, isInstallRelevant } from '@/hooks/useInstallPrompt';
+
+function fakePrompt(over: Partial<BeforeInstallPromptEvent> = {}): BeforeInstallPromptEvent {
+  return {
+    prompt: vi.fn(async () => {}),
+    userChoice: Promise.resolve({ outcome: 'accepted' as const }),
+    ...over,
+  } as unknown as BeforeInstallPromptEvent;
+}
+
+beforeEach(() => {
+  deviceInfo.isIOS = false;
+  localStorage.clear();
+  useInstallStore.setState({
+    deferredPrompt: null,
+    canInstall: false,
+    isInstalled: false,
+    dismissedUntil: null,
+    installModalOpen: false,
+  });
+});
+
+describe('installStore transitions', () => {
+  it('capturing a prompt flips canInstall; clearing it flips back', () => {
+    const s = useInstallStore.getState();
+    s.setDeferredPrompt(fakePrompt());
+    expect(useInstallStore.getState().canInstall).toBe(true);
+    s.setDeferredPrompt(null);
+    expect(useInstallStore.getState().canInstall).toBe(false);
+  });
+
+  it('installing retires the captured prompt (it can never fire post-install)', () => {
+    const s = useInstallStore.getState();
+    s.setDeferredPrompt(fakePrompt());
+    s.setInstalled(true);
+    const st = useInstallStore.getState();
+    expect(st.isInstalled).toBe(true);
+    expect(st.deferredPrompt).toBeNull();
+    expect(st.canInstall).toBe(false);
+  });
+
+  it('snoozeBanner sets a future timestamp (default ~14 days)', () => {
+    useInstallStore.getState().snoozeBanner();
+    const until = useInstallStore.getState().dismissedUntil!;
+    expect(until).toBeGreaterThan(Date.now() + 13 * 24 * 60 * 60 * 1000);
+    expect(until).toBeLessThan(Date.now() + 15 * 24 * 60 * 60 * 1000);
+  });
+
+  it('persists ONLY the snooze — never the live event or derived flags', () => {
+    const s = useInstallStore.getState();
+    s.setDeferredPrompt(fakePrompt());
+    s.snoozeBanner();
+    const persisted = JSON.parse(localStorage.getItem('dondocs-install') ?? '{}');
+    expect(Object.keys(persisted.state ?? {})).toEqual(['dismissedUntil']);
+  });
+});
+
+describe('promptInstall — never a dead end', () => {
+  it('fires the native prompt when one is captured, then consumes the single-use event', async () => {
+    const ev = fakePrompt();
+    useInstallStore.getState().setDeferredPrompt(ev);
+    await promptInstall();
+    expect(ev.prompt).toHaveBeenCalledTimes(1);
+    expect(useInstallStore.getState().deferredPrompt).toBeNull();
+    expect(useInstallStore.getState().installModalOpen).toBe(false); // native path, no modal
+  });
+
+  it('opens the instructions modal when no prompt was ever captured (iOS/Firefox/enterprise)', async () => {
+    await promptInstall();
+    expect(useInstallStore.getState().installModalOpen).toBe(true);
+  });
+
+  it('falls back to the modal when a stale/consumed event throws', async () => {
+    const ev = fakePrompt({ prompt: vi.fn(async () => Promise.reject(new Error('already used'))) });
+    useInstallStore.getState().setDeferredPrompt(ev);
+    await promptInstall();
+    expect(useInstallStore.getState().installModalOpen).toBe(true);
+    expect(useInstallStore.getState().deferredPrompt).toBeNull(); // still consumed
+  });
+});
+
+describe('isInstallRelevant — where install affordances may appear', () => {
+  it('never once installed', () => {
+    expect(isInstallRelevant(true, true)).toBe(false);
+    expect(isInstallRelevant(false, true)).toBe(false);
+  });
+
+  it('with a captured prompt', () => {
+    expect(isInstallRelevant(true, false)).toBe(true);
+  });
+
+  it('on iOS even without a prompt (manual Add-to-Home-Screen path)', () => {
+    deviceInfo.isIOS = true;
+    expect(isInstallRelevant(false, false)).toBe(true);
+  });
+
+  it('nowhere else — no dead suggestions on prompt-less desktops', () => {
+    deviceInfo.isIOS = false;
+    expect(isInstallRelevant(false, false)).toBe(false);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -232,7 +232,9 @@ export default defineConfig({
         // Matches index.html's light theme-color meta (the manifest can't be
         // media-queried, so it carries the light value; the metas handle dark).
         theme_color: '#f1f6fa',
-        background_color: '#ffffff',
+        // Android's install splash background — match the app canvas so launch
+        // doesn't flash pure white before first paint.
+        background_color: '#f1f6fa',
         display: 'standalone',
         orientation: 'portrait',
         scope: '/',


### PR DESCRIPTION
## Why

Part 2 of the install flow (part 1 = #120, the icons/meta prereqs). Installing DonDocs was always technically possible, but the app never offered it: nothing listened for the browser's install signal, Chrome's affordance hides in the address bar, and **iOS — which never volunteers PWA installs — got literally nothing**. The audit called this the app's single biggest competitive gap: for a local-first tool, the installed app *is* the retention surface, and it doubles as the offline story for the SIPR/JWICS audience.

## What

**`installStore` + `useInstallPrompt`** — captures `beforeinstallprompt` (with `preventDefault`, so Chrome's mini-infobar defers to the app), tracks `appinstalled`, seeds installed state from standalone display-mode. The live event is single-use and non-serializable; only the banner snooze persists (partialize whitelist).

**The key design rule:** `beforeinstallprompt` fires far less than expected — never on Safari/iOS/Firefox, often not on locked-down enterprise Chrome/Edge (NMCI). So `promptInstall()` never dead-ends: with a captured prompt it opens the **native install dialog** directly; otherwise the device-branched **`InstallAppModal`**:

| Device | Guide |
|---|---|
| iOS Safari | Share <kbd>⬆︎</kbd> → Add to Home Screen → Add (inline SVG glyph) |
| iOS Chrome/Firefox | installs come from Safari — open there first |
| In-app browser (FB/IG) | escape to a real browser first |
| Android | browser menu → Add to Home screen |
| Desktop Chrome/Edge | address-bar install icon / menu → Install DonDocs… |
| macOS Safari | File → Add to Dock |
| Elsewhere | honest "not supported — keep using it in a tab" |

**Placements, persistent but non-nagging:**
- **Help dropdown + mobile hamburger menu**: "Install app" item, hidden once installed
- **`InstallNotice`**: slim dismissible strip (the StorageNotice pattern) — the affordance that carries mobile, since the Help dropdown is desktop-only. Renders **only where installing is actually possible** (captured prompt or iOS's manual path — never a dead suggestion on desktop Firefox); ✕ snoozes 14 days (persisted); installing retires it forever
- **Getting-started checklist**: "Install the app" step (pill now up to 6 steps), included only where install is possible so no platform carries a forever-incomplete row blocking the celebration

Plus: manifest `background_color` aligned to the app canvas so the Android install splash doesn't flash white (flagged in #120's review).

All local browser APIs — zero network calls, air-gap safe; `check-no-cdn` passes.

## Verification (live in the browser, every state)

- Banner: hidden by default (no prompt, desktop) → **appears** when a prompt is captured → ✕ **snoozes** (persisted to `dondocs-install`) → gone
- No-prompt path: `promptInstall()` → **modal opens** with the correct desktop-Chromium branch (screenshot)
- Captured-prompt path: **native `prompt()` fired**, event consumed (`deferredPrompt` cleared, `canInstall` false), no modal
- Help item present when not installed / **hidden when installed** (verified at xl viewport — the earlier sub-xl read was vacuous and re-run properly)
- Checklist: "Install the app" row appears when installable (pill 1/6), marked done when installed; banner gone once installed
- React Compiler purity rules honored (`Date.now` via `useSyncExternalStore`)
- Full suite **1516 passing**, tsc + lint clean, build + `check-no-cdn` OK. Version 1.2.12 + CHANGELOG.

Together with #120 this closes UX-audit ask #1 (the install flow) — the last of the audit's three headline gaps with committed work is mobile onboarding.