### PR TITLE
fix(design): one focus ring, working semantic tokens, AA contrast, navy shadows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.13] — 2026-07-03
+
+### Fixed
+
+- Readability failures on the labels that matter most: the TOP SECRET and
+  TOP SECRET//SCI classification labels (2.3:1 and 3.0:1 against a light
+  card — both WCAG AA failures) and the NIST modal's "Development Domain"
+  warning heading (2.9:1) now use darkened text that clears 4.5:1, while the
+  bright banner colors remain for fills. The labels on "Reset Everything" /
+  "Discard Changes" confirm buttons rendered near-black on dark red because
+  their text token was never defined; it now resolves to white (12.5:1).
+- One focus ring everywhere: 28 controls drew a thinner 2px keyboard-focus
+  ring than the app's 3px standard (so tabbing visibly changed the ring),
+  one drew an amber ring, and three icon buttons had no ring at all.
+- Cards and every dialog now use the app's navy-tinted elevation instead of
+  bespoke pure-black shadows that read as grey smudges on the light canvas.
+- Status greens and warning ambers are driven by semantic theme tokens
+  (`--success` was defined but never wired; `--warning` didn't exist), so
+  they stay consistent across all color schemes.
+
 ## [1.2.12] — 2026-07-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.12",
+  "version": "1.2.13",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/BackupNotice.tsx
+++ b/src/components/BackupNotice.tsx
@@ -45,7 +45,7 @@ export function BackupNotice() {
       <button
         type="button"
         onClick={() => void onAction()}
-        className="shrink-0 rounded px-2 py-0.5 font-medium text-amber-700 underline-offset-2 outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring/50 dark:text-amber-300"
+        className="shrink-0 rounded px-2 py-0.5 font-medium text-amber-700 underline-offset-2 outline-none hover:underline focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:text-amber-300"
       >
         {actionLabel}
       </button>
@@ -53,7 +53,7 @@ export function BackupNotice() {
         type="button"
         onClick={() => setDismissedStatus(status)}
         aria-label="Dismiss backup notice"
-        className="shrink-0 rounded p-0.5 text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+        className="shrink-0 rounded p-0.5 text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
       >
         <X className="h-3.5 w-3.5" />
       </button>

--- a/src/components/SaveStatus.tsx
+++ b/src/components/SaveStatus.tsx
@@ -66,7 +66,7 @@ export function SaveStatus({ className }: { className?: string }) {
   const backedUp = backupStatus === 'connected' && lastBackupAt != null;
   return (
     <span className={`inline-flex items-center gap-1 ${base}`}>
-      <Check className="h-3 w-3 text-[var(--success)]" aria-hidden />
+      <Check className="h-3 w-3 text-success" aria-hidden />
       Saved · {savedAgo(lastSavedAt)}
       {backedUp && (
         <span

--- a/src/components/StorageNotice.tsx
+++ b/src/components/StorageNotice.tsx
@@ -40,7 +40,7 @@ export function StorageNotice() {
         type="button"
         onClick={dismiss}
         aria-label="Dismiss storage notice"
-        className="shrink-0 rounded p-0.5 text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+        className="shrink-0 rounded p-0.5 text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
       >
         <X className="h-3.5 w-3.5" />
       </button>

--- a/src/components/editor/AddressingSection.tsx
+++ b/src/components/editor/AddressingSection.tsx
@@ -359,7 +359,7 @@ export function AddressingSection({ config }: AddressingSectionProps) {
                   onChange={(e) => setField('to', e.target.value)}
                   aria-invalid={validationVisible && unfilled(formData.to) ? true : undefined}
                   placeholder="Mr. John Smith&#10;Director of Operations&#10;ABC Company&#10;123 Main Street&#10;City, State ZIP"
-                  className="flex min-h-[100px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20"
+                  className="flex min-h-[100px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20"
                   rows={5}
                 />
                 <p className="text-xs text-muted-foreground flex items-center gap-1">

--- a/src/components/editor/BlockParagraphsEditor.tsx
+++ b/src/components/editor/BlockParagraphsEditor.tsx
@@ -451,7 +451,7 @@ export function BlockParagraphsEditor() {
                     <button
                       type="button"
                       onClick={() => insertClause(sn.text)}
-                      className="min-w-0 flex-1 rounded-md px-2 py-1.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                      className="min-w-0 flex-1 rounded-md px-2 py-1.5 text-left outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
                     >
                       <span className="block truncate text-sm text-foreground">{sn.name}</span>
                       <span className="block truncate text-[11px] text-muted-foreground">{sn.text}</span>
@@ -487,7 +487,7 @@ export function BlockParagraphsEditor() {
                   }
                   setClausesOpen(false);
                 }}
-                className="w-full rounded-md px-2 py-1.5 text-left text-sm text-foreground outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-40 disabled:hover:bg-transparent"
+                className="w-full rounded-md px-2 py-1.5 text-left text-sm text-foreground outline-none hover:bg-muted focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-40 disabled:hover:bg-transparent"
               >
                 Save last paragraph as a clause
               </button>

--- a/src/components/editor/ClassificationSection.tsx
+++ b/src/components/editor/ClassificationSection.tsx
@@ -27,22 +27,25 @@ const CLASSIFICATION_LEVELS = [
   { value: 'cui', label: 'CUI (Controlled Unclassified Information)', color: 'text-[#502B85] dark:text-[#9572D4]' },
   { value: 'confidential', label: 'CONFIDENTIAL', color: 'text-[#0033A0] dark:text-[#5B7FD9]' },
   { value: 'secret', label: 'SECRET', color: 'text-[#C8102E] dark:text-[#E74C5C]' },
-  { value: 'top_secret', label: 'TOP SECRET', color: 'text-[#FF8C00] dark:text-[#FFA940]' },
-  // TS//SCI's banner yellow (#FCE83A) is too low-contrast as text on white,
-  // so use a darker amber here; the bright yellow stays for fills/tints.
-  { value: 'top_secret_sci', label: 'TOP SECRET//SCI', color: 'text-[#A8920E] dark:text-[#FCE83A]' },
+  // TOP SECRET's banner orange (#FF8C00, 2.3:1) and the TS//SCI amber
+  // (#A8920E, 3.0:1) fail WCAG AA as text on the light card — on the very
+  // labels that must be unmissable. Text uses darkened variants (≥4.5:1 on the
+  // card AND on the /10–/20 tints); the bright banner colors stay for
+  // fills/tints only. Dark-mode variants sit on the deep canvas and pass as-is.
+  { value: 'top_secret', label: 'TOP SECRET', color: 'text-[#B45309] dark:text-[#FFA940]' },
+  { value: 'top_secret_sci', label: 'TOP SECRET//SCI', color: 'text-[#756808] dark:text-[#FCE83A]' },
 ];
 
 // Quick-fill presets for the Custom Classification field. Tinted backgrounds use
-// the CNSI/ISOO colors above so each button reads as a mini banner. SCI text uses
-// the darker #A8920E amber to stay readable on its yellow tint in light mode.
+// the CNSI/ISOO banner colors so each button reads as a mini banner; the TOP
+// SECRET / SCI label text uses the darkened AA-safe variants from above.
 const CLASSIFICATION_PRESETS = [
   { value: 'UNCLASSIFIED',    label: 'Unclassified',    color: 'text-[#007A33] dark:text-[#3DBE6B]', bg: 'bg-[#007A33]/10 dark:bg-[#007A33]/20 border-[#007A33]/30 hover:bg-[#007A33]/20 dark:hover:bg-[#007A33]/30' },
   { value: 'CUI',             label: 'CUI',             color: 'text-[#502B85] dark:text-[#9572D4]', bg: 'bg-[#502B85]/10 dark:bg-[#502B85]/20 border-[#502B85]/30 hover:bg-[#502B85]/20 dark:hover:bg-[#502B85]/30' },
   { value: 'CONFIDENTIAL',    label: 'CONFIDENTIAL',    color: 'text-[#0033A0] dark:text-[#5B7FD9]', bg: 'bg-[#0033A0]/10 dark:bg-[#0033A0]/20 border-[#0033A0]/30 hover:bg-[#0033A0]/20 dark:hover:bg-[#0033A0]/30' },
   { value: 'SECRET',          label: 'SECRET',          color: 'text-[#C8102E] dark:text-[#E74C5C]', bg: 'bg-[#C8102E]/10 dark:bg-[#C8102E]/20 border-[#C8102E]/30 hover:bg-[#C8102E]/20 dark:hover:bg-[#C8102E]/30' },
-  { value: 'TOP SECRET',      label: 'TOP SECRET',      color: 'text-[#FF8C00] dark:text-[#FFA940]', bg: 'bg-[#FF8C00]/10 dark:bg-[#FF8C00]/20 border-[#FF8C00]/30 hover:bg-[#FF8C00]/20 dark:hover:bg-[#FF8C00]/30' },
-  { value: 'TOP SECRET//SCI', label: 'TOP SECRET//SCI', color: 'text-[#A8920E] dark:text-[#FCE83A]', bg: 'bg-[#FCE83A]/20 dark:bg-[#FCE83A]/20 border-[#A8920E]/40 hover:bg-[#FCE83A]/40 dark:hover:bg-[#FCE83A]/30' },
+  { value: 'TOP SECRET',      label: 'TOP SECRET',      color: 'text-[#B45309] dark:text-[#FFA940]', bg: 'bg-[#FF8C00]/10 dark:bg-[#FF8C00]/20 border-[#FF8C00]/30 hover:bg-[#FF8C00]/20 dark:hover:bg-[#FF8C00]/30' },
+  { value: 'TOP SECRET//SCI', label: 'TOP SECRET//SCI', color: 'text-[#756808] dark:text-[#FCE83A]', bg: 'bg-[#FCE83A]/20 dark:bg-[#FCE83A]/20 border-[#A8920E]/40 hover:bg-[#FCE83A]/40 dark:hover:bg-[#FCE83A]/30' },
 ];
 
 const CUI_CATEGORIES = [

--- a/src/components/editor/EndorsementBasicLetterSection.tsx
+++ b/src/components/editor/EndorsementBasicLetterSection.tsx
@@ -151,7 +151,7 @@ export function EndorsementBasicLetterSection() {
                           <button
                             type="button"
                             onClick={() => applyBasicLetter(d.meta)}
-                            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left outline-none hover:bg-muted/60 focus-visible:ring-2 focus-visible:ring-ring/50"
+                            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left outline-none hover:bg-muted/60 focus-visible:ring-[3px] focus-visible:ring-ring/50"
                           >
                             <span className="inline-flex h-4 shrink-0 items-center justify-center rounded bg-muted px-1 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground" style={{ minWidth: '2.4rem' }}>
                               {docTypeChip(d.meta.docType)}
@@ -175,7 +175,7 @@ export function EndorsementBasicLetterSection() {
                       type="button"
                       onClick={() => setApplied(null)}
                       aria-label="Dismiss basic-letter summary"
-                      className="shrink-0 rounded p-0.5 text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+                      className="shrink-0 rounded p-0.5 text-muted-foreground outline-none hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
                     >
                       <X className="h-3.5 w-3.5" />
                     </button>

--- a/src/components/layout/EditorSidebar.tsx
+++ b/src/components/layout/EditorSidebar.tsx
@@ -243,7 +243,7 @@ export function EditorSidebar() {
             onClick={toggleSidebar}
             aria-label="Collapse sidebar"
             aria-expanded={true}
-            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
           >
             <PanelLeftClose className="h-4 w-4" />
           </button>
@@ -263,7 +263,7 @@ export function EditorSidebar() {
               onClick={() => setSort((s) => (s === 'recent' ? 'name' : 'recent'))}
               aria-label={sort === 'recent' ? 'Sort by name' : 'Sort by most recent'}
               title={sort === 'recent' ? 'Sorted by most recent — switch to A–Z' : 'Sorted A–Z — switch to most recent'}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 transition-colors"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 transition-colors"
             >
               {sort === 'recent' ? <Clock className="h-3.5 w-3.5" /> : <ArrowDownAZ className="h-3.5 w-3.5" />}
             </button>
@@ -272,7 +272,7 @@ export function EditorSidebar() {
               onClick={() => (selectMode ? exitSelectMode() : setSelectMode(true))}
               aria-pressed={selectMode}
               title={selectMode ? 'Exit selection' : 'Select multiple documents'}
-              className={`inline-flex h-7 w-7 items-center justify-center rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring/50 transition-colors ${
+              className={`inline-flex h-7 w-7 items-center justify-center rounded-md outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 transition-colors ${
                 selectMode ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
               }`}
             >
@@ -300,7 +300,7 @@ export function EditorSidebar() {
                 type="button"
                 onClick={deleteSelected}
                 disabled={selected.size === 0}
-                className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium text-destructive outline-none hover:bg-destructive/10 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-40 disabled:hover:bg-transparent"
+                className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium text-destructive outline-none hover:bg-destructive/10 focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-40 disabled:hover:bg-transparent"
               >
                 <Trash2 className="h-3.5 w-3.5" /> Delete
               </button>
@@ -308,7 +308,7 @@ export function EditorSidebar() {
                 type="button"
                 onClick={exitSelectMode}
                 aria-label="Cancel selection"
-                className="inline-flex items-center rounded px-1 py-0.5 text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+                className="inline-flex items-center rounded px-1 py-0.5 text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
               >
                 <X className="h-3.5 w-3.5" />
               </button>
@@ -337,7 +337,7 @@ export function EditorSidebar() {
             <button
               type="button"
               onClick={() => restoreDeleted()}
-              className="inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 font-medium text-primary outline-none hover:bg-primary/10 focus-visible:ring-2 focus-visible:ring-ring/50"
+              className="inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 font-medium text-primary outline-none hover:bg-primary/10 focus-visible:ring-[3px] focus-visible:ring-ring/50"
             >
               <Undo2 className="h-3.5 w-3.5" /> Undo
             </button>
@@ -367,14 +367,14 @@ export function EditorSidebar() {
                   <button
                     type="button"
                     onClick={newDocument}
-                    className="rounded-md px-2.5 py-1.5 text-left text-sm text-foreground outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/50"
+                    className="rounded-md px-2.5 py-1.5 text-left text-sm text-foreground outline-none hover:bg-muted focus-visible:ring-[3px] focus-visible:ring-ring/50"
                   >
                     Start a naval letter
                   </button>
                   <button
                     type="button"
                     onClick={() => useUIStore.getState().setTemplateLoaderOpen(true)}
-                    className="rounded-md px-2.5 py-1.5 text-left text-sm text-foreground outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/50"
+                    className="rounded-md px-2.5 py-1.5 text-left text-sm text-foreground outline-none hover:bg-muted focus-visible:ring-[3px] focus-visible:ring-ring/50"
                   >
                     Browse templates
                   </button>
@@ -384,7 +384,7 @@ export function EditorSidebar() {
                       useUIStore.getState().setDocumentGuideTab('finder');
                       useUIStore.getState().setDocumentGuideOpen(true);
                     }}
-                    className="rounded-md px-2.5 py-1.5 text-left text-sm text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+                    className="rounded-md px-2.5 py-1.5 text-left text-sm text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
                   >
                     Not sure which? Answer a few questions
                   </button>
@@ -422,7 +422,7 @@ export function EditorSidebar() {
                             data-doc-id={m.id}
                             onClick={() => toggleSelected(m.id)}
                             aria-pressed={isSelected}
-                            className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-1.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                            className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-1.5 text-left outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
                           >
                             <span
                               aria-hidden="true"
@@ -448,7 +448,7 @@ export function EditorSidebar() {
                               else if (e.key === 'Escape') setRenamingId(null);
                             }}
                             aria-label={`Rename ${m.title}`}
-                            className="min-w-0 flex-1 rounded-md border border-border bg-card px-2.5 py-1.5 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                            className="min-w-0 flex-1 rounded-md border border-border bg-card px-2.5 py-1.5 text-sm text-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
                           />
                         ) : (
                           /* Open the document; sibling to the actions menu, not nested. */
@@ -457,7 +457,7 @@ export function EditorSidebar() {
                             data-doc-id={m.id}
                             onClick={() => switchTo(m.id)}
                             aria-current={active ? 'true' : undefined}
-                            className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-1.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                            className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-1.5 text-left outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
                           >
                             <span
                               aria-hidden="true"
@@ -490,7 +490,7 @@ export function EditorSidebar() {
                               <button
                                 type="button"
                                 aria-label={`Actions for ${m.title}`}
-                                className="shrink-0 rounded p-1 text-muted-foreground opacity-0 outline-none transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/50 group-hover:opacity-100 data-[state=open]:opacity-100"
+                                className="shrink-0 rounded p-1 text-muted-foreground opacity-0 outline-none transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:ring-[3px] focus-visible:ring-ring/50 group-hover:opacity-100 data-[state=open]:opacity-100"
                               >
                                 <MoreHorizontal className="h-3.5 w-3.5" />
                               </button>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -631,7 +631,7 @@ export function Header({
           Not an official DoW website. Beta release — report issues on GitHub.
           <button
             onClick={dismissBanner}
-            className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/40 transition-colors"
+            className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 transition-colors"
             aria-label="Dismiss banner"
           >
             <X className="h-3 w-3" />
@@ -684,7 +684,7 @@ export function Header({
               // carries the success tint. Faint muted bg on hover, neutral focus ring.
               className="flex items-center justify-center gap-1.5 rounded-md border border-border text-muted-foreground text-xs cursor-pointer hover:bg-muted transition-colors p-1.5 lg:px-2 lg:py-1 shrink-0 outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]"
             >
-              <Shield className="h-4 w-4 lg:h-3 lg:w-3 text-[var(--success)]" />
+              <Shield className="h-4 w-4 lg:h-3 lg:w-3 text-success" />
               <span className="hidden lg:inline">NIST 800-171</span>
             </button>
           </HeaderTip>
@@ -871,7 +871,7 @@ export function Header({
                 <>
                   <DropdownMenuItem
                     onClick={() => void writeBackupNow()}
-                    className="text-orange-600 dark:text-orange-400"
+                    className="text-warning"
                   >
                     <AlertTriangle className="h-4 w-4 mr-2" />
                     <span className="truncate">Auto-backup failing — retry now</span>
@@ -895,7 +895,7 @@ export function Header({
                 </>
               )}
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => setShowClearFieldsDialog(true)} className="text-orange-600 dark:text-orange-400">
+              <DropdownMenuItem onClick={() => setShowClearFieldsDialog(true)} className="text-warning">
                 <Eraser className="h-4 w-4 mr-2" />
                 Clear fields (keep letterhead)
               </DropdownMenuItem>

--- a/src/components/layout/ReadinessMeter.tsx
+++ b/src/components/layout/ReadinessMeter.tsx
@@ -96,7 +96,7 @@ export function ReadinessMeter() {
           onClick={() => jump(missing[0])}
           title={`${complete} of ${required} required sections complete — jump to the first incomplete one`}
           aria-label={`Document readiness: Drafting, ${complete} of ${required} required sections complete. Jump to the first incomplete section.`}
-          className="flex items-center gap-1.5 rounded outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+          className="flex items-center gap-1.5 rounded outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
         >
           {inner}
         </button>

--- a/src/components/layout/ResizableDivider.tsx
+++ b/src/components/layout/ResizableDivider.tsx
@@ -71,7 +71,7 @@ export function ResizableDivider({ onResize, containerRef, currentWidth }: Resiz
       )}
       <div
         onMouseDown={handleMouseDown}
-        className="relative flex-shrink-0 cursor-col-resize group rounded outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+        className="relative flex-shrink-0 cursor-col-resize group rounded outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
         role="separator"
         aria-orientation="vertical"
         aria-label="Resize preview panel. Drag, or use the left and right arrow keys."

--- a/src/components/layout/SectionRail.tsx
+++ b/src/components/layout/SectionRail.tsx
@@ -60,7 +60,7 @@ export function SectionRail({
                 onClick={() => onJump(s.id)}
                 aria-current={active ? 'true' : undefined}
                 className={cn(
-                  'flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+                  'flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-sm transition-colors duration-150 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50',
                   active
                     ? 'font-medium text-primary'
                     : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground'

--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -135,10 +135,10 @@ const BatchModalRow = memo(function BatchModalRow({
   handlePreview,
 }: BatchModalRowProps) {
   return (
-    <tr className={`border-t ${row.status === 'error' ? 'bg-destructive/10' : row.status === 'success' ? 'bg-green-500/10' : ''}`}>
+    <tr className={`border-t ${row.status === 'error' ? 'bg-destructive/10' : row.status === 'success' ? 'bg-success/10' : ''}`}>
       <td className="px-2 py-1 text-muted-foreground">
         <div className="flex items-center gap-1">
-          {row.status === 'success' && <CheckCircle className="h-4 w-4 text-green-500" />}
+          {row.status === 'success' && <CheckCircle className="h-4 w-4 text-success" />}
           {row.status === 'error' && <XCircle className="h-4 w-4 text-destructive" />}
           {row.status === 'generating' && <Loader2 className="h-4 w-4 animate-spin" />}
           {(!row.status || row.status === 'pending') && <span>{idx + 1}</span>}
@@ -924,7 +924,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
                     Add
                   </Button>
                   {addStatus && (
-                    <span className="text-xs text-green-600 dark:text-green-400 flex items-center gap-1">
+                    <span className="text-xs text-success flex items-center gap-1">
                       <CheckCircle className="h-3 w-3" />
                       {addStatus}
                     </span>
@@ -1099,10 +1099,10 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
 
                     {/* Results Summary */}
                     {lastResults && (
-                      <div className={`p-4 rounded-lg border shadow-sm transition-colors duration-300 ${lastResults.failed > 0 ? 'border-amber-500/30 bg-amber-500/10' : 'border-green-500/30 bg-green-500/10'}`}>
+                      <div className={`p-4 rounded-lg border shadow-sm transition-colors duration-300 ${lastResults.failed > 0 ? 'border-amber-500/30 bg-amber-500/10' : 'border-success/30 bg-success/10'}`}>
                         <div className="flex items-center gap-2 mb-2">
                           {lastResults.failed === 0 ? (
-                            <CheckCircle className="h-5 w-5 text-green-500" />
+                            <CheckCircle className="h-5 w-5 text-success" />
                           ) : (
                             <AlertCircle className="h-5 w-5 text-amber-500" />
                           )}

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -93,7 +93,7 @@ function DocumentFinder({ onSelectGuide }: { onSelectGuide: (guideId: string) =>
     return (
       <div className="p-4 space-y-4">
         <div className="text-center pb-4 border-b">
-          <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-green-500/10 text-green-500 mb-3">
+          <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-success/10 text-success mb-3">
             <Sparkles className="h-6 w-6" />
           </div>
           <h3 className="font-semibold text-lg">Recommended Document Types</h3>
@@ -133,7 +133,7 @@ function DocumentFinder({ onSelectGuide }: { onSelectGuide: (guideId: string) =>
                     <div className="flex items-center gap-2 flex-wrap">
                       <span className="font-semibold">{guide.name}</span>
                       {index === 0 ? (
-                        <Badge className="bg-green-500/10 text-green-600 border-green-500/30">
+                        <Badge className="bg-success/10 text-success border-success/30">
                           Best Match
                         </Badge>
                       ) : (
@@ -279,7 +279,7 @@ function GuideCard({ guide, isExpanded, onToggle }: {
             <ul className="space-y-1.5">
               {guide.whenToUse.map((item, i) => (
                 <li key={i} className="flex items-start gap-2 text-sm text-muted-foreground">
-                  <CheckCircle2 className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
+                  <CheckCircle2 className="h-4 w-4 text-success mt-0.5 shrink-0" />
                   <span>{item}</span>
                 </li>
               ))}
@@ -979,7 +979,7 @@ export function DocumentGuideModal() {
                 </div>
                 <div className="h-1.5 rounded-full bg-muted overflow-hidden">
                   <div
-                    className="h-full bg-green-500 transition-all duration-300"
+                    className="h-full bg-success transition-all duration-300"
                     style={{ width: `${(learnedCount / POWER_FEATURES.length) * 100}%` }}
                   />
                 </div>
@@ -998,7 +998,7 @@ export function DocumentGuideModal() {
                     >
                       {isLearned ? (
                         <span
-                          className="flex-none mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-500/15 text-green-600 dark:text-green-400"
+                          className="flex-none mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-success/15 text-success"
                           aria-label="Learned"
                         >
                           <Check className="h-3 w-3" />

--- a/src/components/modals/EnclosureErrorModal.tsx
+++ b/src/components/modals/EnclosureErrorModal.tsx
@@ -58,7 +58,7 @@ export function EnclosureErrorModal({ errors, open, onClose }: EnclosureErrorMod
                   {error.error}
                 </div>
                 {error.pagesSucceeded !== undefined && error.pagesSucceeded > 0 && (
-                  <div className="text-xs text-green-600 dark:text-green-400 mt-1">
+                  <div className="text-xs text-success mt-1">
                     {error.pagesSucceeded} page(s) loaded successfully
                   </div>
                 )}

--- a/src/components/modals/LogViewerModal.tsx
+++ b/src/components/modals/LogViewerModal.tsx
@@ -130,7 +130,7 @@ export function LogViewerModal() {
 
         <div className="flex gap-2 mb-2">
           <Button variant="outline" size="sm" onClick={handleCopyLogs} disabled={logs.length === 0}>
-            {copied ? <Check className="h-4 w-4 mr-2 text-green-500" /> : <Copy className="h-4 w-4 mr-2" />}
+            {copied ? <Check className="h-4 w-4 mr-2 text-success" /> : <Copy className="h-4 w-4 mr-2" />}
             {copied ? 'Copied!' : 'Copy'}
           </Button>
           <Button variant="outline" size="sm" onClick={handleDownloadLogs} disabled={logs.length === 0}>

--- a/src/components/modals/NISTComplianceModal.tsx
+++ b/src/components/modals/NISTComplianceModal.tsx
@@ -21,7 +21,7 @@ export function NISTComplianceModal() {
       <DialogContent className="sm:max-w-lg max-h-[85vh]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Shield className="h-5 w-5 text-green-500" />
+            <Shield className="h-5 w-5 text-success" />
             NIST 800-171 Compliance
           </DialogTitle>
         </DialogHeader>
@@ -39,8 +39,8 @@ export function NISTComplianceModal() {
               <h4 className="font-semibold">How This Application Complies</h4>
 
               <div className="space-y-3">
-                <div className="flex items-start gap-3 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
-                  <Server className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
+                <div className="flex items-start gap-3 p-3 rounded-lg bg-success/10 border border-success/20">
+                  <Server className="h-4 w-4 text-success mt-0.5 shrink-0" />
                   <div>
                     <p className="text-sm font-medium">No Server Communication</p>
                     <p className="text-xs text-muted-foreground">
@@ -49,8 +49,8 @@ export function NISTComplianceModal() {
                   </div>
                 </div>
 
-                <div className="flex items-start gap-3 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
-                  <Lock className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
+                <div className="flex items-start gap-3 p-3 rounded-lg bg-success/10 border border-success/20">
+                  <Lock className="h-4 w-4 text-success mt-0.5 shrink-0" />
                   <div>
                     <p className="text-sm font-medium">Local Processing Only</p>
                     <p className="text-xs text-muted-foreground">
@@ -59,8 +59,8 @@ export function NISTComplianceModal() {
                   </div>
                 </div>
 
-                <div className="flex items-start gap-3 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
-                  <Wifi className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
+                <div className="flex items-start gap-3 p-3 rounded-lg bg-success/10 border border-success/20">
+                  <Wifi className="h-4 w-4 text-success mt-0.5 shrink-0" />
                   <div>
                     <p className="text-sm font-medium">Air-Gap Compatible</p>
                     <p className="text-xs text-muted-foreground">
@@ -69,8 +69,8 @@ export function NISTComplianceModal() {
                   </div>
                 </div>
 
-                <div className="flex items-start gap-3 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
-                  <Eye className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
+                <div className="flex items-start gap-3 p-3 rounded-lg bg-success/10 border border-success/20">
+                  <Eye className="h-4 w-4 text-success mt-0.5 shrink-0" />
                   <div>
                     <p className="text-sm font-medium">No Telemetry or Analytics</p>
                     <p className="text-xs text-muted-foreground">
@@ -79,8 +79,8 @@ export function NISTComplianceModal() {
                   </div>
                 </div>
 
-                <div className="flex items-start gap-3 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
-                  <Database className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
+                <div className="flex items-start gap-3 p-3 rounded-lg bg-success/10 border border-success/20">
+                  <Database className="h-4 w-4 text-success mt-0.5 shrink-0" />
                   <div>
                     <p className="text-sm font-medium">Browser-Only Storage</p>
                     <p className="text-xs text-muted-foreground">
@@ -103,7 +103,9 @@ export function NISTComplianceModal() {
                 <div className="flex items-start gap-3 p-3 mt-3 rounded-lg bg-amber-500/10 border border-amber-500/30">
                   <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
                   <div>
-                    <p className="text-sm font-medium text-amber-600 dark:text-amber-400">Development Domain</p>
+                    {/* amber-800 (not 600, which is 2.9:1 here): a 14px "do not
+                        use for official correspondence" warning must clear AA. */}
+                    <p className="text-sm font-medium text-amber-800 dark:text-amber-300">Development Domain</p>
                     <p className="text-xs text-muted-foreground">
                       This application is currently hosted on a non-government domain. Do not use for official correspondence or enter sensitive information. For official use, access this application through your authorized .mil network.
                     </p>

--- a/src/components/modals/PIIWarningModal.tsx
+++ b/src/components/modals/PIIWarningModal.tsx
@@ -84,7 +84,7 @@ function FindingItem({ finding }: { finding: PIIFinding }) {
                 onClick={() => setRevealed((v) => !v)}
                 aria-label={revealed ? 'Hide value' : 'Reveal value'}
                 aria-pressed={revealed}
-                className="rounded p-1 opacity-70 outline-none transition-opacity hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/50"
+                className="rounded p-1 opacity-70 outline-none transition-opacity hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-[3px] focus-visible:ring-ring/50"
               >
                 {revealed ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
               </button>

--- a/src/components/modals/ShareModal.tsx
+++ b/src/components/modals/ShareModal.tsx
@@ -237,7 +237,7 @@ export function ShareModal({
                   aria-label="Copy again"
                 >
                   {copied ? (
-                    <Check className="h-4 w-4 text-green-600" />
+                    <Check className="h-4 w-4 text-success" />
                   ) : (
                     <KeyRound className="h-4 w-4" />
                   )}

--- a/src/components/onboarding/ActivationChecklist.tsx
+++ b/src/components/onboarding/ActivationChecklist.tsx
@@ -221,7 +221,7 @@ export function ActivationChecklist() {
         <div className={`${cardChrome} ${cardMotion}`} role="dialog" aria-label="Onboarding complete">
           <div className="p-6 text-center">
             <div
-              className={`mx-auto mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-green-500/10 text-green-600 dark:text-green-400 ${
+              className={`mx-auto mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-success/10 text-success ${
                 reduce ? '' : 'animate-in zoom-in-50 duration-300'
               }`}
             >
@@ -254,7 +254,7 @@ export function ActivationChecklist() {
           aria-label={`Get set up — ${done} of ${total} steps complete`}
           aria-expanded={false}
           aria-haspopup="dialog"
-          className="inline-flex h-11 items-center gap-2.5 rounded-full border border-border bg-popover pl-1.5 pr-3.5 text-popover-foreground shadow-elevated outline-none transition-[transform,border-color] duration-150 hover:-translate-y-px hover:border-primary/40 active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transition-none max-sm:w-11 max-sm:justify-center max-sm:px-0"
+          className="inline-flex h-11 items-center gap-2.5 rounded-full border border-border bg-popover pl-1.5 pr-3.5 text-popover-foreground shadow-elevated outline-none transition-[transform,border-color] duration-150 hover:-translate-y-px hover:border-primary/40 active:scale-[0.98] focus-visible:ring-[3px] focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transition-none max-sm:w-11 max-sm:justify-center max-sm:px-0"
         >
           <ProgressRing size={28} done={done} total={total} />
           <span className="hidden text-[13px] font-medium leading-none sm:inline">Get set up</span>
@@ -286,7 +286,7 @@ export function ActivationChecklist() {
             type="button"
             onClick={collapse}
             aria-label="Collapse checklist"
-            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
           >
             <ChevronDown className="h-4 w-4" />
           </button>
@@ -294,7 +294,7 @@ export function ActivationChecklist() {
             type="button"
             onClick={hide}
             aria-label="Hide getting-started checklist"
-            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
           >
             <X className="h-4 w-4" />
           </button>
@@ -334,7 +334,7 @@ export function ActivationChecklist() {
                   }`}
                 >
                   {row.done ? (
-                    <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
+                    <CheckCircle2 className="h-5 w-5 shrink-0 text-success" />
                   ) : (
                     <Glyph className="h-5 w-5 shrink-0 text-muted-foreground" />
                   )}

--- a/src/components/onboarding/ProgressRing.tsx
+++ b/src/components/onboarding/ProgressRing.tsx
@@ -38,7 +38,7 @@ export function ProgressRing({ size, done, total }: { size: number; done: number
         />
       </svg>
       <span className="absolute inline-flex items-center justify-center text-[11px] font-semibold tabular-nums leading-none text-foreground">
-        {complete ? <Check className="h-3 w-3 text-green-600 dark:text-green-400" /> : `${done}/${total}`}
+        {complete ? <Check className="h-3 w-3 text-success" /> : `${done}/${total}`}
       </span>
     </span>
   );

--- a/src/components/pdf/PdfPageLayer.tsx
+++ b/src/components/pdf/PdfPageLayer.tsx
@@ -297,7 +297,7 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
                       'overflow-hidden rounded-[3px] bg-white transition-shadow',
                       currentPage === i + 1
                         ? 'ring-2 ring-primary'
-                        : 'ring-1 ring-black/10 group-hover:ring-ring/60 group-focus-visible:ring-2 group-focus-visible:ring-ring/60 dark:ring-white/10'
+                        : 'ring-1 ring-black/10 group-hover:ring-ring/60 group-focus-visible:ring-[3px] group-focus-visible:ring-ring/50 dark:ring-white/10'
                     )}
                   >
                     <Page

--- a/src/components/pdf/PdfViewerToolbar.tsx
+++ b/src/components/pdf/PdfViewerToolbar.tsx
@@ -130,7 +130,7 @@ export function PdfViewerToolbar({
           disabled={pageCount === 0}
           inputMode="numeric"
           aria-label="Page number"
-          className="tnum h-6 w-9 rounded border border-border bg-background text-center text-xs text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50"
+          className="tnum h-6 w-9 rounded border border-border bg-background text-center text-xs text-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-50"
           onKeyDown={(e) => {
             if (e.key === 'Enter') commitPage(e.currentTarget);
             if (e.key === 'Escape') e.currentTarget.value = String(page);

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,11 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.05),0_4px_16px_-6px_rgba(0,0,0,0.45)]",
+        // shadow-md = the navy-tinted ladder step for cards. The old bespoke
+        // 45%-black drop (tuned for a dark surface) read as a grey smudge on
+        // the light canvas; its white inset highlight only makes sense in dark
+        // mode, so it's scoped there.
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-md dark:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.05),0_4px_16px_-6px_rgba(0,0,0,0.45)]",
         className
       )}
       {...props}

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -332,7 +332,7 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
               command(customItem);
             }}
           >
-            <div className="w-8 h-8 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center text-green-600 dark:text-green-400 text-lg">
+            <div className="w-8 h-8 rounded-full bg-success/15 dark:bg-success/25 flex items-center justify-center text-success text-lg">
               +
             </div>
             <div className="flex-1">

--- a/src/index.css
+++ b/src/index.css
@@ -122,6 +122,11 @@
   --color-brand-accent: var(--brand-accent);
   --color-brand-accent-foreground: var(--brand-accent-foreground);
   --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -187,7 +192,11 @@
   --brand-accent: oklch(0.32 0.06 230);    /* #07405B navy — intentional brand highlight */
   --brand-accent-foreground: oklch(0.99 0 0);
   --destructive: oklch(0.33 0.14 25);      /* #7A131B battle red */
+  --destructive-foreground: oklch(0.99 0 0); /* label on a destructive fill */
   --success: oklch(0.63 0.17 149);         /* ~green-600 — status/compliance tint */
+  --success-foreground: oklch(0.99 0 0);
+  --warning: oklch(0.55 0.13 65);          /* ~amber-700 — ≥4.5:1 as text on the light canvas */
+  --warning-foreground: oklch(0.99 0 0);
   --border: oklch(0.88 0.02 250);          /* Navy-tinted border */
   --input: oklch(0.95 0.01 250);
   --ring: oklch(0.43 0.17 25);             /* USMC Red ring */
@@ -411,7 +420,11 @@
   --brand-accent: oklch(0.80 0.15 85);     /* #f1b434 gold — brand highlight */
   --brand-accent-foreground: oklch(0.14 0.008 260);
   --destructive: oklch(0.50 0.18 25);      /* Brighter red — WCAG AA */
+  --destructive-foreground: oklch(0.99 0 0);
   --success: oklch(0.79 0.18 149);         /* ~green-400 — brighter for deep canvas */
+  --success-foreground: oklch(0.20 0.04 150);
+  --warning: oklch(0.83 0.16 85);          /* ~amber-400 — bright enough as text on deep canvas */
+  --warning-foreground: oklch(0.22 0.03 85);
   --border: oklch(0.305 0.008 260);        /* Crisper edges for card separation */
   --input: oklch(0.23 0.008 260);
   --ring: oklch(0.55 0.20 25);             /* Bright USMC Red ring */
@@ -455,7 +468,11 @@
     --brand-accent: #06384b;
     --brand-accent-foreground: #fcfcfc;
     --destructive: #6c0008;
+    --destructive-foreground: #ffffff;
     --success: #15803d;
+    --success-foreground: #ffffff;
+    --warning: #b45309;
+    --warning-foreground: #ffffff;
     --border: #ced9e5;
     --input: #eaeff5;
     --ring: #970818;
@@ -491,7 +508,11 @@
     --brand-accent: #eab532;
     --brand-accent-foreground: #07090c;
     --destructive: #b32228;
+    --destructive-foreground: #ffffff;
     --success: #4ade80;
+    --success-foreground: #052e16;
+    --warning: #fbbf24;
+    --warning-foreground: #1c1917;
     --border: #2d2f33;
     --input: #1b1d21;
     --ring: #cc272e;
@@ -547,11 +568,15 @@
      text-reveal entrance, and the unused animate-spin-slow) were removed:
      motion and effects are reserved for communicating state, never
      decoration. */
+  /* Both aliases resolve to the navy-tinted ladder above (cards → md,
+     floating layers/dialogs → xl, per the ladder's own mapping) instead of
+     the pure-black one-offs they used to carry — a raw black drop over the
+     light canvas read as a foreign asset next to every other elevation. */
   .shadow-card {
-    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.2), 0 2px 4px -2px rgb(0 0 0 / 0.15);
+    box-shadow: var(--shadow-md);
   }
   .shadow-elevated {
-    box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.2), 0 8px 10px -6px rgb(0 0 0 / 0.15);
+    box-shadow: var(--shadow-xl);
   }
 
   /* Tabular figures — align digits in columns (timestamps, counts, page numbers). */


### PR DESCRIPTION
## Why

The UI audit's cross-cutting verdict: **the design system exists but components quietly disagree with it** — the same defect wearing different hats. This is the "make the system win every collision" sweep it recommended as the highest-leverage single PR, closing ~10 of the 33 HIGH findings, including three **measured WCAG AA failures** on exactly the labels that must be unmissable.

## What

**Broken/missing tokens** (the root cause behind dozens of drift sites):
- `--success` was defined in every scheme but never registered in `@theme` → `text-success` compiled to *nothing*, so ~20 status greens hand-rolled `green-500/600`. Now registered; all status greens route through it.
- `--warning` didn't exist behind the hand-mixed ambers. Now defined (light/dark + sRGB fallbacks) with real consumers (Header's warning menu items), so it isn't dead-on-arrival like `--success` was.
- `--destructive-foreground` was referenced by both destructive confirm buttons but **never defined** — "Reset Everything" / "Discard Changes" rendered near-black labels on battle red. Now defined; labels measure **12.5:1**.

**Contrast — canvas-resolved measurements, before → after (light mode):**

| Label | Before | After |
|---|---|---|
| TOP SECRET classification text | **2.27:1** ✗ | **4.88:1** (4.50 on its tint) ✓ |
| TOP SECRET//SCI | **3.01:1** ✗ | **5.46:1** (5.21 on tint) ✓ |
| NIST "Development Domain" warning heading | **2.88:1** ✗ | **6.38:1** ✓ |

The bright CNSI banner colors stay for fills/tints — only the *text* darkened. Dark-mode variants already passed (9–14:1, verified).

**One focus ring:** 28 hand-rolled `focus-visible:ring-2` sites → the house `ring-[3px] ring-ring/50`, so tabbing across the app no longer visibly changes ring thickness. The stray amber ring normalized, `/60` opacities unified to `/50`, and rings **added** to the three icon buttons that had none (sidebar collapse, checklist collapse/close — a WCAG 2.4.7 fix). Verified: the generated CSS no longer contains a `focus-visible:ring-2` utility at all.

**Shadows:** `.shadow-card`/`.shadow-elevated` now resolve to the navy-tinted ladder (`--shadow-md`/`--shadow-xl`) instead of pure-black one-offs — every dialog, the palette, the tour card, and the checklist inherit the same elevation family with zero call-site changes. `Card`'s bespoke 45%-black drop becomes `shadow-md`, with its white inset highlight correctly scoped to dark mode (it was invisible on light and made the shadow read as a grey smudge).

## Verification

- **Live canvas-resolved contrast measurements** for every fixed ratio (table above), in the running app.
- Live: all three new tokens resolve in light and dark; `shadow-elevated`/`shadow-md` computed styles carry the navy `rgb(18 27 46)`; screenshots light + dark show no visual regressions.
- Full suite **1527 passing**, tsc + lint clean, build + `check-no-cdn` OK. Version 1.2.13 + CHANGELOG.
- Zero raw `green-*` classes left in components; zero `focus-visible:ring-2` anywhere.

## Out of scope (later ledger passes)

The full 278-raw-palette-shade routing, `<Notice variant>` extraction for the per-modal severity colors, the density system, and the command-palette fuzzy matching — all tracked in the audit ledger.