### PR TITLE
fix(mobile): visible-viewport shell + notch/home-indicator safe areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.14] — 2026-07-03
+
+### Fixed
+
+- On phones, the bottom controls (Preview PDF, Recents) no longer sit partly
+  under the browser's own toolbar: the app shell now sizes to the *visible*
+  viewport (`100dvh`, with a fallback for older browsers) instead of the
+  full 100vh that mobile browser chrome overlaps.
+- The full-screen mobile PDF preview now respects notched phones: its
+  header (title, Download, Logs, Close) pads below the status bar / dynamic
+  island, and its bottom edge clears the home indicator — previously both
+  rendered underneath in an installed app.
+
 ## [1.2.13] — 2026-07-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.13",
+  "version": "1.2.14",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1804,7 +1804,12 @@ ${texFiles['body.tex'] || '% No body content'}
 
   return (
     <TooltipProvider>
-    <div className="flex flex-col h-screen bg-background relative overflow-hidden">
+    {/* h-screen-dvh (index.css): the shell sizes to the VISIBLE viewport on
+        mobile — 100vh is ~50-100px taller than what's on screen under iOS
+        Safari / Chrome Android browser chrome, which pushed the bottom FABs
+        and preview toolbar under it — with a 100vh fallback for pre-dvh
+        engines. */}
+    <div className="flex flex-col h-screen-dvh bg-background relative overflow-hidden">
       {/* Faint Marine Coders EGA watermark behind the whole app. The animated
           beams + a denser EGA seal live inside the editor column (FormPanel),
           so the branded motion stays in the editor and doesn't sweep behind the

--- a/src/components/modals/MobilePreviewModal.tsx
+++ b/src/components/modals/MobilePreviewModal.tsx
@@ -61,9 +61,20 @@ export function MobilePreviewModal({ pdfUrl, isCompiling, error }: MobilePreview
   if (!mobilePreviewOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 bg-background flex flex-col">
+    // `fixed inset-0` extends under a notched phone's status bar and home
+    // indicator (index.html sets viewport-fit=cover), so the header and content
+    // pad by the safe-area insets — without this the title and Download/Logs/
+    // Close controls render behind the clock/dynamic island in a standalone
+    // install, and the viewer's bottom edge sits under the home indicator.
+    <div
+      className="fixed inset-0 z-50 bg-background flex flex-col"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+    >
       {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-border bg-card shrink-0">
+      <div
+        className="flex items-center justify-between px-3 py-2 border-b border-border bg-card shrink-0"
+        style={{ paddingTop: 'max(0.5rem, env(safe-area-inset-top, 0px))' }}
+      >
         <span className="font-semibold text-sm">PDF Preview</span>
         <div className="flex items-center gap-1">
           {pdfUrl && !isCompiling && (

--- a/src/index.css
+++ b/src/index.css
@@ -585,6 +585,18 @@
     font-feature-settings: 'tnum' 1;
   }
 
+  /* Full-height app shell: dvh sizes to the VISIBLE viewport on mobile (100vh
+     is ~50–100px taller than what's on screen under iOS Safari / Chrome
+     Android browser chrome). Declaration-order fallback — the browser keeps
+     the last value it understands, so pre-dvh engines (old NMCI Chromium)
+     get 100vh. NOT `h-screen h-[100dvh]` classes: at equal specificity the
+     STYLESHEET order decides, and Tailwind emits .h-screen after arbitrary
+     values, silently nullifying the dvh. */
+  .h-screen-dvh {
+    height: 100vh;
+    height: 100dvh;
+  }
+
   /* Unified modal scrim — one look for every overlay (Dialog, AlertDialog, and
      the command palette) instead of the previous black/70 vs rgba mismatch. */
   .dd-scrim {


### PR DESCRIPTION
## Why

First half of the mobile arc — two audit HIGHs that hit every phone user, and hit *installed*-app users hardest (which matters now that #120/#121 invite people to install):

1. **The app was sized to a viewport phones don't have.** The root shell used `h-screen` (100vh) — on iOS Safari / Chrome Android that's ~50–100px *taller* than what's visible under the browser's own chrome, so the bottom FABs (Preview PDF, Recents) and the preview toolbar sat partly underneath it.
2. **The mobile PDF preview ignored the notch.** It's `fixed inset-0` under `viewport-fit=cover`, so on a notched phone its header (title, Download, Logs, Close) rendered behind the status bar / dynamic island, and its bottom edge sat under the home indicator.

## What

- **New `.h-screen-dvh` utility** (`index.css`): `height: 100vh; height: 100dvh;` — sizes to the *visible* viewport where `dvh` is supported, with a declaration-order fallback for pre-dvh engines (old NMCI Chromium — the same audience the sRGB color fallbacks serve). App root uses it.
- **MobilePreviewModal**: header pads by `max(0.5rem, env(safe-area-inset-top))`, container by `env(safe-area-inset-bottom)` — both no-ops on inset-less screens, following the codebase's existing bottom-inset FAB pattern.

## The bug the verification caught

The obvious approach — `h-screen h-[100dvh]` classes — **silently doesn't work**: both compile to `height` at equal specificity, so the *stylesheet* order decides, and Tailwind emits `.h-screen` *after* arbitrary values. Verified live: `.h-[100dvh]` at position 16669 vs `.h-screen` at 17093 → 100vh won and the fix was a no-op. Hence the dedicated utility with the in-rule fallback, verified in the cascade (`ruleHasVhThenDvh: true`) and by computed height matching `innerHeight` at a 375×812 viewport.

## Verification

- Live at mobile viewport: root height == visible viewport; mobile preview opens with header fully visible, `paddingTop` resolving via `max()` (8px where env()=0, the inset on real notches).
- Full suite 1527 passing, tsc + lint clean, build + `check-no-cdn` OK. Version 1.2.14 + CHANGELOG.

## Next (second half of the mobile arc)

Mobile onboarding: the getting-started checklist hard-returns `null` on phones — the hamburger's "Getting started" item currently does nothing there, and phone users can't see the backup/install steps. Separate PR.