### PR TITLE
feat(mobile): getting-started checklist as a bottom sheet on phones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.15] — 2026-07-03
+
+### Added
+
+- Phones finally get the getting-started checklist. It was desktop-only —
+  the floating launcher collides with the mobile Preview button, so mobile
+  hid it entirely and the menu's "Getting started" item silently did
+  nothing. On mobile it now opens as a bottom sheet with the same steps
+  (tour, profile, first document, back up, install, power features),
+  closing itself when a step opens its surface.
+
 ## [1.2.14] — 2026-07-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.14",
+  "version": "1.2.15",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -189,8 +189,16 @@ export function Header({
   const fullQualityPreview = useUIStore((s) => s.fullQualityPreview);
   const setFullQualityPreview = useUIStore((s) => s.setFullQualityPreview);
   // Reopen the getting-started checklist. Hidden once onboarding is finished.
+  // Desktop un-hides the floating card; on mobile (no floating launcher — the
+  // Preview FAB owns that corner) it opens the checklist's bottom sheet.
   const checklistCelebrated = useOnboardingStore((s) => s.checklistCelebrated);
-  const reopenChecklist = () => useOnboardingStore.getState().setChecklistDismissed(false);
+  const reopenChecklist = () => {
+    if (useUIStore.getState().isMobile) {
+      useUIStore.getState().setChecklistSheetOpen(true);
+    } else {
+      useOnboardingStore.getState().setChecklistDismissed(false);
+    }
+  };
 
   // Actions only, no document-state subscription. The handlers below read the
   // full document via useDocumentStore.getState() at call time, so Header

--- a/src/components/onboarding/ActivationChecklist.tsx
+++ b/src/components/onboarding/ActivationChecklist.tsx
@@ -14,6 +14,13 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import { TourButton } from '@/components/tour/TourButton';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
 import { ProgressRing } from './ProgressRing';
 import { useOnboardingStore } from '@/stores/onboardingStore';
 import { useProfileStore } from '@/stores/profileStore';
@@ -63,9 +70,12 @@ export function ActivationChecklist() {
   const setCelebrated = useOnboardingStore((s) => s.setChecklistCelebrated);
   // Hide the launcher while a tour is running so they don't compete.
   const tourActive = useTourStore((s) => s.active);
-  // On mobile the Preview PDF FAB owns the bottom-right corner; hide this so they
-  // don't overlap.
+  // On mobile the Preview PDF FAB owns the bottom-right corner, so there is no
+  // floating launcher there — instead the same checklist renders as a bottom
+  // sheet, opened from the menu's "Getting started" item.
   const isMobile = useUIStore((s) => s.isMobile);
+  const sheetOpen = useUIStore((s) => s.checklistSheetOpen);
+  const setSheetOpen = useUIStore((s) => s.setChecklistSheetOpen);
 
   // Credit the tour only when finished (reaching the last step marks
   // GUIDED_TOUR_KEY); skipping or exiting doesn't count.
@@ -189,12 +199,121 @@ export function ActivationChecklist() {
     }
   }, [open]);
 
+  // Shared row list — identical rows on the desktop card and the mobile sheet;
+  // only the close-on-navigate callback differs.
+  const renderRows = (onNavigate: () => void) => (
+    <ul className="p-1.5">
+      {rows.map((row) => {
+        const Glyph = row.glyph;
+        return (
+          <li key={row.title}>
+            <button
+              type="button"
+              disabled={row.done}
+              onClick={() => {
+                row.action();
+                onNavigate();
+              }}
+              aria-label={
+                row.done
+                  ? `${row.title} — completed`
+                  : row.badge
+                    ? `${row.title} — ${row.badge.replace('/', ' of ')} learned`
+                    : `${row.title} — not started`
+              }
+              className={`group flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left transition-colors ${
+                row.done ? 'cursor-default' : 'hover:bg-muted/60'
+              }`}
+            >
+              {row.done ? (
+                <CheckCircle2 className="h-5 w-5 shrink-0 text-success" />
+              ) : (
+                <Glyph className="h-5 w-5 shrink-0 text-muted-foreground" />
+              )}
+              <div className="min-w-0 flex-1">
+                <div
+                  className={`text-sm font-medium leading-snug ${
+                    row.done ? 'text-muted-foreground line-through' : 'text-foreground'
+                  }`}
+                >
+                  {row.title}
+                </div>
+                {!row.done && <div className="text-xs text-muted-foreground">{row.sub}</div>}
+              </div>
+              {!row.done &&
+                (row.badge ? (
+                  <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
+                    {row.badge}
+                  </span>
+                ) : (
+                  <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+                ))}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+
   // The first-run tour owns the screen.
   if (tourActive) return null;
-  // The mobile Preview FAB owns the corner (see isMobile note above).
-  if (isMobile) return null;
   // A finished celebration retires the launcher for good.
   if (celebrated) return null;
+
+  // ── Mobile: bottom sheet, opened from the menu's "Getting started" ────────
+  // No floating launcher (the Preview FAB owns the corner) and the `dismissed`
+  // flag doesn't apply — the sheet only ever appears when explicitly opened.
+  if (isMobile) {
+    return (
+      <Dialog open={sheetOpen} onOpenChange={setSheetOpen}>
+        <DialogContent
+          className="top-auto bottom-0 left-0 translate-x-0 translate-y-0 w-full max-w-full sm:max-w-full rounded-b-none rounded-t-2xl border-x-0 border-b-0 p-0 gap-0"
+          style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+        >
+          {showCelebration ? (
+            <div className="p-6 text-center">
+              <div className="mx-auto mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-success/10 text-success">
+                <PartyPopper className="h-6 w-6" />
+              </div>
+              <DialogTitle className="text-base font-semibold">Squared away</DialogTitle>
+              <DialogDescription className="mt-1 text-sm text-muted-foreground">
+                Everything&apos;s in order — time to draft.
+              </DialogDescription>
+              <TourButton
+                className="mt-4"
+                onClick={() => {
+                  setCelebrated(true);
+                  setSheetOpen(false);
+                }}
+              >
+                Start drafting
+              </TourButton>
+            </div>
+          ) : (
+            <>
+              <DialogHeader className="px-4 pt-4 pb-1 text-left">
+                <DialogTitle className="flex items-center gap-2.5 text-sm font-semibold">
+                  <ProgressRing size={26} done={done} total={total} />
+                  Getting started
+                </DialogTitle>
+                <DialogDescription className="text-xs text-muted-foreground">
+                  {done === total ? 'Squared away' : `${done} of ${total} done`}
+                </DialogDescription>
+              </DialogHeader>
+              <div className="mx-4 mb-1 h-1 overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full bg-primary transition-[width] duration-500 ease-out motion-reduce:transition-none"
+                  style={{ width: `${(done / total) * 100}%` }}
+                />
+              </div>
+              {renderRows(() => setSheetOpen(false))}
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
   // Dismissed and hidden until re-opened from Help. The celebrated guard above
   // means a dismissed user who later finishes is retired without a surprise popup.
   if (dismissed && !celebrated) return null;
@@ -310,57 +429,7 @@ export function ActivationChecklist() {
         <p className="sr-only" role="status" aria-live="polite">{`${done} of ${total} steps complete`}</p>
 
         {/* Items */}
-        <ul className="p-1.5">
-          {rows.map((row) => {
-            const Glyph = row.glyph;
-            return (
-              <li key={row.title}>
-                <button
-                  type="button"
-                  disabled={row.done}
-                  onClick={() => {
-                    row.action();
-                    setOpen(false);
-                  }}
-                  aria-label={
-                    row.done
-                      ? `${row.title} — completed`
-                      : row.badge
-                        ? `${row.title} — ${row.badge.replace('/', ' of ')} learned`
-                        : `${row.title} — not started`
-                  }
-                  className={`group flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left transition-colors ${
-                    row.done ? 'cursor-default' : 'hover:bg-muted/60'
-                  }`}
-                >
-                  {row.done ? (
-                    <CheckCircle2 className="h-5 w-5 shrink-0 text-success" />
-                  ) : (
-                    <Glyph className="h-5 w-5 shrink-0 text-muted-foreground" />
-                  )}
-                  <div className="min-w-0 flex-1">
-                    <div
-                      className={`text-sm font-medium leading-snug ${
-                        row.done ? 'text-muted-foreground line-through' : 'text-foreground'
-                      }`}
-                    >
-                      {row.title}
-                    </div>
-                    {!row.done && <div className="text-xs text-muted-foreground">{row.sub}</div>}
-                  </div>
-                  {!row.done &&
-                    (row.badge ? (
-                      <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
-                        {row.badge}
-                      </span>
-                    ) : (
-                      <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
-                    ))}
-                </button>
-              </li>
-            );
-          })}
-        </ul>
+        {renderRows(() => setOpen(false))}
 
         {/* Footer */}
         <div className="border-t border-border px-4 py-2.5">

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -59,6 +59,11 @@ interface UIState {
    *  it open and spotlight the backup items inside it. Session-only. */
   saveMenuOpen: boolean;
   setSaveMenuOpen: (open: boolean) => void;
+  /** Mobile-only getting-started sheet (the floating checklist card collides
+   *  with the Preview FAB on phones, so mobile gets a bottom sheet opened from
+   *  the menu instead). Session-only. */
+  checklistSheetOpen: boolean;
+  setChecklistSheetOpen: (open: boolean) => void;
   setProfileModalOpen: (open: boolean) => void;
   setRestoreModalOpen: (open: boolean) => void;
   setShareModal: (mode: 'share' | 'import' | null) => void;
@@ -168,6 +173,8 @@ export const useUIStore = create<UIState>()(
       shareModal: null,
       saveMenuOpen: false,
       setSaveMenuOpen: (open) => set({ saveMenuOpen: open }),
+      checklistSheetOpen: false,
+      setChecklistSheetOpen: (open) => set({ checklistSheetOpen: open }),
       setProfileModalOpen: (open) => set({ profileModalOpen: open }),
       setRestoreModalOpen: (open) => set({ restoreModalOpen: open }),
       setShareModal: (mode) => set({ shareModal: mode }),

--- a/tests/component/ActivationChecklistSheet.test.tsx
+++ b/tests/component/ActivationChecklistSheet.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+/**
+ * The mobile getting-started sheet (PR: mobile onboarding). Locks the contract
+ * that made the desktop-only checklist a dead menu item on phones:
+ *  - on mobile, the checklist renders as a sheet driven by checklistSheetOpen
+ *    (no floating pill), and `dismissed` does NOT block it — it is
+ *    explicit-open only;
+ *  - tapping a row runs its action and closes the sheet;
+ *  - on desktop the floating pill renders and no sheet exists.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ActivationChecklist } from '@/components/onboarding/ActivationChecklist';
+import { useUIStore } from '@/stores/uiStore';
+import { useOnboardingStore } from '@/stores/onboardingStore';
+import { useTourStore } from '@/stores/tourStore';
+
+beforeEach(() => {
+  localStorage.clear();
+  useUIStore.setState({ isMobile: true, checklistSheetOpen: false, templateLoaderOpen: false });
+  useOnboardingStore.setState({ completed: {}, checklistDismissed: false, checklistCelebrated: false });
+  useTourStore.setState({ active: false });
+});
+
+describe('ActivationChecklist — mobile bottom sheet', () => {
+  it('renders nothing on mobile until the sheet is opened (no floating pill)', () => {
+    render(<ActivationChecklist />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/get set up/i)).not.toBeInTheDocument();
+  });
+
+  it('opens as a sheet with the checklist rows, even when dismissed', () => {
+    // dismissed hides the DESKTOP launcher; the sheet is explicit-open only
+    // and must ignore it — this exact combination was the dead-menu-item bug.
+    useOnboardingStore.setState({ checklistDismissed: true });
+    useUIStore.setState({ checklistSheetOpen: true });
+    render(<ActivationChecklist />);
+    const sheet = screen.getByRole('dialog');
+    expect(sheet).toHaveTextContent('Getting started');
+    expect(sheet).toHaveTextContent('Take the guided tour');
+    expect(sheet).toHaveTextContent('Back up your work');
+  });
+
+  it('tapping a row fires its action and closes the sheet', async () => {
+    const user = userEvent.setup();
+    useUIStore.setState({ checklistSheetOpen: true });
+    render(<ActivationChecklist />);
+    await user.click(screen.getByRole('button', { name: /build your first document/i }));
+    expect(useUIStore.getState().templateLoaderOpen).toBe(true); // action ran
+    expect(useUIStore.getState().checklistSheetOpen).toBe(false); // sheet closed
+  });
+
+  it('renders the floating pill (not a sheet) on desktop', () => {
+    useUIStore.setState({ isMobile: false, checklistSheetOpen: false });
+    render(<ActivationChecklist />);
+    expect(screen.getByLabelText(/get set up/i)).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('celebrated retires the sheet entirely', () => {
+    useOnboardingStore.setState({ checklistCelebrated: true });
+    useUIStore.setState({ checklistSheetOpen: true });
+    render(<ActivationChecklist />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Why

Second half of the mobile arc, and the **last of the UX audit's three headline gaps** (backup ✅ #114–118, install ✅ #120–121, mobile onboarding — this PR).

The getting-started checklist was desktop-only: its floating launcher collides with the mobile Preview FAB, so the component hard-returned `null` on phones. Two consequences:
- The menu's **"Getting started" item silently did nothing** on mobile — a dead menu entry.
- Phone users never saw the checklist at all — including the **backup** and **install** steps built over the last several PRs, aimed at exactly the users the install flow now invites in.

## What

- **On mobile the same checklist renders as a bottom sheet** — a Dialog pinned to the bottom edge (rounded top, full-width, `safe-area-inset-bottom` padded per #123's pattern), opened from the menu's "Getting started" item via a session-only `uiStore.checklistSheetOpen` flag.
- **Rows are shared, not duplicated** — the row list is extracted and used by both the desktop card and the sheet, so the two surfaces can never drift. Tapping a step runs its action and closes the sheet so the opened surface isn't buried. The completion celebration renders in-sheet with "Start drafting".
- The **`dismissed` flag deliberately doesn't apply** to the sheet — it only ever appears when explicitly opened, so it can't nag; `celebrated` still retires the entry point everywhere.
- **Desktop behavior byte-for-byte unchanged**: floating pill → expanding card, dismissal, celebration, focus/Escape handling all as before.

## Verification (live, both form factors)

- **Mobile (375×812)**: no floating pill; hamburger → "Getting started" → sheet opens pinned to the bottom (screenshot: progress ring "1/5", rail, all rows incl. "Back up your work", completed row struck through, features 0/8 badge); tapping "Build your first document" **closed the sheet and opened the template loader**.
- **Desktop**: pill present, expands to the card, footer intact — unchanged.
- Full suite 1527 passing, tsc + lint clean, build + `check-no-cdn` OK. Version 1.2.15 + CHANGELOG.

With this, all three headline audit gaps are closed. Remaining ledger work: PDF-viewer keyboard access (2 HIGHs), native `alert()` cleanup, and the polish tail.