### PR TITLE
feat(pdf): keyboard access — focusable viewer, page/zoom keys, ctrl+wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.16] — 2026-07-04
+
+### Added
+
+- The PDF preview is fully keyboard-accessible. Keyboard users could reach
+  its toolbar but never scroll or navigate the document itself; the viewer
+  is now focusable with arrow keys to scroll, Page Up/Down to change pages,
+  Home/End for first/last page, `+`/`-` to zoom, and `0` to fit the width —
+  plus Ctrl/⌘ + scroll (and trackpad pinch) to zoom, matching every desktop
+  PDF reader.
+
 ## [1.2.15] — 2026-07-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.15",
+  "version": "1.2.16",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/pdf/PdfViewer.tsx
+++ b/src/components/pdf/PdfViewer.tsx
@@ -138,6 +138,74 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
     [reducedMotion]
   );
 
+  // ── Keyboard access ───────────────────────────────────────────────────────
+  // The scrollable element lives inside a per-generation layer that is
+  // REPLACED on every recompile, so focus can't live there — the stable
+  // content wrapper is the keyboard surface instead, routing keys to the
+  // active layer. Without this a keyboard-only user could reach the toolbar
+  // but never scroll or navigate the document at all.
+  const handleContentKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.ctrlKey || e.metaKey || e.altKey) return; // browser shortcuts pass through
+      const layer = activeLayerRef.current;
+      const pageCount = docMeta?.numPages ?? 0;
+      const scrollBy = (delta: number) => {
+        if (layer) layer.setScrollTop(layer.getScrollTop() + delta);
+      };
+      switch (e.key) {
+        case 'ArrowDown':
+          scrollBy(80);
+          break;
+        case 'ArrowUp':
+          scrollBy(-80);
+          break;
+        case 'PageDown':
+          goToPage(1);
+          break;
+        case 'PageUp':
+          goToPage(-1);
+          break;
+        case 'Home':
+          layer?.scrollToPage(0, !reducedMotion);
+          break;
+        case 'End':
+          if (pageCount > 0) layer?.scrollToPage(pageCount - 1, !reducedMotion);
+          break;
+        case '+':
+        case '=':
+          zoomStep(1);
+          break;
+        case '-':
+          zoomStep(-1);
+          break;
+        case '0':
+          zoomFitWidth();
+          break;
+        default:
+          return; // unhandled: let it propagate (Tab, Escape, …)
+      }
+      e.preventDefault();
+      e.stopPropagation();
+    },
+    [docMeta?.numPages, goToPage, reducedMotion, zoomStep, zoomFitWidth]
+  );
+
+  // Ctrl/⌘ + wheel (and trackpad pinch, which browsers report as ctrl+wheel)
+  // zooms the document instead of the page. Must be a native non-passive
+  // listener — React's synthetic wheel handlers are passive, so preventDefault
+  // there can't stop the browser's own page zoom.
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey && !e.metaKey) return;
+      e.preventDefault();
+      zoomStep(e.deltaY < 0 ? 1 : -1);
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [zoomStep]);
+
   if (loadFailed) {
     return (
       <div className={cn('flex h-full flex-col items-center justify-center gap-3 p-6', className)}>
@@ -190,7 +258,16 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
             aria-label="Page thumbnails"
           />
         )}
-        <div ref={contentRef} className="relative min-h-0 flex-1">
+        <div
+          ref={contentRef}
+          tabIndex={0}
+          role="region"
+          aria-label="PDF document. Arrow keys scroll, Page Up and Page Down change pages, Home and End jump to the first and last page, plus and minus zoom, 0 fits the width."
+          onKeyDown={handleContentKeyDown}
+          // ring-inset: the ring must draw inside the scroll area's edges — an
+          // outset ring would be clipped by the flex parent and invisible.
+          className="relative min-h-0 flex-1 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:ring-inset"
+        >
         {/* ONE keyed array on purpose: React only reconciles keys across a
             single children array, not across separate JSX expression slots.
             On promotion the incoming element becomes the active one and the

--- a/src/components/pdf/PdfViewer.tsx
+++ b/src/components/pdf/PdfViewer.tsx
@@ -159,6 +159,13 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
         case 'ArrowUp':
           scrollBy(-80);
           break;
+        case ' ': {
+          // Space / Shift+Space: near-viewport scroll, the universal PDF-reader
+          // binding. The wrapper's height ≈ the layer's (layers are inset-0).
+          const viewport = contentRef.current?.clientHeight ?? 400;
+          scrollBy(e.shiftKey ? -viewport * 0.9 : viewport * 0.9);
+          break;
+        }
         case 'PageDown':
           goToPage(1);
           break;
@@ -204,7 +211,10 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
     };
     el.addEventListener('wheel', onWheel, { passive: false });
     return () => el.removeEventListener('wheel', onWheel);
-  }, [zoomStep]);
+    // loadFailed in the deps: the error branch renders WITHOUT the content
+    // wrapper, so if the viewer ever recovers, the effect must re-run to
+    // attach onto the freshly-mounted element.
+  }, [zoomStep, loadFailed]);
 
   if (loadFailed) {
     return (
@@ -262,7 +272,7 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
           ref={contentRef}
           tabIndex={0}
           role="region"
-          aria-label="PDF document. Arrow keys scroll, Page Up and Page Down change pages, Home and End jump to the first and last page, plus and minus zoom, 0 fits the width."
+          aria-label="PDF document. Arrow keys and Space scroll, Page Up and Page Down change pages, Home and End jump to the first and last page, plus and minus zoom, 0 fits the width."
           onKeyDown={handleContentKeyDown}
           // ring-inset: the ring must draw inside the scroll area's edges — an
           // outset ring would be clipped by the flex parent and invisible.

--- a/tests/component/PdfViewer.test.tsx
+++ b/tests/component/PdfViewer.test.tsx
@@ -167,4 +167,74 @@ describe('PdfViewer', () => {
       expect(after).toBeGreaterThan(before);
     });
   });
+
+  // ── Keyboard access (audit HIGH: the document was pointer-only) ───────────
+  describe('keyboard access', () => {
+    const getRegion = async () => {
+      await waitFor(() => expect(screen.getByRole('region', { name: /PDF document/ })).toBeTruthy());
+      return screen.getByRole('region', { name: /PDF document/ });
+    };
+
+    it('the document region is focusable and announces its key bindings', async () => {
+      renderViewer('blob:test/kb1');
+      const region = await getRegion();
+      expect(region.tabIndex).toBe(0);
+      expect(region.getAttribute('aria-label')).toMatch(/plus and minus zoom/);
+      expect(region.getAttribute('aria-label')).toMatch(/Space scroll/);
+    });
+
+    it('+ / - / 0 drive zoom from the keyboard', async () => {
+      const { container } = renderViewer('blob:test/kb2');
+      const region = await getRegion();
+      await waitFor(() => expect(container.querySelector('[data-testid="page:1"]')).toBeTruthy());
+      const width = () => Number(container.querySelector('[data-testid="page:1"]')!.getAttribute('data-width'));
+      const fit = width();
+
+      // Two steps up (a single '+' from the tiny happy-dom fit width lands on
+      // the ladder's FLOOR step, where '-' would clamp in place).
+      fireEvent.keyDown(region, { key: '+' });
+      fireEvent.keyDown(region, { key: '+' });
+      await waitFor(() => expect(width()).toBeGreaterThan(fit));
+      const zoomed = width();
+
+      fireEvent.keyDown(region, { key: '-' });
+      await waitFor(() => expect(width()).toBeLessThan(zoomed));
+
+      fireEvent.keyDown(region, { key: '0' }); // back to fit-width
+      await waitFor(() => expect(width()).toBe(fit));
+    });
+
+    it('PageDown / Home navigate pages via the active layer', async () => {
+      const { container } = renderViewer('blob:test/kb3');
+      const region = await getRegion();
+      // Wait for the PROMOTED layer's page render, not just the meta ('of 2'
+      // appears during pre-render, before activeLayerRef is populated).
+      await waitFor(() => expect(container.querySelector('[data-testid="page:1"]')).toBeTruthy());
+
+      const scrollCalls: Array<{ top?: number }> = [];
+      (Element.prototype as { scrollTo: (o: { top?: number }) => void }).scrollTo = function (o) {
+        scrollCalls.push(o);
+      };
+      fireEvent.keyDown(region, { key: 'PageDown' });
+      expect(scrollCalls.length).toBeGreaterThan(0);
+      expect(scrollCalls[scrollCalls.length - 1].top).toBeGreaterThan(0); // page 2 band
+
+      fireEvent.keyDown(region, { key: 'Home' });
+      // Page 1's band top = layer pad minus the page gap (~8px), not exactly 0.
+      expect(scrollCalls[scrollCalls.length - 1].top).toBeLessThan(24);
+      expect(container).toBeTruthy();
+    });
+
+    it('modifier chords pass through untouched (browser shortcuts keep working)', async () => {
+      const { container } = renderViewer('blob:test/kb4');
+      const region = await getRegion();
+      await waitFor(() => expect(container.querySelector('[data-testid="page:1"]')).toBeTruthy());
+      const before = Number(container.querySelector('[data-testid="page:1"]')!.getAttribute('data-width'));
+
+      // Ctrl+'+' must NOT be handled here (that's the browser's page zoom).
+      const handled = !fireEvent.keyDown(region, { key: '+', ctrlKey: true });
+      expect(handled).toBe(false); // not preventDefault'ed
+      expect(Number(container.querySelector('[data-testid="page:1"]')!.getAttribute('data-width'))).toBe(before);
+    });
+  });
 });


### PR DESCRIPTION
## Why

The last two a11y HIGHs from the UI audit: a keyboard-only user could Tab to the PDF toolbar but **never scroll or navigate the document itself** — the scroll container was completely unfocusable — and zoom was mouse-only. For the NMCI keyboard-heavy audience this made the preview effectively pointer-only.

## What

**The keyboard surface is the stable content wrapper, not the scrollable layer.** The scrolling element lives inside a per-generation layer that's *replaced on every recompile* — focus there would drop every few seconds while typing. The wrapper persists; keys route to the active layer through the existing imperative handle.

- `tabIndex=0` + `role="region"` with the key bindings spelled out in the aria-label (screen readers announce how to drive it), inset house focus ring (`ring-[3px] ring-ring/50` — inset because an outset ring would be clipped by the flex parent).
- **Keys**: `↑`/`↓` scroll (80px steps) · `PageUp`/`PageDown` previous/next page · `Home`/`End` first/last page · `+`/`=`/`-` zoom steps · `0` fit-width. Out-of-range page jumps no-op via `scrollToPage`'s existing layout guard; Ctrl/Alt/Meta chords pass through so browser shortcuts keep working; unhandled keys propagate (Tab, Escape).
- **Ctrl/⌘ + wheel** (and trackpad pinch, which browsers report as ctrl+wheel) zooms the document instead of the browser page — a *native non-passive* listener, because React's synthetic wheel handlers are passive and `preventDefault` there can't stop the browser's own zoom. Matches Acrobat/Figma/Dropbox.

## Verification (live, real compiled document)

- Region focusable, aria instructions present.
- `+`×3: 46%→67% · `-`×2 steps back · `0` → fit (46%) · **Ctrl+wheel**: 46%→50%.
- Arrows: with genuine overflow (shrunk viewport, 264px range) `↓`×3 scrolled 0→240 (exact 80px steps), `↑` back to 160. *(First probe showed no movement — the page simply fit the viewport at that zoom; verified against real overflow.)*
- `Home` returns to top; `PageDown`/`End` on a 1-page doc are safe no-ops (no throw, guarded).
- Full suite 1532 passing, tsc + lint clean, build + `check-no-cdn` OK. Version 1.2.16 + CHANGELOG.

This clears the last HIGH-severity accessibility findings from the audit.