### PR TITLE
fix(ui): replace every native alert()/confirm() with a themed in-app dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.17] — 2026-07-04
+
+### Changed
+
+- Every message the app raises now appears in its own themed dialog instead
+  of a native browser popup. `alert()`/`confirm()` follow the operating
+  system's theme, not the app's — a white OS popup over a dark UI (the same
+  class of bug as the old crash screen). All ten remaining native alerts
+  (storage-full warnings, signature-size limits, import errors, in-app
+  browser download instructions) and the profile-delete confirm were moved
+  to an in-app alert dialog, and a lint rule keeps native popups from
+  coming back.
+
 ## [1.2.16] — 2026-07-04
 
 ### Added

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,6 +57,10 @@ export default defineConfig([
       globals: globals.browser,
     },
     rules: {
+      // Native alert()/confirm()/prompt() follow the OS theme, not the app's
+      // (a white popup over a dark UI). Use showAppAlert/showAppConfirm from
+      // stores/alertStore instead — they render in the themed AppAlertDialog.
+      'no-alert': 'error',
       // Standard convention: an underscore prefix on a destructured key,
       // catch binding, or function arg signals "I know this is unused on
       // purpose" (e.g. omitting a key with `const { [k]: _omit, ...rest } = obj`).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.16",
+  "version": "1.2.17",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import {
 } from '@/components/modals/downloadProgressTypes';
 import { parseShareUrl } from '@/lib/shareCrypto';
 import { BrowserCompatibilityNotice } from '@/components/BrowserCompatibilityNotice';
+import { AppAlertDialog } from '@/components/AppAlertDialog';
 import { StorageNotice } from '@/components/StorageNotice';
 import { BackupNotice } from '@/components/BackupNotice';
 import { InstallNotice } from '@/components/InstallNotice';
@@ -1965,6 +1966,7 @@ ${texFiles['body.tex'] || '% No body content'}
         onDismiss={dismissUpdatePrompt}
       />
       <InstallAppModal />
+      <AppAlertDialog />
       <DownloadProgressModal
         phase={downloadProgress}
         onClose={() => setDownloadProgress(null)}

--- a/src/components/AppAlertDialog.tsx
+++ b/src/components/AppAlertDialog.tsx
@@ -1,0 +1,88 @@
+import { useAlertStore } from '@/stores/alertStore';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+/**
+ * The single renderer for showAppAlert()/showAppConfirm() (alertStore).
+ * Mounted once in App; every message the app used to raise via native
+ * alert()/confirm() surfaces here in the app's own theme.
+ *
+ * z-[110]: BrowserCompatibilityNotice's overlay sits at z-[100] and fires
+ * alerts of its own ("Open in Safari" instructions) — this dialog must render
+ * above it, not underneath. The Radix focus trap works regardless of paint
+ * order, so only the content needs the boost; the scrim staying at z-50 is
+ * invisible behind the notice's own backdrop and correct everywhere else.
+ */
+export function AppAlertDialog() {
+  const open = useAlertStore((s) => s.open);
+  const current = useAlertStore((s) => s.current);
+  const dismiss = useAlertStore((s) => s.dismiss);
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) dismiss(false); // Esc — same as Cancel
+      }}
+    >
+      {current && (
+        <AlertDialogContent className="z-[110]">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{current.title}</AlertDialogTitle>
+            {/* pre-line: the migrated messages carry \n step lists */}
+            <AlertDialogDescription className="whitespace-pre-line">
+              {current.message}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {/* preventDefault on every button: Radix's Action/Cancel otherwise
+              fire their own close request AFTER our onClick, dismissing twice
+              and eating any queued alert. The store alone drives `open`. */}
+          <AlertDialogFooter>
+            {current.confirm ? (
+              <>
+                <AlertDialogCancel
+                  onClick={(e) => {
+                    e.preventDefault();
+                    dismiss(false);
+                  }}
+                >
+                  Cancel
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={(e) => {
+                    e.preventDefault();
+                    dismiss(true);
+                  }}
+                  className={
+                    current.confirm.destructive
+                      ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                      : undefined
+                  }
+                >
+                  {current.confirm.confirmLabel}
+                </AlertDialogAction>
+              </>
+            ) : (
+              <AlertDialogAction
+                onClick={(e) => {
+                  e.preventDefault();
+                  dismiss(false);
+                }}
+              >
+                OK
+              </AlertDialogAction>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      )}
+    </AlertDialog>
+  );
+}

--- a/src/components/BrowserCompatibilityNotice.tsx
+++ b/src/components/BrowserCompatibilityNotice.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { AlertTriangle, X, ExternalLink } from 'lucide-react';
 import { getDeviceInfo, type DeviceInfo } from '@/utils/device';
+import { showAppAlert } from '@/stores/alertStore';
 
 // Browser icons as simple SVG components
 function SafariIcon({ className }: { className?: string }) {
@@ -130,10 +131,18 @@ export function BrowserCompatibilityNotice() {
     const currentUrl = window.location.href;
     try {
       await navigator.clipboard.writeText(currentUrl);
-      alert('URL copied to clipboard!\n\nTo open in Safari:\n1. Open Safari app\n2. Paste the URL in the address bar\n\nOr:\n1. Tap the ⋮ or share button in this browser\n2. Select "Open in Safari"');
+      showAppAlert({
+        title: 'URL copied to clipboard',
+        message:
+          'To open in Safari:\n1. Open Safari app\n2. Paste the URL in the address bar\n\nOr:\n1. Tap the ⋮ or share button in this browser\n2. Select "Open in Safari"',
+      });
     } catch {
       // Clipboard API might not work, just show instructions
-      alert('To open in Safari:\n\n1. Tap the ⋮ or share button at the top/bottom of your screen\n2. Select "Open in Safari" or "Open in Browser"');
+      showAppAlert({
+        title: 'Open in Safari',
+        message:
+          '1. Tap the ⋮ or share button at the top/bottom of your screen\n2. Select "Open in Safari" or "Open in Browser"',
+      });
     }
   }, []);
 

--- a/src/components/editor/BlockParagraphsEditor.tsx
+++ b/src/components/editor/BlockParagraphsEditor.tsx
@@ -19,6 +19,7 @@ import { VariableChipEditor } from '@/components/ui/variable-chip-editor';
 import { HelpTip } from '@/components/ui/help-tip';
 import { useDocumentStore } from '@/stores/documentStore';
 import { useSnippetsStore } from '@/stores/snippetsStore';
+import { showAppAlert } from '@/stores/alertStore';
 import { DOC_TYPE_CONFIG, type PortionMarking } from '@/types/document';
 import { calculateLabels, canIndentAt } from '@/lib/paragraphUtils';
 import { cn } from '@/lib/utils';
@@ -480,10 +481,11 @@ export function BlockParagraphsEditor() {
                     addSnippet('', lastNonEmpty);
                   } catch (err) {
                     console.error('Failed to save clause (storage may be full)', err);
-                    alert(
-                      "Couldn't save this clause — your browser's local storage is full. " +
-                        'Delete a few documents or clauses, then try again.'
-                    );
+                    showAppAlert({
+                      title: "Couldn't save this clause",
+                      message:
+                        "Your browser's local storage is full. Delete a few documents or clauses, then try again.",
+                    });
                   }
                   setClausesOpen(false);
                 }}

--- a/src/components/editor/ProfileBar.tsx
+++ b/src/components/editor/ProfileBar.tsx
@@ -17,6 +17,7 @@ import { useProfileStore } from '@/stores/profileStore';
 import { useDocumentStore } from '@/stores/documentStore';
 import { SaveStatus } from '@/components/SaveStatus';
 import { useUIStore } from '@/stores/uiStore';
+import { showAppAlert, showAppConfirm } from '@/stores/alertStore';
 import { debug } from '@/lib/debug';
 import { profileFormPatch } from '@/stores/documentsStore';
 import { readFileAsText, triggerDownload } from '@/lib/encoding';
@@ -78,9 +79,15 @@ export function ProfileBar() {
     }
   };
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (!selectedProfile) return;
-    if (confirm(`Delete profile "${selectedProfile}"?`)) {
+    const confirmed = await showAppConfirm({
+      title: 'Delete profile?',
+      message: `"${selectedProfile}" will be removed. This can't be undone.`,
+      confirmLabel: 'Delete',
+      destructive: true,
+    });
+    if (confirmed) {
       try {
         deleteProfile(selectedProfile);
       } catch (err) {
@@ -116,7 +123,10 @@ export function ProfileBar() {
       debug.log('Profile', 'Import successful', { count: profileCount });
     } catch (err) {
       debug.error('Profile', 'Failed to import profiles', err);
-      alert(`Failed to import profiles: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      showAppAlert({
+        title: "Couldn't import profiles",
+        message: err instanceof Error ? err.message : 'Unknown error',
+      });
     } finally {
       e.target.value = '';
     }

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -14,6 +14,7 @@ import { useDocumentStore } from '@/stores/documentStore';
 import { useUIStore } from '@/stores/uiStore';
 import { unfilled } from '@/lib/requiredField';
 import { FILE_LIMITS } from '@/lib/constants';
+import { showAppAlert } from '@/stores/alertStore';
 import type { DocTypeConfig, SignatureImage, SignatureType } from '@/types/document';
 import { ALL_SERVICE_RANKS, formatRank } from '@/data/ranks';
 import { getOfficeCode, OFFICE_CODES } from '@/data/officeCodes';
@@ -112,7 +113,10 @@ export function SignatureSection({ config }: SignatureSectionProps) {
     }
     // Signatures are stored base64 in localStorage; cap the size so they can't fill it.
     if (file.size > FILE_LIMITS.MAX_SIGNATURE_SIZE_MB * 1024 * 1024) {
-      alert(`That signature image is too large (max ${FILE_LIMITS.MAX_SIGNATURE_SIZE_MB} MB). Please use a smaller file.`);
+      showAppAlert({
+        title: 'Image too large',
+        message: `That signature image is too large (max ${FILE_LIMITS.MAX_SIGNATURE_SIZE_MB} MB). Please use a smaller file.`,
+      });
       return;
     }
 

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -34,6 +34,7 @@ import {
 import { UnitLookupModal } from '@/components/modals/UnitLookupModal';
 import { SSICLookupModal } from '@/components/modals/SSICLookupModal';
 import { useUIStore } from '@/stores/uiStore';
+import { showAppAlert } from '@/stores/alertStore';
 import { useProfileStore } from '@/stores/profileStore';
 import { useDocumentStore } from '@/stores/documentStore';
 import type { Profile, SignatureImage } from '@/types/document';
@@ -185,7 +186,7 @@ export function ProfileModal() {
 
   const handleSave = () => {
     if (!profileName.trim()) {
-      alert('Please enter a profile name');
+      showAppAlert({ title: 'Name required', message: 'Please enter a profile name.' });
       return;
     }
 
@@ -222,10 +223,12 @@ export function ProfileModal() {
       useDocumentStore.getState().setFormData(formFields);
     } catch (err) {
       console.error('Failed to save profile (storage may be full)', err);
-      alert(
-        "Couldn't save this profile — your browser's local storage is full. " +
-          'Try a smaller signature image, or delete an old profile, then save again.'
-      );
+      showAppAlert({
+        title: "Couldn't save this profile",
+        message:
+          "Your browser's local storage is full. " +
+          'Try a smaller signature image, or delete an old profile, then save again.',
+      });
       return; // keep the modal open so the user can adjust and retry
     }
 
@@ -264,7 +267,10 @@ export function ProfileModal() {
     }
     // Signatures are stored base64 in localStorage; cap the size so they can't fill it.
     if (file.size > FILE_LIMITS.MAX_SIGNATURE_SIZE_MB * 1024 * 1024) {
-      alert(`That signature image is too large (max ${FILE_LIMITS.MAX_SIGNATURE_SIZE_MB} MB). Please use a smaller file.`);
+      showAppAlert({
+        title: 'Image too large',
+        message: `That signature image is too large (max ${FILE_LIMITS.MAX_SIGNATURE_SIZE_MB} MB). Please use a smaller file.`,
+      });
       return;
     }
 

--- a/src/components/modals/TemplateLoaderModal.tsx
+++ b/src/components/modals/TemplateLoaderModal.tsx
@@ -14,6 +14,7 @@ import { useUIStore } from '@/stores/uiStore';
 import { useDocumentStore, getSerializedSessionForShare, loadSharedSession } from '@/stores/documentStore';
 import { useDocumentsStore } from '@/stores/documentsStore';
 import { useUserTemplatesStore } from '@/stores/userTemplatesStore';
+import { showAppAlert } from '@/stores/alertStore';
 import { useProfileStore } from '@/stores/profileStore';
 import { LETTER_TEMPLATES, type LetterTemplate } from '@/data/templates';
 import { DOC_TYPE_LABELS } from '@/types/document';
@@ -185,10 +186,11 @@ export function TemplateLoaderModal() {
       setSavingName(null);
     } catch (err) {
       console.error('Failed to save template (storage may be full)', err);
-      alert(
-        "Couldn't save this template — your browser's local storage is full. " +
-          'Delete a few documents or templates, then try again.'
-      );
+      showAppAlert({
+        title: "Couldn't save this template",
+        message:
+          "Your browser's local storage is full. Delete a few documents or templates, then try again.",
+      });
     }
   };
 

--- a/src/stores/alertStore.ts
+++ b/src/stores/alertStore.ts
@@ -1,0 +1,93 @@
+import { create } from 'zustand';
+
+/**
+ * In-app replacement for native `alert()` / `confirm()`.
+ *
+ * Native dialogs follow the OS theme, not the app's — a white popup over a
+ * dark UI (the same class of bug as the old crash screen). Every message the
+ * app raises goes through this store instead and renders in the themed
+ * <AppAlertDialog/> mounted once in App. ESLint's `no-alert` rule keeps new
+ * native calls out.
+ *
+ * Imperative helpers (`showAppAlert`, `showAppConfirm`) work from anywhere —
+ * React components and plain utils alike (e.g. downloadPdf.ts) — because
+ * zustand stores are framework-free.
+ *
+ * Session-only by design: dialogs are transient UI, nothing persists.
+ */
+
+interface AlertRequest {
+  title: string;
+  /** Rendered with `whitespace-pre-line`, so \n line breaks survive. */
+  message: string;
+  /** Present only for confirms; resolves that showAppConfirm() promise. */
+  confirm?: {
+    confirmLabel: string;
+    destructive: boolean;
+    resolve: (confirmed: boolean) => void;
+  };
+}
+
+interface AlertState {
+  /** Controls the Radix open prop. `current` intentionally survives dismiss
+   *  so the exit animation doesn't render an empty dialog. */
+  open: boolean;
+  current: AlertRequest | null;
+  /** Native alert() queues when fired back-to-back; so do we. */
+  queue: AlertRequest[];
+  show: (req: AlertRequest) => void;
+  /** Called by the dialog on OK / Cancel / Esc. `confirmed` is false for
+   *  every path except the explicit confirm button. */
+  dismiss: (confirmed: boolean) => void;
+}
+
+export const useAlertStore = create<AlertState>((set, get) => ({
+  open: false,
+  current: null,
+  queue: [],
+  show: (req) => {
+    const { open, queue } = get();
+    if (open) {
+      set({ queue: [...queue, req] });
+    } else {
+      set({ open: true, current: req });
+    }
+  },
+  dismiss: (confirmed) => {
+    const { current, queue } = get();
+    current?.confirm?.resolve(confirmed);
+    if (queue.length > 0) {
+      const [next, ...rest] = queue;
+      set({ current: next, queue: rest });
+    } else {
+      set({ open: false });
+    }
+  },
+}));
+
+/** Themed drop-in for `alert(message)`. Returns immediately (fire-and-forget,
+ *  like the sites it replaced — none of them awaited the dismissal). */
+export function showAppAlert(opts: { title: string; message: string }): void {
+  useAlertStore.getState().show(opts);
+}
+
+/** Themed drop-in for `confirm(message)` — resolves true only when the user
+ *  presses the confirm button; Cancel/Esc resolve false. */
+export function showAppConfirm(opts: {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  destructive?: boolean;
+}): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    useAlertStore.getState().show({
+      title: opts.title,
+      message: opts.message,
+      confirm: {
+        confirmLabel: opts.confirmLabel ?? 'Confirm',
+        destructive: opts.destructive ?? false,
+        resolve,
+      },
+    });
+  });
+}

--- a/src/utils/downloadPdf.ts
+++ b/src/utils/downloadPdf.ts
@@ -11,8 +11,9 @@ import {
   getDeviceInfo, 
   getPdfDownloadStrategy, 
   getDownloadUnsupportedMessage,
-  type DeviceInfo 
+  type DeviceInfo
 } from './device';
+import { showAppAlert } from '@/stores/alertStore';
 
 /**
  * Download PDF using FileReader -> Data URL -> anchor click
@@ -154,7 +155,7 @@ export async function downloadPdfBlob(
       // In-app browsers can't download - show user instructions
       console.log('[downloadPdf] In-app browser detected - showing instructions');
       const message = getDownloadUnsupportedMessage(device);
-      alert(message);
+      showAppAlert({ title: 'Downloads need a real browser', message });
       
       // Still try blob URL as last-ditch effort (probably won't work)
       const pdfBlob = new Blob([blob], { type: 'application/pdf' });

--- a/tests/component/AppAlertDialog.test.tsx
+++ b/tests/component/AppAlertDialog.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+
+import { AppAlertDialog } from '@/components/AppAlertDialog';
+import { useAlertStore, showAppAlert, showAppConfirm } from '@/stores/alertStore';
+
+// The dialog is a singleton fed by the store; reset between tests so a
+// leftover open/queue never leaks across cases.
+beforeEach(() => {
+  useAlertStore.setState({ open: false, current: null, queue: [] });
+});
+
+describe('AppAlertDialog', () => {
+  it('showAppAlert renders a themed dialog with title + message, OK closes it', async () => {
+    render(<AppAlertDialog />);
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+
+    act(() => {
+      showAppAlert({ title: 'Image too large', message: 'Max 2 MB. Please use a smaller file.' });
+    });
+
+    await waitFor(() => expect(screen.getByRole('alertdialog')).toBeTruthy());
+    expect(screen.getByText('Image too large')).toBeTruthy();
+    expect(screen.getByText(/smaller file/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
+
+  it('multi-line messages keep their line breaks (pre-line)', async () => {
+    render(<AppAlertDialog />);
+    act(() => {
+      showAppAlert({ title: 'Open in Safari', message: '1. Tap share\n2. Select "Open in Safari"' });
+    });
+    await waitFor(() => expect(screen.getByRole('alertdialog')).toBeTruthy());
+
+    const description = screen.getByText(/Tap share/);
+    // The class carries the whitespace behavior; happy-dom doesn't compute
+    // styles for Tailwind utilities, so assert the class contract directly.
+    expect(description.className).toContain('whitespace-pre-line');
+    expect(description.textContent).toContain('\n');
+  });
+
+  it('showAppConfirm resolves true on the confirm button', async () => {
+    render(<AppAlertDialog />);
+    let resolved: boolean | undefined;
+    act(() => {
+      void showAppConfirm({
+        title: 'Delete profile?',
+        message: '"Alpha" will be removed.',
+        confirmLabel: 'Delete',
+        destructive: true,
+      }).then((ok) => {
+        resolved = ok;
+      });
+    });
+
+    await waitFor(() => expect(screen.getByRole('alertdialog')).toBeTruthy());
+    const confirmBtn = screen.getByRole('button', { name: 'Delete' });
+    // Destructive confirms wear the destructive palette, not the default.
+    expect(confirmBtn.className).toContain('bg-destructive');
+
+    fireEvent.click(confirmBtn);
+    await waitFor(() => expect(resolved).toBe(true));
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
+
+  it('showAppConfirm resolves false on Cancel', async () => {
+    render(<AppAlertDialog />);
+    let resolved: boolean | undefined;
+    act(() => {
+      void showAppConfirm({ title: 'Delete profile?', message: 'Sure?' }).then((ok) => {
+        resolved = ok;
+      });
+    });
+
+    await waitFor(() => expect(screen.getByRole('alertdialog')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => expect(resolved).toBe(false));
+  });
+
+  it('Escape dismisses and resolves false (never true)', async () => {
+    render(<AppAlertDialog />);
+    let resolved: boolean | undefined;
+    act(() => {
+      void showAppConfirm({ title: 'Delete?', message: 'Sure?' }).then((ok) => {
+        resolved = ok;
+      });
+    });
+
+    await waitFor(() => expect(screen.getByRole('alertdialog')).toBeTruthy());
+    fireEvent.keyDown(screen.getByRole('alertdialog'), { key: 'Escape' });
+    await waitFor(() => expect(resolved).toBe(false));
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
+
+  it('alerts fired back-to-back queue like native alert(): second shows after the first is dismissed', async () => {
+    render(<AppAlertDialog />);
+    act(() => {
+      showAppAlert({ title: 'First', message: 'one' });
+      showAppAlert({ title: 'Second', message: 'two' });
+    });
+
+    await waitFor(() => expect(screen.getByText('First')).toBeTruthy());
+    expect(screen.queryByText('Second')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+    await waitFor(() => expect(screen.getByText('Second')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: 'OK' }));
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
+});


### PR DESCRIPTION
## Why

Native \`alert()\`/\`confirm()\` follow the **operating system's** theme, not the app's — a stark white OS popup over a dark UI, with unstyled system chrome. This is the same class of bug as the crash screen that was fixed in #119, and the UX audit flagged it across the app. Ten \`alert()\` call sites and one native \`confirm()\` remained.

## What

**One shared, themed dialog** replaces them all:

- **\`src/stores/alertStore.ts\`** — a small zustand store with two imperative helpers usable from React components *and* plain utils (e.g. \`downloadPdf.ts\`):
  - \`showAppAlert({ title, message })\` — fire-and-forget, like the sites it replaced
  - \`showAppConfirm({ title, message, confirmLabel, destructive })\` — resolves a promise: \`true\` only on the confirm button; Cancel/Esc resolve \`false\`
  - Back-to-back alerts **queue** (native \`alert()\` semantics) instead of clobbering each other
- **\`AppAlertDialog\`** — the single renderer, mounted once in App, built on the existing shadcn \`AlertDialog\`:
  - \`z-[110]\` so alerts fired *from* the in-app-browser notice (whose overlay is \`z-[100]\`) render above it
  - \`whitespace-pre-line\` messages — the migrated Safari/download instructions keep their numbered step lists
  - destructive confirms wear the destructive palette (matches the Header's reset dialog)
  - buttons \`preventDefault()\` so Radix's built-in Action/Cancel close can't double-dismiss and silently eat a queued alert
- **All 11 sites migrated** with real titles instead of bare prose: storage-full warnings (profile/template/clause), signature-size limits ×2, profile-name validation, profile import errors, in-app-browser download + Safari instructions ×3, and the profile-delete \`confirm()\` (now a destructive confirm)
- **\`no-alert\` ESLint rule** keeps native popups from coming back

## Verification

- Live in the preview (dark + light): delete-profile confirm renders on-theme (\`bg oklch(0.16 0.008 260)\` in dark, \`oklch(0.97 0.008 250)\` in light), Cancel resolves false and leaves the profile intact, plain alerts show a single OK, zero console errors
- 6 new component tests (1542 total, 84 files): render + theming, pre-line preservation, confirm true/false, Esc-resolves-false, destructive palette, queue ordering — the queue test caught the Radix double-dismiss bug during development
- \`eslint\` clean with the new rule; \`npm run build\` green incl. the no-CDN guard

Version 1.2.17.