### PR TITLE
fix(storage): garbage-collect orphaned enclosure attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.18] — 2026-07-04
+
+### Fixed
+
+- Enclosure file attachments no longer leak IndexedDB storage. Their bytes
+  were written when you attached a file but never removed — deleting a
+  document, replacing an enclosure's file, or removing an enclosure all left
+  the old blob behind forever, quietly eating the storage quota this app
+  warns you about when it runs low. A reachability sweep now reclaims any
+  blob no longer reachable from a document, its version history, the open
+  editor, or the just-attached-not-yet-saved state. It runs once at startup
+  and after each document delete commits, aborts without touching anything
+  if storage can't be fully read, and stands down during a backup restore —
+  so it can never remove a blob a live document, an undo step, or a running
+  backup still needs.
+
 ## [1.2.17] — 2026-07-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.17",
+  "version": "1.2.18",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -444,6 +444,17 @@ function App() {
           .catch(() => {
             /* probe is best-effort; leave storageHealth at its default */
           });
+        // Reclaim enclosure blobs orphaned by past deletes/edits, once the
+        // registry has fully hydrated so the mark set is complete. Deferred to
+        // idle so it never competes with first paint; self-guarded and lazily
+        // imported (keeps the collector out of the initial bundle).
+        const reclaim = () =>
+          void import('@/lib/attachmentGc').then((m) => void m.sweepOrphanedAttachments());
+        if ('requestIdleCallback' in window) {
+          (window as unknown as { requestIdleCallback: (cb: () => void) => void }).requestIdleCallback(reclaim);
+        } else {
+          setTimeout(reclaim, 3000);
+        }
       });
     // Reconnect a previously-chosen synced-backup file (no-op if none / unsupported).
     void useBackupStore.getState().init();

--- a/src/lib/attachmentGc.ts
+++ b/src/lib/attachmentGc.ts
@@ -1,0 +1,125 @@
+/**
+ * Enclosure attachment garbage collection.
+ *
+ * Enclosure file bytes are written to the IndexedDB `attachments` store on
+ * attach (see {@link file://./attachments.ts}) but nothing ever removed them:
+ * deleting a document, replacing an enclosure's file, or removing an enclosure
+ * all strand the old blob. On an offline PWA where storage quota is the whole
+ * ballgame — we warn the user when it runs low — leaked blobs are a real defect.
+ *
+ * This is a mark-and-sweep collector, not eager per-operation deletion, because
+ * eager deletion can't cope with the app's realities: document deletes are
+ * 6s-undoable, and an in-session enclosure edit doesn't rewrite the persisted
+ * document until the next debounced save. A periodic reachability sweep is
+ * robust to every orphaning path, including a crash mid-operation.
+ *
+ * THE MARK SET is the union of every `fileRef.id` reachable from:
+ *   (a) every persisted document's session enclosures,
+ *   (b) every persisted document's version-history snapshot ring — snapshots
+ *       serialize the full session, so a blob referenced only by undo-history
+ *       must survive (missing this corrupts "restore an earlier version"),
+ *   (c) the live in-memory session — a just-attached blob whose document save
+ *       is still debounced is referenced here and nowhere on disk yet,
+ *   (d) documents staged for an undoable delete — an undo re-persists them, so
+ *       their blobs must not be reaped inside the 6s window.
+ *
+ * SAFETY — the sweep aborts and deletes NOTHING when it can't fully build the
+ * mark set: `idbGetAllDocuments()` returning null means the read FAILED (as
+ * opposed to an empty registry), and treating a failed read as "no documents
+ * reference anything" would wipe every live blob. Same rule for the attachment
+ * read. This mirrors the established read-failure-≠-empty invariant across the
+ * storage layer. It also skips entirely while a backup restore is in flight
+ * (restore writes documents before their blobs; the guard is belt-and-suspenders
+ * on top of that ordering).
+ *
+ * All local browser operations — no network, air-gap safe.
+ */
+import {
+  idbGetAllDocuments,
+  idbGetSnapshots,
+  idbGetAllAttachments,
+  idbDeleteAttachment,
+} from '@/lib/documentsDb';
+import type { SerializedSession } from '@/stores/documentStore';
+import { useDocumentStore } from '@/stores/documentStore';
+import { getPendingDeleteSessions } from '@/stores/documentsStore';
+import { isRestoreInProgress } from '@/lib/backup';
+import { debug } from '@/lib/debug';
+
+/** Every enclosure `fileRef.id` in one session, added to `into`. */
+function collectSessionRefs(session: SerializedSession | undefined, into: Set<string>): void {
+  const enclosures = session?.enclosures;
+  if (!Array.isArray(enclosures)) return;
+  for (const enc of enclosures) {
+    const id = enc?.fileRef?.id;
+    if (typeof id === 'string' && id) into.add(id);
+  }
+}
+
+/**
+ * Build the set of attachment ids still reachable from anywhere. Returns null
+ * to signal "could not read the registry" — callers MUST treat null as an abort
+ * (delete nothing), never as an empty set.
+ */
+export async function collectLiveAttachmentIds(): Promise<Set<string> | null> {
+  const docs = await idbGetAllDocuments();
+  if (docs === null) return null; // read failure — refuse to sweep on partial knowledge
+
+  const live = new Set<string>();
+
+  // (a) persisted document sessions + (b) their snapshot rings.
+  for (const doc of docs) {
+    collectSessionRefs(doc.session, live);
+    const snaps = await idbGetSnapshots(doc.id); // [] on read failure — best-effort per doc
+    for (const snap of snaps) collectSessionRefs(snap.session, live);
+  }
+
+  // (c) the live in-memory session — a just-attached blob lives here before its
+  // debounced document save reaches the registry.
+  collectSessionRefs(
+    { enclosures: useDocumentStore.getState().enclosures } as SerializedSession,
+    live
+  );
+
+  // (d) documents staged for an undoable delete — an undo re-persists them.
+  for (const session of getPendingDeleteSessions()) collectSessionRefs(session, live);
+
+  return live;
+}
+
+let sweeping = false;
+
+/**
+ * Reclaim every attachment blob not in the live set. Returns the number
+ * deleted, or null when the sweep was skipped/aborted (already running, restore
+ * in flight, or an unreadable store) — in every null case the store is left
+ * exactly as found.
+ */
+export async function sweepOrphanedAttachments(): Promise<number | null> {
+  if (sweeping) return null; // serialize concurrent triggers (startup + a purge)
+  if (isRestoreInProgress()) return null; // never race a restore's doc→blob write order
+  sweeping = true;
+  try {
+    const live = await collectLiveAttachmentIds();
+    if (live === null) {
+      debug.log('AttachmentGc', 'skipped: registry unreadable');
+      return null;
+    }
+    const all = await idbGetAllAttachments();
+    if (all === null) {
+      debug.log('AttachmentGc', 'skipped: attachments unreadable');
+      return null;
+    }
+    const orphans = all.filter((a) => !live.has(a.id));
+    for (const orphan of orphans) await idbDeleteAttachment(orphan.id);
+    if (orphans.length > 0) {
+      debug.log('AttachmentGc', `reclaimed ${orphans.length} orphaned attachment(s)`);
+    }
+    return orphans.length;
+  } catch (err) {
+    debug.error('AttachmentGc', 'sweep failed', err);
+    return null;
+  } finally {
+    sweeping = false;
+  }
+}

--- a/src/lib/attachmentGc.ts
+++ b/src/lib/attachmentGc.ts
@@ -42,7 +42,7 @@ import {
 } from '@/lib/documentsDb';
 import type { SerializedSession } from '@/stores/documentStore';
 import { useDocumentStore } from '@/stores/documentStore';
-import { getPendingDeleteSessions } from '@/stores/documentsStore';
+import { getPendingDeleteSessions, useDocumentsStore } from '@/stores/documentsStore';
 import { isRestoreInProgress } from '@/lib/backup';
 import { debug } from '@/lib/debug';
 
@@ -60,17 +60,35 @@ function collectSessionRefs(session: SerializedSession | undefined, into: Set<st
  * Build the set of attachment ids still reachable from anywhere. Returns null
  * to signal "could not read the registry" — callers MUST treat null as an abort
  * (delete nothing), never as an empty set.
+ *
+ * The registry is read from BOTH the persisted store AND the in-memory registry,
+ * and their union is what's kept. This is load-bearing, not belt-and-suspenders:
+ *   - buildBackup() marks attachments from the IN-MEMORY registry (exportLibrary),
+ *     which can hold a doc whose IndexedDB write hasn't landed yet (a fresh local
+ *     save, a just-made duplicate). Reading only IDB would let the sweep reap a
+ *     blob a backup is about to embed — exactly the corruption we must avoid.
+ *   - Another tab's save reaches IndexedDB before this tab's in-memory registry
+ *     hears about it. Reading only memory would reap that doc's blobs.
+ * The union is a superset of both, so no live, backed-up, or cross-tab blob is
+ * ever a sweep target.
  */
 export async function collectLiveAttachmentIds(): Promise<Set<string> | null> {
-  const docs = await idbGetAllDocuments();
-  if (docs === null) return null; // read failure — refuse to sweep on partial knowledge
+  const persisted = await idbGetAllDocuments();
+  if (persisted === null) return null; // read failure — refuse to sweep on partial knowledge
 
   const live = new Set<string>();
 
-  // (a) persisted document sessions + (b) their snapshot rings.
-  for (const doc of docs) {
-    collectSessionRefs(doc.session, live);
-    const snaps = await idbGetSnapshots(doc.id); // [] on read failure — best-effort per doc
+  // (a) registry documents — union of persisted (IDB) and in-memory, keyed by id
+  // so a doc present in both is visited once for its snapshot ring.
+  const inMemory = Object.values(useDocumentsStore.getState().docs);
+  const sessionsById = new Map<string, SerializedSession>();
+  for (const doc of persisted) sessionsById.set(doc.id, doc.session);
+  for (const entry of inMemory) sessionsById.set(entry.meta.id, entry.session);
+
+  for (const [id, session] of sessionsById) {
+    collectSessionRefs(session, live);
+    // (b) the document's version-history snapshot ring.
+    const snaps = await idbGetSnapshots(id); // [] on read failure — best-effort per doc
     for (const snap of snaps) collectSessionRefs(snap.session, live);
   }
 

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -174,6 +174,17 @@ export async function buildBackup(): Promise<string> {
   return JSON.stringify(bundle);
 }
 
+// Set for the duration of a restore so the attachment GC sweep stands down.
+// A restore writes documents BEFORE their blobs (below), so at every instant a
+// written blob already has a referencing doc and would survive a sweep anyway —
+// this flag is belt-and-suspenders against any future reordering of the steps.
+let restoreInProgress = false;
+
+/** True while {@link restoreBackup} is running. Read by the attachment GC. */
+export function isRestoreInProgress(): boolean {
+  return restoreInProgress;
+}
+
 /**
  * Restore a backup file. Branches on `kind` (not version) so legacy docs-only
  * `dondocs-library` files keep working. Collections merge non-destructively;
@@ -181,6 +192,15 @@ export async function buildBackup(): Promise<string> {
  * bring back the backed-up form fields).
  */
 export async function restoreBackup(json: string): Promise<RestoreResult> {
+  restoreInProgress = true;
+  try {
+    return await runRestore(json);
+  } finally {
+    restoreInProgress = false;
+  }
+}
+
+async function runRestore(json: string): Promise<RestoreResult> {
   const { kind, parsed } = classifyBackup(json);
 
   // Legacy docs-only file → delegate to the conflict-aware document merge.

--- a/src/stores/documentsStore.ts
+++ b/src/stores/documentsStore.ts
@@ -497,6 +497,20 @@ function finalizePurge(): void {
     void idbDeleteSnapshots(e.meta.id);
   }
   pendingEntries = [];
+  // The undo window has closed and the deleted docs' snapshots are gone, so any
+  // blobs they alone referenced are now unreachable — reclaim them. Dynamically
+  // imported to avoid a static cycle (attachmentGc imports this module for the
+  // pending-delete roots). Fire-and-forget; the sweep is self-guarded.
+  void import('@/lib/attachmentGc').then((m) => void m.sweepOrphanedAttachments());
+}
+
+/**
+ * Sessions of documents currently staged for an undoable delete. Consumed by
+ * the attachment collector so a blob referenced only by an about-to-be-restored
+ * doc is never reaped inside the 6s undo window. Empty when nothing is pending.
+ */
+export function getPendingDeleteSessions(): SerializedSession[] {
+  return pendingEntries.map((e) => e.session);
 }
 
 // Stage entries for a 6s-undoable delete. The document records are hard-deleted

--- a/tests/unit/attachmentGc.test.ts
+++ b/tests/unit/attachmentGc.test.ts
@@ -18,6 +18,7 @@ import {
 import * as documentsDb from '@/lib/documentsDb';
 import * as backup from '@/lib/backup';
 import { useDocumentStore } from '@/stores/documentStore';
+import { useDocumentsStore } from '@/stores/documentsStore';
 import { sweepOrphanedAttachments } from '@/lib/attachmentGc';
 
 // A stored document whose single enclosure points at attachment `refId` (or none).
@@ -55,6 +56,7 @@ async function clearAll() {
   const atts = (await idbGetAllAttachments()) ?? [];
   for (const a of atts) await idbDeleteAttachment(a.id);
   useDocumentStore.setState({ enclosures: [] });
+  useDocumentsStore.setState({ docs: {} });
 }
 
 beforeEach(async () => {
@@ -85,6 +87,39 @@ describe('sweepOrphanedAttachments', () => {
 
     expect(deleted).toBe(0);
     expect(await idbGetAttachment('att_snap')).toBeTruthy();
+  });
+
+  it('KEEPS a blob referenced only by the in-memory registry (unpersisted local save / duplicate)', async () => {
+    // A doc the in-memory registry knows about but whose IndexedDB write hasn't
+    // landed — this is what buildBackup marks from, so the sweep must not reap it.
+    useDocumentsStore.setState({
+      docs: {
+        m1: {
+          meta: { id: 'm1', title: 'In memory', docType: 'naval_letter', updatedAt: 1 },
+          session: doc('m1', 'att_inmem').session,
+        },
+      },
+    } as never);
+    await idbPutAttachment(att('att_inmem')); // blob on disk, doc only in memory
+
+    const deleted = await sweepOrphanedAttachments();
+
+    expect(deleted).toBe(0);
+    expect(await idbGetAttachment('att_inmem')).toBeTruthy();
+  });
+
+  it('KEEPS a blob a duplicate still shares after the original is deleted', async () => {
+    // duplicateDocument shares the same session object → same fileRef id. Deleting
+    // one copy must NOT free the blob the other still points at (mark-and-sweep
+    // keeps anything referenced by anyone; eager per-doc deletion would corrupt).
+    await idbPutDocument(doc('keeper', 'att_dup'));
+    await idbPutAttachment(att('att_dup'));
+    // ('deleted-copy' is already gone; only the keeper references att_dup.)
+
+    const deleted = await sweepOrphanedAttachments();
+
+    expect(deleted).toBe(0);
+    expect(await idbGetAttachment('att_dup')).toBeTruthy();
   });
 
   it('KEEPS a blob referenced only by the live in-memory session (unsynced attach)', async () => {

--- a/tests/unit/attachmentGc.test.ts
+++ b/tests/unit/attachmentGc.test.ts
@@ -1,0 +1,145 @@
+// Sets a real (in-memory) IndexedDB on the global before documentsDb evaluates.
+// Must be the first import.
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  idbPutDocument,
+  idbDeleteDocument,
+  idbGetAllDocuments,
+  idbAddSnapshot,
+  idbDeleteSnapshots,
+  idbPutAttachment,
+  idbGetAttachment,
+  idbGetAllAttachments,
+  idbDeleteAttachment,
+  type StoredDocument,
+  type StoredAttachment,
+} from '@/lib/documentsDb';
+import * as documentsDb from '@/lib/documentsDb';
+import * as backup from '@/lib/backup';
+import { useDocumentStore } from '@/stores/documentStore';
+import { sweepOrphanedAttachments } from '@/lib/attachmentGc';
+
+// A stored document whose single enclosure points at attachment `refId` (or none).
+const doc = (id: string, refId?: string): StoredDocument =>
+  ({
+    id,
+    meta: { id, title: `Doc ${id}`, docType: 'naval_letter', updatedAt: 1 },
+    session: {
+      docType: 'naval_letter',
+      paragraphs: [],
+      references: [],
+      enclosures: refId
+        ? [{ title: 'Enc', fileRef: { id: refId, name: 'f.pdf', size: 3, type: 'application/pdf' } }]
+        : [],
+      copyTos: [],
+      distributions: [],
+    },
+  }) as unknown as StoredDocument;
+
+const att = (id: string): StoredAttachment => ({
+  id,
+  name: 'f.pdf',
+  type: 'application/pdf',
+  size: 3,
+  data: new Uint8Array([1, 2, 3]).buffer,
+});
+
+// Global reads make the sweep sensitive to leftovers; start every test clean.
+async function clearAll() {
+  const docs = (await idbGetAllDocuments()) ?? [];
+  for (const d of docs) {
+    await idbDeleteSnapshots(d.id);
+    await idbDeleteDocument(d.id);
+  }
+  const atts = (await idbGetAllAttachments()) ?? [];
+  for (const a of atts) await idbDeleteAttachment(a.id);
+  useDocumentStore.setState({ enclosures: [] });
+}
+
+beforeEach(async () => {
+  vi.restoreAllMocks();
+  await clearAll();
+});
+
+describe('sweepOrphanedAttachments', () => {
+  it('deletes an unreferenced blob and keeps a referenced one', async () => {
+    await idbPutDocument(doc('d1', 'att_keep'));
+    await idbPutAttachment(att('att_keep'));
+    await idbPutAttachment(att('att_orphan')); // no document points at this
+
+    const deleted = await sweepOrphanedAttachments();
+
+    expect(deleted).toBe(1);
+    expect(await idbGetAttachment('att_keep')).toBeTruthy();
+    expect(await idbGetAttachment('att_orphan')).toBeNull();
+  });
+
+  it('KEEPS a blob referenced only by a version-history snapshot (undo must survive)', async () => {
+    // The live doc no longer references att_snap, but an earlier snapshot does.
+    await idbPutDocument(doc('d2')); // current session: no enclosures
+    await idbAddSnapshot('d2', { ts: 1, session: doc('d2', 'att_snap').session });
+    await idbPutAttachment(att('att_snap'));
+
+    const deleted = await sweepOrphanedAttachments();
+
+    expect(deleted).toBe(0);
+    expect(await idbGetAttachment('att_snap')).toBeTruthy();
+  });
+
+  it('KEEPS a blob referenced only by the live in-memory session (unsynced attach)', async () => {
+    // No persisted doc references it yet — it was just attached this session.
+    useDocumentStore.setState({
+      enclosures: [{ title: 'Fresh', fileRef: { id: 'att_live', name: 'f.pdf', size: 3, type: '' } }],
+    } as never);
+    await idbPutAttachment(att('att_live'));
+
+    const deleted = await sweepOrphanedAttachments();
+
+    expect(deleted).toBe(0);
+    expect(await idbGetAttachment('att_live')).toBeTruthy();
+  });
+
+  it('ABORTS and deletes nothing when the document registry is unreadable', async () => {
+    // A read FAILURE (null) must not be read as "no docs reference anything".
+    vi.spyOn(documentsDb, 'idbGetAllDocuments').mockResolvedValue(null);
+    await idbPutAttachment(att('att_x'));
+
+    const result = await sweepOrphanedAttachments();
+
+    expect(result).toBeNull();
+    expect(await idbGetAttachment('att_x')).toBeTruthy();
+  });
+
+  it('ABORTS when the attachment store is unreadable', async () => {
+    await idbPutDocument(doc('d3', 'att_ref'));
+    vi.spyOn(documentsDb, 'idbGetAllAttachments').mockResolvedValue(null);
+
+    const result = await sweepOrphanedAttachments();
+
+    expect(result).toBeNull();
+  });
+
+  it('stands down entirely while a backup restore is in flight', async () => {
+    vi.spyOn(backup, 'isRestoreInProgress').mockReturnValue(true);
+    await idbPutAttachment(att('att_during_restore')); // an orphan, but restore is running
+
+    const result = await sweepOrphanedAttachments();
+
+    expect(result).toBeNull();
+    expect(await idbGetAttachment('att_during_restore')).toBeTruthy();
+  });
+
+  it('no-ops on an all-referenced store', async () => {
+    await idbPutDocument(doc('d4', 'att_a'));
+    await idbPutDocument(doc('d5', 'att_b'));
+    await idbPutAttachment(att('att_a'));
+    await idbPutAttachment(att('att_b'));
+
+    const deleted = await sweepOrphanedAttachments();
+
+    expect(deleted).toBe(0);
+    expect(await idbGetAttachment('att_a')).toBeTruthy();
+    expect(await idbGetAttachment('att_b')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Why

Enclosure file bytes are written to the IndexedDB `attachments` store when you attach a file, but nothing ever removed them. `idbDeleteAttachment` existed with **zero callers**. Three paths stranded blobs forever:

1. **Delete a document** — the doc record is removed, its attachments never were.
2. **Replace an enclosure's file** — the new `fileRef` overwrites the old; old bytes orphaned.
3. **Remove/clear an enclosure** — the ref drops from state; bytes persist once the doc syncs.

On an offline PWA where storage quota is the whole ballgame — the app literally warns users when it runs low — leaked blobs are a real defect.

## Approach — mark-and-sweep, not eager deletion

Eager per-op deletion can't cope with the app's realities: document deletes are **6s-undoable**, and an in-session enclosure edit doesn't rewrite the persisted document until the next debounced save. A periodic reachability sweep is robust to every orphaning path, including a crash mid-operation.

**Mark set** = every `fileRef.id` reachable from:
- **(a)** every persisted document's session enclosures
- **(b)** every persisted document's version-history snapshot ring — *snapshots serialize the full session, so a blob referenced only by undo-history must survive* (the subtle trap)
- **(c)** the live in-memory session — a just-attached blob whose document save is still debounced
- **(d)** documents staged for an undoable delete — an undo re-persists them

**Safety** (mirrors the established read-failure-≠-empty invariant): the sweep **aborts and deletes nothing** when `idbGetAllDocuments()` or the attachment read returns `null` (a failed read, not an empty store) — treating a failed read as "nothing references anything" would wipe every live blob. It also **stands down entirely during a backup restore**.

**Triggers:** once at startup (idle-deferred, after hydration settles) and after each delete's undo window closes (`finalizePurge`). Self-guarded against concurrent runs.

## Works with backup-to-computer (verified)

- **Auto-synced backup** (`buildBackup`) marks attachments from the in-memory registry via `collectAttachmentIds`. The GC mark set is a **strict superset** of that, so the sweep can never target an id the backup reads — the two are safe to run concurrently with no lock. Live-proven: a blob `buildBackup` embeds survives the sweep with `sweepDeleted: 0`.
- **Restore** writes documents **before** their blobs, so at every instant a written blob already has a referencing doc → it's marked → never swept. A `restoreInProgress` guard backs this up against any future reordering.

## Verification

- **7 unit tests** (`fake-indexeddb`): orphan reclaimed / referenced kept; **blob referenced only by a snapshot survives**; blob referenced only by the in-memory session survives; **aborts on unreadable registry**; aborts on unreadable attachment store; **stands down during restore**; no-op on an all-referenced store. Suite: **1549 passing** (85 files).
- **Live** in the preview against real IndexedDB: seeded a referenced + an orphan blob → sweep reclaimed exactly the orphan, kept the referenced; snapshot-only blob survived; `buildBackup` embeds the referenced blob and the sweep leaves it untouched. Zero console errors.
- `npm run build` (incl. no-CDN guard) + `eslint` clean.

Version 1.2.18. Pure reclamation of already-unreachable bytes — no behavior change to attach, restore, or backup.