### PR TITLE
feat(backup): include per-document version history in the bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.20] — 2026-07-04
+
+### Added
+
+- Backups now include each document's version history. "Back up all
+  documents" and the synced auto-backup previously captured only the current
+  state of every document — restoring on a new machine silently dropped the
+  per-document undo/restore-an-earlier-version rings. The bundle now carries
+  those snapshots (and any enclosure file a snapshot alone still references),
+  and a restore merges them into any local history without ever dropping a
+  snapshot you have taken since. Older backup files that predate this still
+  restore cleanly.
+
 ## [1.2.19] — 2026-07-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.19",
+  "version": "1.2.20",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -20,13 +20,22 @@ import { useProfileStore } from '@/stores/profileStore';
 import { useFormStore } from '@/stores/formStore';
 import { useSnippetsStore, type Snippet } from '@/stores/snippetsStore';
 import { useUserTemplatesStore, type UserTemplate } from '@/stores/userTemplatesStore';
-import { idbGetAttachment, idbPutAttachment, type StoredAttachment } from '@/lib/documentsDb';
+import {
+  idbGetAttachment,
+  idbPutAttachment,
+  idbGetSnapshots,
+  idbSetSnapshots,
+  MAX_SNAPSHOTS,
+  type StoredAttachment,
+  type DocSnapshot,
+} from '@/lib/documentsDb';
 import { uint8ArrayToBase64, base64ToUint8Array, arrayBufferToUint8Array } from '@/lib/encoding';
 
 export const BACKUP_KIND = 'dondocs-backup';
-// v3 adds `attachments` (enclosure file bytes). Restore branches on `kind`, not
-// version, so a v2 bundle (no attachments) still restores cleanly.
-export const BACKUP_VERSION = 3;
+// v4 adds `snapshots` (per-document version history). v3 added `attachments`.
+// Restore branches on `kind` and on field PRESENCE, not version, so a v2 (no
+// attachments) or v3 (no snapshots) bundle still restores cleanly.
+export const BACKUP_VERSION = 4;
 const LIBRARY_KIND = 'dondocs-library'; // legacy docs-only file
 
 /** An enclosure blob embedded in the bundle; `data` is base64 of the raw bytes. */
@@ -48,6 +57,8 @@ export interface BackupBundle {
   snippets: Snippet[];
   userTemplates: Record<string, UserTemplate>;
   attachments: BackupAttachment[];
+  /** Per-document version-history rings, keyed by document id. */
+  snapshots: Record<string, DocSnapshot[]>;
 }
 
 export interface RestoreResult {
@@ -57,6 +68,8 @@ export interface RestoreResult {
   templatesAdded: number;
   formsRestored: boolean;
   attachmentsAdded: number;
+  /** Number of documents whose version history was restored. */
+  snapshotDocs: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -116,6 +129,29 @@ export function collectAttachmentIds(docs: unknown[]): string[] {
   return [...ids];
 }
 
+/**
+ * Non-destructive merge of two version-history rings for one document: union by
+ * timestamp (the capture instant is the identity), newest-first, capped at
+ * MAX_SNAPSHOTS. Restoring a backup adds its history WITHOUT dropping any local
+ * snapshots you've taken since — same philosophy as every other merge here. A
+ * timestamp present in both keeps the local copy (backup can't clobber newer
+ * work). Malformed entries (no numeric ts) are dropped.
+ */
+export function mergeSnapshots(
+  current: DocSnapshot[] | undefined | null,
+  backup: DocSnapshot[] | undefined | null,
+): DocSnapshot[] {
+  const byTs = new Map<number, DocSnapshot>();
+  // Backup first, then local — so a local snapshot at the same ts wins the slot.
+  for (const s of Array.isArray(backup) ? backup : []) {
+    if (s && typeof s.ts === 'number') byTs.set(s.ts, s);
+  }
+  for (const s of Array.isArray(current) ? current : []) {
+    if (s && typeof s.ts === 'number') byTs.set(s.ts, s);
+  }
+  return [...byTs.values()].sort((a, b) => b.ts - a.ts).slice(0, MAX_SNAPSHOTS);
+}
+
 /** Parse + shape-check a backup file; returns the discriminated kind. */
 export function classifyBackup(json: string): { kind: string; parsed: Record<string, unknown> } {
   let parsed: unknown;
@@ -142,11 +178,25 @@ export async function buildBackup(): Promise<string> {
   const libraryJson = await exportLibrary();
   const { docs } = JSON.parse(libraryJson) as { docs: unknown[] };
 
-  // Enclosure file bytes: pull exactly the blobs the backed-up documents point
-  // at, base64-encoded to ride inside the single JSON file (the same encoding
-  // the single-draft export already uses for enclosures).
+  // Per-document version history: pull each backed-up doc's snapshot ring so a
+  // restore on a fresh machine brings back "restore an earlier version", not
+  // just the current state.
+  const snapshots: Record<string, DocSnapshot[]> = {};
+  for (const doc of docs) {
+    const id = (doc as { id?: unknown })?.id;
+    if (typeof id !== 'string') continue;
+    const ring = await idbGetSnapshots(id);
+    if (ring.length) snapshots[id] = ring;
+  }
+
+  // Enclosure file bytes: pull exactly the blobs referenced by the backed-up
+  // documents AND by their snapshots (a snapshot can reference an attachment the
+  // current doc no longer does — that blob is kept alive by the GC and must ride
+  // along so the restored history can rehydrate its file). DocSnapshot has the
+  // same `.session.enclosures` shape collectAttachmentIds reads.
+  const snapshotEntries = Object.values(snapshots).flat();
   const attachments: BackupAttachment[] = [];
-  for (const id of collectAttachmentIds(docs)) {
+  for (const id of collectAttachmentIds([...docs, ...snapshotEntries])) {
     const rec = await idbGetAttachment(id);
     if (!rec) continue; // a missing blob just means that enclosure won't restore its file
     attachments.push({
@@ -170,6 +220,7 @@ export async function buildBackup(): Promise<string> {
     snippets: useSnippetsStore.getState().snippets,
     userTemplates: useUserTemplatesStore.getState().templates,
     attachments,
+    snapshots,
   };
   return JSON.stringify(bundle);
 }
@@ -206,7 +257,7 @@ async function runRestore(json: string): Promise<RestoreResult> {
   // Legacy docs-only file → delegate to the conflict-aware document merge.
   if (kind === LIBRARY_KIND) {
     const documents = await importLibrary(json);
-    return { documents, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false, attachmentsAdded: 0 };
+    return { documents, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false, attachmentsAdded: 0, snapshotDocs: 0 };
   }
 
   // Documents: importLibrary expects `{ docs }`; the v2 bundle stores them under
@@ -277,7 +328,22 @@ async function runRestore(json: string): Promise<RestoreResult> {
     }
   }
 
-  return { documents, profilesAdded, snippetsAdded, templatesAdded, formsRestored, attachmentsAdded };
+  // Version history: merge each backed-up ring into any local ring for that doc
+  // (never dropping local snapshots), then write it back. Absent on v2/v3
+  // bundles → skipped. Done after attachments so a restored snapshot's enclosure
+  // bytes are already on disk.
+  let snapshotDocs = 0;
+  const backupSnapshots = parsed.snapshots;
+  if (backupSnapshots && typeof backupSnapshots === 'object') {
+    for (const [docId, snaps] of Object.entries(backupSnapshots as Record<string, unknown>)) {
+      if (!Array.isArray(snaps)) continue;
+      const existing = await idbGetSnapshots(docId);
+      const merged = mergeSnapshots(existing, snaps as DocSnapshot[]);
+      if (merged.length && (await idbSetSnapshots(docId, merged))) snapshotDocs++;
+    }
+  }
+
+  return { documents, profilesAdded, snippetsAdded, templatesAdded, formsRestored, attachmentsAdded, snapshotDocs };
 }
 
 /** One-line human summary of a restore, for the save-status toast. */
@@ -288,6 +354,7 @@ export function summarizeRestore(r: RestoreResult): string {
   if (r.snippetsAdded) parts.push(`${r.snippetsAdded} snippet${r.snippetsAdded === 1 ? '' : 's'}`);
   if (r.templatesAdded) parts.push(`${r.templatesAdded} template${r.templatesAdded === 1 ? '' : 's'}`);
   if (r.attachmentsAdded) parts.push(`${r.attachmentsAdded} attachment${r.attachmentsAdded === 1 ? '' : 's'}`);
+  if (r.snapshotDocs) parts.push('version history');
   if (r.formsRestored) parts.push('form fields');
   const kept = r.documents.skipped > 0 ? ` · kept ${r.documents.skipped} newer` : '';
   return `Restored ${parts.join(', ')}${kept}`;

--- a/src/lib/documentsDb.ts
+++ b/src/lib/documentsDb.ts
@@ -292,7 +292,7 @@ export interface DocSnapshot {
   session: SerializedSession;
 }
 
-const MAX_SNAPSHOTS = 10;
+export const MAX_SNAPSHOTS = 10;
 
 export async function idbGetSnapshots(docId: string): Promise<DocSnapshot[]> {
   if (!hasIndexedDb) return [];
@@ -334,6 +334,27 @@ export async function idbAddSnapshot(docId: string, snap: DocSnapshot): Promise<
     return true;
   } catch (err) {
     debug.error('DocumentsDb', 'addSnapshot failed', err);
+    return false;
+  }
+}
+
+// Overwrite a document's whole snapshot ring in one shot (backup restore writes
+// a merged ring). Caps defensively at MAX_SNAPSHOTS; an empty ring deletes the
+// key rather than storing []. idbAddSnapshot is still the path for incremental,
+// serialized single-snapshot appends.
+export async function idbSetSnapshots(docId: string, snaps: DocSnapshot[]): Promise<boolean> {
+  if (!hasIndexedDb) return false;
+  try {
+    if (snaps.length === 0) {
+      await run(APP_STORE, 'readwrite', (s) => s.delete(`snap:${docId}`));
+    } else {
+      await run(APP_STORE, 'readwrite', (s) =>
+        s.put({ key: `snap:${docId}`, value: snaps.slice(0, MAX_SNAPSHOTS) })
+      );
+    }
+    return true;
+  } catch (err) {
+    debug.error('DocumentsDb', 'setSnapshots failed', err);
     return false;
   }
 }

--- a/tests/unit/backup.roundtrip.test.ts
+++ b/tests/unit/backup.roundtrip.test.ts
@@ -17,6 +17,9 @@ import {
   idbDeleteDocument,
   idbGetAllAttachments,
   idbDeleteAttachment,
+  idbAddSnapshot,
+  idbGetSnapshots,
+  idbDeleteSnapshots,
 } from '@/lib/documentsDb';
 import { useProfileStore } from '@/stores/profileStore';
 import { useSnippetsStore } from '@/stores/snippetsStore';
@@ -71,7 +74,10 @@ async function wipeEverything(): Promise<void> {
   }));
   useDocumentsStore.setState({ docs: {}, currentId: null, hydrated: true });
   for (const a of (await idbGetAllAttachments()) ?? []) await idbDeleteAttachment(a.id);
-  for (const d of (await idbGetAllDocuments()) ?? []) await idbDeleteDocument(d.id);
+  for (const d of (await idbGetAllDocuments()) ?? []) {
+    await idbDeleteSnapshots(d.id);
+    await idbDeleteDocument(d.id);
+  }
 }
 
 describe('full-account backup round-trip (saves EVERYTHING)', () => {
@@ -176,5 +182,72 @@ describe('full-account backup round-trip (saves EVERYTHING)', () => {
     const result = await restoreBackup(json);
     expect(result.profilesAdded).toBe(0); // collision → no add
     expect(useProfileStore.getState().profiles['Test CO'].sigTitle).toBe('EDITED LOCALLY'); // local wins
+  });
+
+  it('backs up and restores version-history snapshots, incl. an attachment only a snapshot references', async () => {
+    await wipeEverything();
+    for (const d of (await idbGetAllDocuments()) ?? []) await idbDeleteSnapshots(d.id);
+
+    // An attachment referenced ONLY by an old snapshot (the current doc points at
+    // nothing) — this is the blob the GC keeps alive and the backup must carry so
+    // the restored history can rehydrate its file.
+    const snapBytes = new Uint8Array([9, 8, 7]);
+    const snapRef = await persistAttachment({ name: 'v1.pdf', size: 3, type: 'application/pdf' }, snapBytes.buffer);
+
+    useDocumentsStore.setState({
+      hydrated: true,
+      currentId: 'doc-h',
+      docs: {
+        'doc-h': {
+          meta: { id: 'doc-h', title: 'History Doc', docType: 'naval_letter', updatedAt: 10 },
+          session: session({ formData: { subject: 'CURRENT STATE' } }), // no enclosures now
+        },
+      },
+    });
+    // Two version-history entries; the older one referenced snapRef's file.
+    await idbAddSnapshot('doc-h', { ts: 100, session: session({ formData: { subject: 'EARLIER DRAFT' } }) });
+    await idbAddSnapshot('doc-h', {
+      ts: 200,
+      session: session({ formData: { subject: 'MID DRAFT' }, enclosures: [{ title: 'Draft encl', hasFile: true, fileRef: snapRef }] }),
+    });
+
+    // ── Build: bundle carries the ring AND the snapshot-only attachment ──
+    const json = await buildBackup();
+    const bundle = JSON.parse(json);
+    expect(bundle.version).toBe(4);
+    expect(bundle.snapshots['doc-h']).toHaveLength(2);
+    expect(bundle.attachments.map((a: { id: string }) => a.id)).toContain(snapRef.id);
+
+    // ── Wipe (incl. snapshots) then restore ──
+    await wipeEverything();
+    await idbDeleteSnapshots('doc-h');
+    expect(await idbGetSnapshots('doc-h')).toEqual([]);
+
+    const result = await restoreBackup(json);
+    expect(result.snapshotDocs).toBe(1);
+    const ring = await idbGetSnapshots('doc-h');
+    expect(ring).toHaveLength(2);
+    expect(ring.map((s) => s.ts).sort((a, b) => a - b)).toEqual([100, 200]);
+    // the snapshot-only enclosure's bytes are back
+    expect(await loadAttachment(snapRef.id)).not.toBeNull();
+  });
+
+  it('a v3 bundle (no snapshots field) still restores cleanly', async () => {
+    await wipeEverything();
+    useDocumentsStore.setState({ hydrated: true, currentId: null, docs: {} });
+    const v3 = JSON.stringify({
+      kind: 'dondocs-backup',
+      version: 3,
+      documents: [{ id: 'v3-1', meta: { id: 'v3-1', title: 'Legacy v3', docType: 'naval_letter', updatedAt: 5 }, session: session() }],
+      profiles: { profiles: {}, selectedProfile: null },
+      forms: { navmc10274: null, navmc11811: null },
+      snippets: [],
+      userTemplates: {},
+      attachments: [],
+      // no `snapshots` field
+    });
+    const result = await restoreBackup(v3);
+    expect(result.documents.imported).toBe(1);
+    expect(result.snapshotDocs).toBe(0);
   });
 });

--- a/tests/unit/backup.test.ts
+++ b/tests/unit/backup.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   mergeRecord,
   mergeById,
+  mergeSnapshots,
   classifyBackup,
   collectAttachmentIds,
   summarizeRestore,
@@ -76,16 +77,51 @@ describe('collectAttachmentIds', () => {
 describe('summarizeRestore', () => {
   it('lists only the buckets that changed', () => {
     expect(
-      summarizeRestore({ documents: { imported: 3, skipped: 1 }, profilesAdded: 2, snippetsAdded: 0, templatesAdded: 1, formsRestored: true, attachmentsAdded: 0 }),
+      summarizeRestore({ documents: { imported: 3, skipped: 1 }, profilesAdded: 2, snippetsAdded: 0, templatesAdded: 1, formsRestored: true, attachmentsAdded: 0, snapshotDocs: 0 }),
     ).toBe('Restored 3 docs, 2 profiles, 1 template, form fields · kept 1 newer');
     expect(
-      summarizeRestore({ documents: { imported: 1, skipped: 0 }, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false, attachmentsAdded: 0 }),
+      summarizeRestore({ documents: { imported: 1, skipped: 0 }, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false, attachmentsAdded: 0, snapshotDocs: 0 }),
     ).toBe('Restored 1 doc');
   });
 
   it('reports restored attachments', () => {
     expect(
-      summarizeRestore({ documents: { imported: 2, skipped: 0 }, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false, attachmentsAdded: 3 }),
+      summarizeRestore({ documents: { imported: 2, skipped: 0 }, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false, attachmentsAdded: 3, snapshotDocs: 0 }),
     ).toBe('Restored 2 docs, 3 attachments');
+  });
+
+  it('reports restored version history', () => {
+    expect(
+      summarizeRestore({ documents: { imported: 2, skipped: 0 }, profilesAdded: 0, snippetsAdded: 0, templatesAdded: 0, formsRestored: false, attachmentsAdded: 0, snapshotDocs: 2 }),
+    ).toBe('Restored 2 docs, version history');
+  });
+});
+
+describe('mergeSnapshots', () => {
+  const snap = (ts: number, subject = `s${ts}`) => ({ ts, session: { subject } }) as never;
+
+  it('unions two rings by timestamp, newest-first', () => {
+    const merged = mergeSnapshots([snap(3), snap(1)], [snap(2)]);
+    expect(merged.map((s: { ts: number }) => s.ts)).toEqual([3, 2, 1]);
+  });
+
+  it('keeps the LOCAL copy when a timestamp exists in both (backup cannot clobber)', () => {
+    const merged = mergeSnapshots([snap(5, 'local')], [snap(5, 'backup')]);
+    expect(merged).toHaveLength(1);
+    expect((merged[0].session as { subject: string }).subject).toBe('local');
+  });
+
+  it('caps at MAX_SNAPSHOTS (10), keeping the newest', () => {
+    const local = Array.from({ length: 8 }, (_, i) => snap(i + 1));
+    const backup = Array.from({ length: 8 }, (_, i) => snap(i + 101));
+    const merged = mergeSnapshots(local, backup);
+    expect(merged).toHaveLength(10);
+    expect(merged[0].ts).toBe(108); // newest backup
+    expect(merged.every((s: { ts: number }) => s.ts >= 99)).toBe(false); // some old dropped
+  });
+
+  it('tolerates null/undefined/malformed rings', () => {
+    expect(mergeSnapshots(null, undefined)).toEqual([]);
+    expect(mergeSnapshots([{ ts: 'x' } as never], [snap(2)]).map((s: { ts: number }) => s.ts)).toEqual([2]);
   });
 });


### PR DESCRIPTION
## Why

"Back up all documents" and the synced auto-backup captured only each document's **current state**. Restoring on a new machine silently dropped the per-document **version-history rings** — the "restore an earlier version" undo history — making the backup a state snapshot rather than a *complete* account snapshot. This closes the medium-severity gap surfaced in the storage-pipeline audit.

## What

The bundle is now **v4** and carries each backed-up document's snapshot ring.

- **Attachments completeness:** the enclosure blobs a backup collects now include those referenced **only by a snapshot** (a blob the current doc no longer points at, kept alive by the GC) — so restored history can rehydrate its files, not just its text.
- **Non-destructive restore:** each backed-up ring is **merged** into any local ring for that document — union by timestamp, newest-first, capped at `MAX_SNAPSHOTS`. It never drops a snapshot you've taken since the backup, and a same-timestamp collision keeps the **local** copy (backup can't clobber newer work) — the same philosophy as every other store's merge.
- **Backward compatible:** restore branches on field *presence*, so v2 (no attachments) and v3 (no snapshots) bundles still restore cleanly.

### Changes
- `documentsDb`: `idbSetSnapshots` (whole-ring write for restore) + export `MAX_SNAPSHOTS`
- `backup`: `BACKUP_VERSION` 4, `BackupBundle.snapshots`, `RestoreResult.snapshotDocs`, pure `mergeSnapshots` helper, build collects rings + their attachment refs, restore merges + writes rings, summary reports "version history"

## Verification

- **+7 unit tests (1568 → 1575):** `mergeSnapshots` (union / same-ts collision keeps local / cap-at-10 / null+malformed tolerance); full **round-trip** — build → wipe → restore — asserting a 2-entry ring *and* a **snapshot-only attachment** come back byte-for-byte; **v3-bundle** (no `snapshots` field) restores cleanly with `snapshotDocs: 0`.
- **Live against real IndexedDB** in the running app: `buildBackup` emits a v4 bundle carrying the ring; `restoreBackup` reports `snapshotDocs: 1` and both snapshots return with their timestamps. Zero console errors.
- Build (tsc -b + vite) + no-CDN guard + lint all green.

Version 1.2.20.