### PR TITLE
fix(pdf): clear the compile-error banner off the viewer toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.21] — 2026-07-04
+
+### Fixed
+
+- The "compile failed" preview banner no longer covers the PDF viewer's own
+  toolbar. It sat at the top of the content area, directly over the page,
+  zoom, and fit controls; it now offsets below the toolbar so those controls
+  stay usable while the banner is shown.
+
 ## [1.2.20] — 2026-07-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.20",
+  "version": "1.2.21",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/layout/PreviewPanel.tsx
+++ b/src/components/layout/PreviewPanel.tsx
@@ -130,8 +130,10 @@ export function PreviewPanel({ pdfUrl, isCompiling, isWarmingUp = false, preview
                 visible indicator — see the auto-popup modal in App.tsx for
                 the one-shot attention-grabber that complements this banner. */}
             {displayError && !isCompiling && (
+              // top-9 clears the PdfViewer's own h-9 toolbar (PdfViewerToolbar.tsx)
+              // so the banner never buries the page/zoom/fit controls beneath it.
               <div
-                className="absolute top-0 inset-x-0 flex items-start gap-2 bg-destructive/10 border-b border-destructive/30 text-destructive px-3 py-2 text-xs"
+                className="absolute top-9 inset-x-0 flex items-start gap-2 bg-destructive/10 border-b border-destructive/30 text-destructive px-3 py-2 text-xs"
                 role="alert"
               >
                 <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />


### PR DESCRIPTION
## Why
The "compile failed — preview is out of date" banner is `absolute top-0` over the preview content, landing directly on the PdfViewer's own `h-9` toolbar and burying the page / zoom / fit controls whenever a compile fails but a stale PDF is still shown. (Audit HIGH — Preview & PDF.)

## What
Offset the banner to `top-9` so it sits **below** the toolbar instead of on top of it. The error stays at the top of the content (where users look) and the viewer controls remain usable. A comment ties the `top-9` to the toolbar's `h-9`.

## Verification
Static layout offset (`top-9` = 36px = the toolbar's `h-9`); `tsc -b` + vite build + no-CDN guard green; eslint clean.

Version 1.2.21.