### PR TITLE
fix(a11y): enlarge the dialog close button to a 36px touch target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.22] — 2026-07-04
+
+### Fixed
+
+- The dialog close (✕) button is now a 36px touch target (was 28px), so it
+  clears the WCAG minimum comfortably on touch. The icon is unchanged; only
+  the hit area grew.
+
 ## [1.2.21] — 2026-07-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.21",
+  "version": "1.2.22",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -69,7 +69,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="focus-visible:ring-ring/50 data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-3 right-3 inline-flex h-7 w-7 items-center justify-center rounded-md opacity-70 transition-[color,background-color,border-color,box-shadow,transform] duration-150 ease-[cubic-bezier(0.4,0,0.2,1)] hover:opacity-100 hover:bg-muted focus-visible:ring-[3px] focus-visible:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="focus-visible:ring-ring/50 data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-2.5 right-2.5 inline-flex h-9 w-9 items-center justify-center rounded-md opacity-70 transition-[color,background-color,border-color,box-shadow,transform] duration-150 ease-[cubic-bezier(0.4,0,0.2,1)] hover:opacity-100 hover:bg-muted focus-visible:ring-[3px] focus-visible:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>


### PR DESCRIPTION
## Why
The shared `Dialog` close (✕) button renders `h-7 w-7` (28px) with a 16px glyph on every dialog keeping `showCloseButton` (Batch, Share, VersionHistory, …) — a sub-minimum touch target. (Audit HIGH — Accessibility & Design-System States.)

## What
Bump the button to `h-9 w-9` (36px) and nudge its inset to `top-2.5 right-2.5` so it stays in the corner. The `size-4` glyph is unchanged; only the hit area grows. One primitive change fixes it everywhere.

## Verification
`tsc -b` + vite build + no-CDN guard green; eslint clean. Icon size unaffected (glyph stays `size-4`).

Version 1.2.22.