### PR TITLE
fix(a11y): surface the required-field state on Letterhead Unit Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.23] — 2026-07-04
+
+### Fixed
+
+- The required "Unit Name" letterhead field now shows a red asterisk and,
+  when validation flags it empty, a visible "Unit name is required" message
+  wired to the input via `aria-describedby` — previously it only painted the
+  invalid ring, leaving both sighted and screen-reader users without a remedy.
+
 ## [1.2.22] — 2026-07-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.22",
+  "version": "1.2.23",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/LetterheadSection.tsx
+++ b/src/components/editor/LetterheadSection.tsx
@@ -40,8 +40,8 @@ export function LetterheadSection() {
   const validationVisible = useUIStore((s) => s.validationVisible);
   // Mirror getSectionError('letterhead'): only a required (non-optional)
   // letterhead flags a missing unit name.
-  const unitNameInvalid =
-    validationVisible && config.letterhead === true && !config.optionalLetterhead && unfilled(formData.unitLine1);
+  const unitNameRequired = config.letterhead === true && !config.optionalLetterhead;
+  const unitNameInvalid = validationVisible && unitNameRequired && unfilled(formData.unitLine1);
 
   // Structured address fields mirror formData.unitAddress (the persisted
   // single-line form). User edits recompose into the string; external writes
@@ -213,14 +213,22 @@ export function LetterheadSection() {
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="unitLine1">Unit Name</Label>
+                <Label htmlFor="unitLine1">
+                  Unit Name{unitNameRequired && <span className="text-destructive"> *</span>}
+                </Label>
                 <Input
                   id="unitLine1"
                   value={formData.unitLine1 || ''}
                   onChange={(e) => setField('unitLine1', e.target.value)}
                   aria-invalid={unitNameInvalid ? true : undefined}
+                  aria-describedby={unitNameInvalid ? 'unitLine1-error' : undefined}
                   placeholder="e.g., HEADQUARTERS UNITED STATES MARINE CORPS"
                 />
+                {unitNameInvalid && (
+                  <p id="unitLine1-error" role="alert" className="text-xs text-destructive">
+                    Unit name is required.
+                  </p>
+                )}
               </div>
 
               <div className="space-y-2">


### PR DESCRIPTION
## Why
The required "Unit Name" letterhead field has `aria-invalid` but no visible error message, no `aria-describedby`, and no required asterisk — so neither sighted nor screen-reader users get a remedy when it's flagged. (Audit HIGH — Letterhead Section, two findings.)

## What
- Red `*` on the label whenever the field is required (`unitNameRequired`, independent of validation state) — matching every other required field.
- When validation flags it empty, render a visible `Unit name is required.` message with `role="alert"`, and point the input at it via `aria-describedby="unitLine1-error"`.
- Refactored the validity check to reuse `unitNameRequired`. Mirrors the existing `ReferencesManager` inline-error pattern.

## Verification
Live against the running app: label reads "Unit Name *" (red asterisk present); triggering validation with an empty field renders the `role="alert"` message and sets `aria-invalid="true"` + `aria-describedby="unitLine1-error"`. `tsc -b` + vite build + no-CDN guard green; eslint clean.

Version 1.2.23.