### PR TITLE
ci: auto-create a GitHub release when the version is bumped on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: release
+
+# Auto-create a GitHub release when package.json's version is bumped on main.
+# Every PR bumps the version + adds a CHANGELOG entry, so the squash-merge push
+# is the release trigger. Idempotent (skips if the release already exists), so
+# re-runs and pushes that don't change the version are safe. The published
+# release then triggers docker-release.yml.
+#
+# Uses the built-in GITHUB_TOKEN with `contents: write` — which, unlike a PAT
+# or OAuth token, can tag even commits that touch .github/workflows, so this
+# never hits the "workflow scope required" wall that blocks manual `gh release`.
+
+on:
+  push:
+    branches: [main]
+    paths: ['package.json']
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve version
+        id: v
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Create release if it doesn't exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="v${{ steps.v.outputs.version }}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists — nothing to do."
+            exit 0
+          fi
+          # Notes = this version's CHANGELOG section (body under the heading).
+          awk -v n="${{ steps.v.outputs.version }}" '
+            $0 ~ "^## \\["n"\\]" { grab = 1; next }
+            grab && /^## \[/ { exit }
+            grab { print }
+          ' CHANGELOG.md | sed '/./,$!d' > notes.md
+          if [ ! -s notes.md ]; then
+            printf 'Release %s\n' "$tag" > notes.md
+          fi
+          gh release create "$tag" --target "${{ github.sha }}" --title "$tag" --notes-file notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.24] — 2026-07-04
+
+### Changed
+
+- Releases are now cut automatically. A GitHub release is created whenever the
+  version in `package.json` is bumped on `main`, with notes drawn from that
+  version's CHANGELOG entry — so tags, releases, and the changelog can no
+  longer drift, and the published release still triggers the Docker image build.
+
 ## [1.2.23] — 2026-07-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.23",
+  "version": "1.2.24",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",


### PR DESCRIPTION
## Why
Every shippable PR bumps `package.json` + adds a `CHANGELOG.md` entry, but the GitHub release was a manual `gh release create` after each merge — easy to forget, and it drifts. It also hits a wall: a personal/OAuth token can't tag a commit that touched `.github/workflows/` without the `workflow` scope (this is why the manual v1.2.5 backfill needed a tag-push workaround).

## What
A new `release` workflow turns "version bumped on main" into a guaranteed release:
- Triggers on push to `main` limited to `paths: ['package.json']`.
- Reads the version, **skips if that release already exists** (idempotent — safe on re-runs and non-bump pushes), else creates it at the merge SHA.
- Release notes = that version's `CHANGELOG.md` section (with a plain fallback).
- Runs as the built-in `GITHUB_TOKEN` with `contents: write`, which **can** tag workflow-touching commits — so it never hits the PAT `workflow`-scope wall.
- The published release still triggers `docker-release.yml` (unchanged chain).

`concurrency` serializes runs per ref; no `cancel-in-progress` so a release is never half-created.

## Verification
YAML parses (`yaml.safe_load`); eslint clean. End-to-end proof is self-demonstrating: **merging this PR bumps the version to 1.2.24, which — with the workflow now live on main — should auto-create the v1.2.24 release.** I'll confirm that release appears after merge.

Version 1.2.24.