### PR TITLE
fix(a11y): keyboard/touch access for drag handles, @-menu create, library Add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.25] — 2026-07-04
+
+### Fixed
+
+- Keyboard and touch access for three editor controls: the reference and
+  enclosure drag handles now carry an accessible name and an explicit button
+  type (they defaulted to form-submit); the "@" variable menu's "Create new
+  variable" row now responds to Enter as its footer promises (not mouse only);
+  and the reference-library "Add" button, previously invisible until hover, is
+  now shown on touch devices and revealed on keyboard focus.
+
 ## [1.2.24] — 2026-07-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.24",
+  "version": "1.2.25",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -85,6 +85,8 @@ function SortableEnclosure({
       <div className="flex items-start gap-2">
         {/* Drag handle */}
         <button
+          type="button"
+          aria-label={`Drag to reorder enclosure ${index + 1}`}
           {...attributes}
           {...listeners}
           className="mt-2 cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground"

--- a/src/components/editor/ReferencesManager.tsx
+++ b/src/components/editor/ReferencesManager.tsx
@@ -76,6 +76,8 @@ const SortableReference = memo(function SortableReference({
       <div className="flex items-start gap-2">
         {/* Drag handle */}
         <button
+          type="button"
+          aria-label={`Drag to reorder reference ${index + 1}`}
           {...attributes}
           {...listeners}
           className="mt-2 cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground"

--- a/src/components/modals/ReferenceLibraryPicker.tsx
+++ b/src/components/modals/ReferenceLibraryPicker.tsx
@@ -101,7 +101,10 @@ export function ReferenceLibraryPicker({
                         variant="ghost"
                         size="sm"
                         onClick={() => onSelect(citation)}
-                        className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+                        // Hidden-until-hover on pointer devices, but always shown on
+                        // touch (no hover) and revealed on keyboard focus, so the
+                        // action is reachable by every input method.
+                        className="opacity-0 [@media(hover:none)]:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 transition-opacity shrink-0"
                       >
                         <Plus className="h-4 w-4 mr-1" />
                         Add

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -289,8 +289,32 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
       if (item) command(item);
     }, [items, command]);
 
+    // The "create custom variable" candidate shown when nothing matches. Shared
+    // by the keyboard handler and the rendered row so BOTH create it — the footer
+    // promised "Enter", but previously only a mouse click worked.
+    const customName = query.trim() ? query.trim().toUpperCase().replace(/[^A-Z0-9_]/g, '_') : '';
+    const createCustom = useCallback(() => {
+      if (!customName) return;
+      addCustomVariable(customName);
+      command({
+        name: customName,
+        label: customName.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase()),
+        category: 'Custom',
+        example: 'Your custom value',
+      });
+    }, [customName, command]);
+
     useImperativeHandle(ref, () => ({
       onKeyDown: (event: KeyboardEvent) => {
+        if (items.length === 0) {
+          // No matches: Enter/Tab creates the custom variable (matching the
+          // footer hint); there's nothing to navigate.
+          if ((event.key === 'Enter' || event.key === 'Tab') && customName) {
+            createCustom();
+            return true;
+          }
+          return false;
+        }
         if (event.key === 'ArrowUp') {
           setSelectedIndex((prev) => (prev - 1 + items.length) % items.length);
           return true;
@@ -305,18 +329,10 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
         }
         return false;
       },
-    }), [items.length, selectItem, selectedIndex]);
+    }), [items.length, selectItem, selectedIndex, customName, createCustom]);
 
     // If no matches and user typed something, offer to create custom variable
     if (items.length === 0 && query.trim()) {
-      const customName = query.toUpperCase().replace(/[^A-Z0-9_]/g, '_');
-      const customItem: VariableItem = {
-        name: customName,
-        label: customName.replace(/_/g, ' ').toLowerCase().replace(/\b\w/g, c => c.toUpperCase()),
-        category: 'Custom',
-        example: `Your custom value`,
-      };
-
       return (
         <div className="bg-popover border border-border rounded-lg shadow-lg overflow-hidden w-[280px]">
           <div className="px-3 py-2 border-b border-border bg-muted/50">
@@ -327,10 +343,7 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
           </div>
           <div
             className="px-3 py-3 cursor-pointer hover:bg-accent flex items-center gap-3"
-            onClick={() => {
-              addCustomVariable(customName);
-              command(customItem);
-            }}
+            onClick={createCustom}
           >
             <div className="w-8 h-8 rounded-full bg-success/15 dark:bg-success/25 flex items-center justify-center text-success text-lg">
               +


### PR DESCRIPTION
## Why
Three editor controls are unreachable or non-functional without a mouse. (Audit HIGH — Block Editor + References & Enclosures.)

## What
- **Drag handles** (`ReferencesManager`, `EnclosuresManager`): bare `<button>` with `{...listeners}` — defaulted to `type="submit"` and announced as an empty button. Add `type="button"` + an index-aware `aria-label` ("Drag to reorder reference N").
- **@-menu "Create new variable"** (`variable-chip-editor`): the footer says "Enter create variable" but Enter was dead — it called `selectItem` on an empty list. Extract a shared `createCustom` used by both the key handler (Enter/Tab when no matches) and the row's click.
- **Reference-library "Add"** (`ReferenceLibraryPicker`): `opacity-0 group-hover:opacity-100` hid it from keyboard and touch. Now `[@media(hover:none)]:opacity-100` (always shown on touch) + `group-focus-within`/`focus-visible` reveals (keyboard), keeping the hover-hide only on pointer devices.

## Verification
`tsc -b` + vite build + no-CDN guard green (validates the `onKeyDown` refactor + hook deps); eslint clean. The create action is now shared by keyboard and click, so both paths do the same thing.

Version 1.2.25.