### PR TITLE
fix(a11y): guided tour announces steps and skips hidden targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.28] — 2026-07-04
+
+### Fixed
+
+- The guided tour no longer spotlights controls that aren't on screen. The
+  appearance and help buttons are hidden below 1280px, so those two steps used
+  to fall back to a centered card describing invisible buttons; they're now
+  filtered out at narrower widths.
+
+### Accessibility
+
+- The guided tour announces each step to screen readers via a polite live
+  region ("Step 3 of 8: …") and shows a visible step counter next to the
+  progress dots. Previously the only progress indicator was the aria-hidden dot
+  row, so assistive tech got no notice when the step changed.
+
 ## [1.2.27] — 2026-07-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.27",
+  "version": "1.2.28",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/tour/TourOverlay.tsx
+++ b/src/components/tour/TourOverlay.tsx
@@ -269,6 +269,15 @@ export function TourOverlay() {
         >
           <X className="h-4 w-4" />
         </button>
+        {/* Announce each step to screen readers: the card element is reused
+            across steps (never remounts), so this region's text updates in
+            place and a polite live region reads the new step. The visual dots
+            below are aria-hidden, so this is the only step-progress a SR gets. */}
+        <p className="sr-only" role="status" aria-live="polite">
+          {isSingle
+            ? step.title
+            : `Step ${stepIndex + 1} of ${steps.length}: ${step.title}`}
+        </p>
         <h3 className="shrink-0 text-sm font-semibold mb-1 pr-6">{step.title}</h3>
         {/* Only the body scrolls when the card is capped to a tight gap; the
             title and controls stay pinned so Back/Next are always in the box. */}
@@ -282,17 +291,22 @@ export function TourOverlay() {
           {isSingle ? (
             <span />
           ) : (
-            <div className="flex min-w-0 items-center gap-1.5 overflow-hidden" aria-hidden="true">
-              {steps.map((_, i) => (
-                <span
-                  key={i}
-                  className={
-                    i === stepIndex
-                      ? 'h-1.5 w-4 shrink-0 rounded-full bg-primary transition-all'
-                      : 'h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30 transition-all'
-                  }
-                />
-              ))}
+            <div className="flex min-w-0 items-center gap-2 overflow-hidden" aria-hidden="true">
+              <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                {stepIndex + 1}/{steps.length}
+              </span>
+              <div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
+                {steps.map((_, i) => (
+                  <span
+                    key={i}
+                    className={
+                      i === stepIndex
+                        ? 'h-1.5 w-4 shrink-0 rounded-full bg-primary transition-all'
+                        : 'h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30 transition-all'
+                    }
+                  />
+                ))}
+              </div>
             </div>
           )}
           <div className="flex shrink-0 gap-2">

--- a/src/components/tour/tourSteps.ts
+++ b/src/components/tour/tourSteps.ts
@@ -63,3 +63,20 @@ export const TOUR_STEPS: TourStep[] = [
     body: 'Guides, keyboard shortcuts, bug reports, and feature ideas are all in this menu, and you can replay this tour from here anytime.',
   },
 ];
+
+/**
+ * Drop steps whose target isn't in the current layout, so the tour never
+ * spotlights an element the user can't see. Two Header controls (appearance,
+ * help) are `hidden xl:flex`, so on sub-1280px widths their steps would
+ * otherwise fall back to a centered card describing invisible buttons. A step
+ * with no target (a centered card) or an `action` (which mounts its own target)
+ * is always kept — only steps that name an element already absent are removed.
+ */
+export function visibleTourSteps(steps: TourStep[] = TOUR_STEPS): TourStep[] {
+  if (typeof document === 'undefined') return steps;
+  return steps.filter((s) => {
+    if (!s.target || s.action) return true;
+    const el = document.querySelector(s.target);
+    return !!el && (el as HTMLElement).getClientRects().length > 0;
+  });
+}

--- a/src/stores/tourStore.ts
+++ b/src/stores/tourStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { TOUR_STEPS, type TourStep } from '@/components/tour/tourSteps';
+import { TOUR_STEPS, visibleTourSteps, type TourStep } from '@/components/tour/tourSteps';
 import { useOnboardingStore } from '@/stores/onboardingStore';
 
 const TOUR_STORAGE_KEY = 'dondocs-tour-completed';
@@ -63,7 +63,9 @@ export const useTourStore = create<TourState>((set, get) => ({
     clearBodyPointerLock();
     // completionKey so finishing the intro tour (reaching the last step) credits
     // the checklist's "Take the guided tour" step — skipping/× does not.
-    set({ active: true, stepIndex: 0, steps: TOUR_STEPS, markOnEnd: true, completionKey: GUIDED_TOUR_KEY });
+    // Filter to steps whose target is present so narrow layouts (where the
+    // appearance/help buttons are hidden) don't spotlight invisible controls.
+    set({ active: true, stepIndex: 0, steps: visibleTourSteps(TOUR_STEPS), markOnEnd: true, completionKey: GUIDED_TOUR_KEY });
   },
   startSteps: (steps, completionKey) => {
     if (steps.length === 0) return;

--- a/tests/unit/tourStore.test.ts
+++ b/tests/unit/tourStore.test.ts
@@ -6,10 +6,29 @@
  * get the intro. These tests lock in that boundary (the `markOnEnd` guard) plus
  * the basics of the generalized step set.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { useTourStore, hasCompletedTour } from '@/stores/tourStore';
 import { useOnboardingStore } from '@/stores/onboardingStore';
-import { TOUR_STEPS } from '@/components/tour/tourSteps';
+import { TOUR_STEPS, visibleTourSteps, type TourStep } from '@/components/tour/tourSteps';
+
+// jsdom does no layout, so getClientRects() is always empty. Mount a stand-in
+// element for each selector and stub getClientRects so visibleTourSteps sees it
+// as laid out — mirroring a real browser where the target is on screen.
+const mounted: HTMLElement[] = [];
+function mountTargets(selectors: string[]): void {
+  for (const sel of selectors) {
+    const name = sel.match(/\[data-tour="(.+?)"\]/)?.[1];
+    if (!name || document.querySelector(sel)) continue;
+    const el = document.createElement('div');
+    el.setAttribute('data-tour', name);
+    el.getClientRects = () => [{ width: 10, height: 10 } as DOMRect] as unknown as DOMRectList;
+    document.body.appendChild(el);
+    mounted.push(el);
+  }
+}
+function mountAllTourTargets(): void {
+  mountTargets(TOUR_STEPS.map((s) => s.target).filter((t): t is string => !!t));
+}
 
 const SPOTLIGHT = [
   { target: '[data-tour="batch"]', title: 'Batch lives here', body: 'Open this to generate one per row.' },
@@ -27,14 +46,33 @@ describe('tourStore', () => {
     useOnboardingStore.setState({ completed: {} });
   });
 
+  afterEach(() => {
+    mounted.splice(0).forEach((el) => el.remove());
+  });
+
   it('start() runs the full intro tour and ending records it as seen', () => {
+    mountAllTourTargets(); // every target on screen → no step filtered out
     useTourStore.getState().start();
     expect(useTourStore.getState().active).toBe(true);
-    expect(useTourStore.getState().steps).toBe(TOUR_STEPS);
+    expect(useTourStore.getState().steps).toEqual(TOUR_STEPS);
 
     useTourStore.getState().end();
     expect(useTourStore.getState().active).toBe(false);
     expect(hasCompletedTour()).toBe(true);
+  });
+
+  it('start() drops steps whose target is absent from the current layout', () => {
+    // Mount every target except the two Header controls that are hidden below xl.
+    mountTargets(
+      TOUR_STEPS.map((s) => s.target).filter(
+        (t): t is string => !!t && t !== '[data-tour="appearance"]' && t !== '[data-tour="help"]'
+      )
+    );
+    useTourStore.getState().start();
+    const steps = useTourStore.getState().steps;
+    expect(steps).toHaveLength(TOUR_STEPS.length - 2);
+    expect(steps.some((s) => s.target === '[data-tour="appearance"]')).toBe(false);
+    expect(steps.some((s) => s.target === '[data-tour="help"]')).toBe(false);
   });
 
   it('startSteps() spotlights ad-hoc steps without marking the first-run tour seen', () => {
@@ -85,5 +123,28 @@ describe('tourStore', () => {
     useTourStore.getState().startSteps(SPOTLIGHT); // no completionKey
     useTourStore.getState().next(); // single step -> finishes
     expect(useOnboardingStore.getState().completed).toEqual({});
+  });
+});
+
+describe('visibleTourSteps', () => {
+  afterEach(() => {
+    mounted.splice(0).forEach((el) => el.remove());
+  });
+
+  it('keeps a step whose target is on screen and drops one whose target is absent', () => {
+    mountTargets(['[data-tour="present"]']);
+    const steps: TourStep[] = [
+      { target: '[data-tour="present"]', title: 'Present', body: 'here' },
+      { target: '[data-tour="absent"]', title: 'Absent', body: 'gone' },
+    ];
+    expect(visibleTourSteps(steps)).toEqual([steps[0]]);
+  });
+
+  it('always keeps a centered step (no target) and an action step (mounts its own target)', () => {
+    const steps: TourStep[] = [
+      { title: 'Centered', body: 'no target' },
+      { target: '[data-tour="absent"]', title: 'Opens surface', body: 'x', action: () => {} },
+    ];
+    expect(visibleTourSteps(steps)).toEqual(steps);
   });
 });


### PR DESCRIPTION
## Why
Two HIGH accessibility findings against the guided tour (audit — Welcome/Tour & Onboarding):

1. **Hidden-target steps.** The appearance and help Header buttons are `hidden xl:flex`, so below 1280px they aren't in the layout. The tour still ran their two steps, and `measure()` fell back to a **centered card describing buttons the user can't see** across most laptop widths.
2. **No screen-reader progress.** The only progress indicator was the `aria-hidden="true"` dot row — no `aria-live`, no step counter. Advancing swapped the card content **silently** for assistive tech, while the checklist/celebration already use `role="status" aria-live="polite"`.

## What
- `visibleTourSteps()` in `tourSteps.ts` filters out steps whose `target` isn't currently present/visible (kept: centered cards and steps with an `action` that mounts their own target). Wired into `tourStore.start()`, so the intro tour adapts to the current breakpoint.
- `TourOverlay` gains a visually-hidden `role="status" aria-live="polite"` region announcing `Step N of M: <title>` (the card element is reused across steps, so its text updates in place and is announced), plus a visible `N/M` counter in tabular figures next to the progress dots.

## Verification
`tsc -b` + vite build + eslint clean. Live in the preview:
- **1440px** — tour runs all 8 steps; live region reads `"Step 1 of 8: Start here"`, visible counter `1/8`.
- **1100px** — appearance/help are `display:none`; tour now runs **6** steps; live region `"Step 1 of 6: Start here"`, counter `1/6`. No centered cards for absent controls.
- No console errors.

Version 1.2.28.