### PR TITLE
fix(ui): one header-control height and full-width type pickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.29] — 2026-07-04
+
+### Fixed
+
+- The top-bar controls now share one height. The undo, redo, refresh, and
+  appearance icon buttons grew to 36px at ≥640px while every other control
+  stayed 32px, breaking the row into two heights; they're now a uniform 32px.
+- The Document Type, font-size, font-family, and Form Type pickers now span
+  their field column. They were sized to their content (w-fit), so the trigger
+  and its chevron floated mid-row out of line with every sibling field, which
+  is full-width.
+
 ## [1.2.28] — 2026-07-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.28",
+  "version": "1.2.29",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/DocumentTypeSelector.tsx
+++ b/src/components/editor/DocumentTypeSelector.tsx
@@ -86,7 +86,7 @@ export function DocumentTypeSelector() {
             select keeps its accessible name via aria-label. */}
         <div data-tour="doctype" className="space-y-2">
           <Select value={docType} onValueChange={(v) => setDocType(v)}>
-            <SelectTrigger aria-label="Document Type">
+            <SelectTrigger aria-label="Document Type" className="w-full">
               <SelectValue placeholder="Select document type" />
             </SelectTrigger>
             <SelectContent>
@@ -141,7 +141,7 @@ export function DocumentTypeSelector() {
                 value={formData.fontSize || config.regulations.fontSize}
                 onValueChange={(v) => setField('fontSize', v)}
               >
-                <SelectTrigger>
+                <SelectTrigger className="w-full">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -189,7 +189,7 @@ export function DocumentTypeSelector() {
                   value={formData.fontSize || '12pt'}
                   onValueChange={(v) => setField('fontSize', v)}
                 >
-                  <SelectTrigger>
+                  <SelectTrigger className="w-full">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -206,7 +206,7 @@ export function DocumentTypeSelector() {
                   value={formData.fontFamily || 'times'}
                   onValueChange={(v) => setField('fontFamily', v)}
                 >
-                  <SelectTrigger>
+                  <SelectTrigger className="w-full">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -250,7 +250,7 @@ export function DocumentTypeSelector() {
         <div className="space-y-2">
           <Label>Form Type</Label>
           <Select value={formType} onValueChange={(v) => setFormType(v as FormType)}>
-            <SelectTrigger>
+            <SelectTrigger className="w-full">
               <SelectValue placeholder="Select form type" />
             </SelectTrigger>
             <SelectContent>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -746,7 +746,7 @@ export function Header({
               onClick={handleUndo}
               disabled={!canUndo}
               aria-label="Undo"
-              className="h-8 w-8 sm:h-9 sm:w-9"
+              className="h-8 w-8"
             >
               <Undo2 className="h-4 w-4" aria-hidden="true" />
             </Button>
@@ -758,7 +758,7 @@ export function Header({
               onClick={handleRedo}
               disabled={!canRedo}
               aria-label="Redo"
-              className="h-8 w-8 sm:h-9 sm:w-9"
+              className="h-8 w-8"
             >
               <Redo2 className="h-4 w-4" aria-hidden="true" />
             </Button>
@@ -775,7 +775,7 @@ export function Header({
               onClick={onRefreshPreview}
               disabled={isCompiling}
               aria-label="Refresh preview"
-              className="h-8 w-8 sm:h-9 sm:w-9 hidden xl:flex"
+              className="h-8 w-8 hidden xl:flex"
             >
               <RefreshCw className={`h-4 w-4 ${isCompiling ? 'animate-spin' : ''}`} aria-hidden="true" />
             </Button>
@@ -1094,7 +1094,7 @@ export function Header({
           <DropdownMenu>
             <HeaderTip label="Appearance">
               <DropdownMenuTrigger asChild>
-                <Button data-tour="appearance" variant="ghost" size="icon" aria-label="Appearance settings" className="h-8 w-8 sm:h-9 sm:w-9 hidden xl:flex">
+                <Button data-tour="appearance" variant="ghost" size="icon" aria-label="Appearance settings" className="h-8 w-8 hidden xl:flex">
                   <Settings className="h-4 w-4" aria-hidden="true" />
                 </Button>
               </DropdownMenuTrigger>


### PR DESCRIPTION
## Why
Two HIGH layout-consistency findings (audit — Header / Editor sections):

- **Header row is two heights.** Undo, redo, refresh, and appearance were `h-8 w-8 sm:h-9 sm:w-9` (32→36px), but save, download, preview, the ⌘K pill, guide/find/batch, and help all stay `h-8`. At ≥640px those four sat 36px against everyone else's 32px, so the toolbar didn't read as one rail.
- **Type pickers collapse to content width.** The Document Type, font-size, font-family, and Form Type `SelectTrigger`s omitted a width class, so the base `w-fit` shrank each to its placeholder while every sibling field is `w-full` — the chevron floated mid-row, out of line with the fields above and below.

## What
- Drop `sm:h-9 sm:w-9` from the four header icon buttons → uniform 32px everywhere.
- Add `className="w-full"` to all five `SelectTrigger`s in `DocumentTypeSelector`.

## Verification
`tsc -b` + vite build + eslint clean. Live in the preview:
- **1024px** — undo/redo/save/download all 32px; doc-type Select trigger spans its full 471px column.
- **1440px** — refresh, appearance, help, undo all 32px; the row is one continuous height.

Version 1.2.29.