### PR TITLE
fix(ui): neutral selection tint in the command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.30] — 2026-07-04
+
+### Changed
+
+- The command palette's selected row now uses a neutral selection tint instead
+  of a saturated brand fill. Arrow-keying through results previously flooded
+  each row with the brand accent (navy, gold, or dress-blue depending on
+  scheme); it now uses the same quiet accent wash as every other menu, keeping
+  saturated color for genuine emphasis.
+
 ## [1.2.29] — 2026-07-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.29",
+  "version": "1.2.30",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/modals/CommandPalette.tsx
+++ b/src/components/modals/CommandPalette.tsx
@@ -170,7 +170,7 @@ export function CommandPalette({
                       onClick={() => run(it)}
                       className={cn(
                         'flex cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2',
-                        active ? 'bg-brand-accent text-brand-accent-foreground' : 'text-popover-foreground'
+                        active ? 'bg-accent text-accent-foreground' : 'text-popover-foreground'
                       )}
                     >
                       <Icon className={cn('h-4 w-4 shrink-0', active ? 'text-current' : 'text-muted-foreground')} />


### PR DESCRIPTION
## Why
HIGH finding (audit — Command palette). The keyboard-selected row was `bg-brand-accent text-brand-accent-foreground` (CommandPalette.tsx:173), and `--brand-accent` is a saturated, semantically-loaded hue in every scheme (default navy, navy-scheme gold, usmc dress-blue, usmc-dark blood-red). Routine arrow-key navigation flooded each row with brand color — even though each scheme already defines a neutral `--accent` (the shadcn selection contract used by every other menu).

## What
Swap the active-row classes to `bg-accent text-accent-foreground` — the neutral selection wash. Saturated color stays reserved for genuine emphasis. `text-current` on the icon/hint now resolves to `accent-foreground`, which reads correctly on the accent wash.

## Verification
`tsc -b` + vite build + eslint clean. Live in the preview (dark scheme): the selected row's computed background is now `oklch(0.27 0.01 260)` — neutral, chroma 0.01 — versus the previous saturated brand fill, with near-white `accent-foreground` text. It's a pure token swap, so it's correct across all four schemes by construction.

Version 1.2.30.