### PR TITLE
fix(ui): shared textarea for recipient address; honest signature size hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.31] — 2026-07-04
+
+### Fixed
+
+- The Recipient Address field now uses the shared textarea component, so it
+  gets the same focus ring, focus/hover transitions, and invalid-state styling
+  as every neighboring field instead of a hand-rolled variant that had a
+  thinner ring and no hover state.
+- The signature upload hint no longer contradicts the limit it enforces. It
+  read "max 500KB recommended" while the guard rejects at 2 MB; it now states
+  the real 2 MB cap and keeps "under 500 KB" as a soft suggestion.
+
 ## [1.2.30] — 2026-07-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.30",
+  "version": "1.2.31",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/AddressingSection.tsx
+++ b/src/components/editor/AddressingSection.tsx
@@ -6,6 +6,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { BookOpen, Plus, Trash2, AlertCircle, GripVertical, Building2 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -353,13 +354,13 @@ export function AddressingSection({ config }: AddressingSectionProps) {
             {config.recipientAddress && (
               <div className="space-y-2">
                 <Label htmlFor="to">Recipient Address</Label>
-                <textarea
+                <Textarea
                   id="to"
                   value={formData.to || ''}
                   onChange={(e) => setField('to', e.target.value)}
                   aria-invalid={validationVisible && unfilled(formData.to) ? true : undefined}
                   placeholder="Mr. John Smith&#10;Director of Operations&#10;ABC Company&#10;123 Main Street&#10;City, State ZIP"
-                  className="flex min-h-[100px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20"
+                  className="min-h-[100px]"
                   rows={5}
                 />
                 <p className="text-xs text-muted-foreground flex items-center gap-1">

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -545,7 +545,7 @@ export function SignatureSection({ config }: SignatureSectionProps) {
                         Drag & drop or click to upload
                       </span>
                       <span className="text-xs text-muted-foreground">
-                        PNG, JPG, or GIF (max 500KB recommended)
+                        PNG, JPG, or GIF — up to {FILE_LIMITS.MAX_SIGNATURE_SIZE_MB} MB (under 500 KB keeps drafts small)
                       </span>
                       <input
                         type="file"


### PR DESCRIPTION
## Why
Two HIGH findings (audit — Addressing / Signature sections):

- **Recipient Address hand-rolls a stale textarea.** It used inline classes with a thinner focus ring, no focus transition, and no hover state, diverging from every neighboring `Input`/shared `Textarea` (AddressingSection.tsx:356).
- **Signature size copy contradicts the enforced limit.** The hint read "max 500KB recommended" but the upload guard rejects at `MAX_SIGNATURE_SIZE_MB` = 2 MB (SignatureSection.tsx:548 vs 115/118).

## What
- Replace the raw `<textarea>` with the shared `<Textarea>`, preserving `id`, value/onChange, the `aria-invalid` wiring, placeholder, `rows`, and a `min-h-[100px]` override.
- Rewrite the signature hint to derive the hard cap from `FILE_LIMITS.MAX_SIGNATURE_SIZE_MB` ("up to 2 MB") and phrase 500 KB as a soft suggestion ("under 500 KB keeps drafts small").

## Verification
`tsc -b` + vite build + eslint clean. Both fields are conditional (recipient address renders only for business-letter doc types; the hint only in the empty upload dropzone), so this is a build-validated component swap plus a constant-driven text change.

Version 1.2.31.