### PR TITLE
fix(a11y): keyboard focus ring on classification preset chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.32] — 2026-07-04
+
+### Accessibility
+
+- The custom-classification preset chips now show a keyboard focus ring. The
+  ring was bound to the selected state only, so tabbing across the chips gave
+  no focus indicator (WCAG 2.4.7). They now carry the standard focus-visible
+  ring independent of selection.
+
 ## [1.2.31] — 2026-07-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.31",
+  "version": "1.2.32",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/ClassificationSection.tsx
+++ b/src/components/editor/ClassificationSection.tsx
@@ -264,7 +264,7 @@ export function ClassificationSection() {
                             key={preset.value}
                             type="button"
                             onClick={() => setField('customClassification', preset.value)}
-                            className={`px-2 py-0.5 text-xs font-medium rounded-md border transition-colors ${preset.color} ${preset.bg} ${active ? 'ring-2 ring-offset-1 ring-offset-background ring-current' : ''}`}
+                            className={`px-2 py-0.5 text-xs font-medium rounded-md border transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 ${preset.color} ${preset.bg} ${active ? 'ring-2 ring-offset-1 ring-offset-background ring-current' : ''}`}
                             title={`Set marking to "${preset.value}"`}
                           >
                             {preset.label}


### PR DESCRIPTION
## Why
HIGH finding (audit — Classification section). The custom-classification preset chips bind their ring to `active` (selected), so tabbing across the chips gives no focus indicator — a WCAG 2.4.7 (focus visible) failure (ClassificationSection.tsx:267).

## What
Add `outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50` to the chip, independent of the selection ring. When a chip is both focused and selected the focus ring takes visual precedence; unselected chips now ring on keyboard focus.

## Verification
`tsc -b` + vite build + eslint clean. Same focus-ring recipe swept app-wide and verified live in #135; the chips render only when Custom Classification is enabled, so this is a build-validated class addition.

Version 1.2.32.