### PR TITLE
fix(ui): sentence-case button labels across the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.33] — 2026-07-04
+
+### Changed
+
+- Button labels now use consistent sentence case. The editor add-buttons ("Add
+  reference", "Add enclosure", "Add via", "Add recipient", "Add action
+  addressee") and the reset/clear/restore dialog actions ("Reset everything",
+  "Clear fields", "Start fresh", "Restore session") were a mix of Title Case
+  and sentence case; they now all follow sentence case, matching the Save menu.
+
 ## [1.2.32] — 2026-07-04
 
 ### Accessibility

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.32",
+  "version": "1.2.33",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/AddressingSection.tsx
+++ b/src/components/editor/AddressingSection.tsx
@@ -426,7 +426,7 @@ export function AddressingSection({ config }: AddressingSectionProps) {
                     disabled={viaLines.length >= 4}
                   >
                     <Plus className="h-4 w-4 mr-1" />
-                    Add Via
+                    Add via
                   </Button>
                 </div>
                 <DndContext

--- a/src/components/editor/CopyToManager.tsx
+++ b/src/components/editor/CopyToManager.tsx
@@ -64,7 +64,7 @@ export function CopyToManager() {
               onClick={() => addCopyTo('')}
             >
               <Plus className="h-4 w-4 mr-2" />
-              Add Recipient
+              Add recipient
             </Button>
           </div>
         </AccordionContent>

--- a/src/components/editor/DistributionManager.tsx
+++ b/src/components/editor/DistributionManager.tsx
@@ -64,7 +64,7 @@ export function DistributionManager() {
               onClick={() => addDistribution('')}
             >
               <Plus className="h-4 w-4 mr-2" />
-              Add Action Addressee
+              Add action addressee
             </Button>
           </div>
         </AccordionContent>

--- a/src/components/editor/DocumentTypeSelector.tsx
+++ b/src/components/editor/DocumentTypeSelector.tsx
@@ -296,7 +296,7 @@ export function DocumentTypeSelector() {
               }}
               className="bg-orange-600 text-white hover:bg-orange-700"
             >
-              Clear Fields
+              Clear fields
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -382,7 +382,7 @@ export function EnclosuresManager() {
                   className="w-full"
                 >
                   <Plus className="h-4 w-4 mr-2" />
-                  Add Enclosure
+                  Add enclosure
                 </Button>
 
                 {/* Drop zone for PDFs */}

--- a/src/components/editor/ReferencesManager.tsx
+++ b/src/components/editor/ReferencesManager.tsx
@@ -246,7 +246,7 @@ export function ReferencesManager() {
                   onClick={() => addReference('')}
                 >
                   <Plus className="h-4 w-4 mr-2" />
-                  Add Reference
+                  Add reference
                 </Button>
                 <Button
                   variant="outline"

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1251,7 +1251,7 @@ export function Header({
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction onClick={handleReset} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-              Reset Everything
+              Reset everything
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -1271,7 +1271,7 @@ export function Header({
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction onClick={handleClearFields} className="bg-orange-600 text-white hover:bg-orange-700">
-              Clear Fields
+              Clear fields
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -675,7 +675,7 @@ const POWER_FEATURES: PowerFeature[] = [
     where: 'Enclosures section',
     body: 'Attach PDF enclosures. They are listed on the letter and merged into the final PDF automatically.',
     steps: [
-      'Open the Enclosures section and click Add Enclosure.',
+      'Open the Enclosures section and click Add enclosure.',
       'Title it, and optionally attach a PDF (drag and drop works).',
       'Attached PDFs merge into the export, in order, after the letter.',
     ],
@@ -688,7 +688,7 @@ const POWER_FEATURES: PowerFeature[] = [
       {
         target: '[data-tour="enclosure-add"]',
         title: 'Add an enclosure',
-        body: 'Click Add Enclosure and give it a title. It is listed on the letter automatically.',
+        body: 'Click Add enclosure and give it a title. It is listed on the letter automatically.',
         action: () => expandSection('enclosures'),
       },
       {

--- a/src/components/modals/RestoreSessionModal.tsx
+++ b/src/components/modals/RestoreSessionModal.tsx
@@ -163,14 +163,14 @@ export function RestoreSessionModal() {
             className="flex items-center justify-center gap-2 w-full sm:w-auto text-muted-foreground hover:text-destructive hover:bg-destructive/10"
           >
             <Trash2 className="h-4 w-4 flex-shrink-0" />
-            <span>Start Fresh</span>
+            <span>Start fresh</span>
           </Button>
           <Button
             onClick={handleRestore}
             className="flex items-center justify-center gap-2 w-full sm:w-auto"
           >
             <RotateCcw className="h-4 w-4 flex-shrink-0" />
-            <span>Restore Session</span>
+            <span>Restore session</span>
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Why
HIGH finding (audit — cross-cutting). Button-label casing used three coexisting systems: editor add-buttons in Title Case ("Add Reference", "Add Enclosure", "Add Via", "Add Recipient", "Add Action Addressee"), the Save dropdown in sentence case, and reset/clear/restore dialog actions back in Title Case ("Reset Everything", "Clear Fields", "Start Fresh", "Restore Session").

## What
Normalize the editor add-buttons and the reset/clear/restore dialog actions to sentence case, matching the Save menu's existing convention. Two guide-modal step sentences that name the "Add enclosure" button are updated to match the new label. Dialog **titles** are left as-is (out of scope for this label pass).

## Verification
`tsc -b` + vite build + eslint clean. `RestoreSessionModal` component tests pass (they match the buttons case-insensitively, so the rename is safe). Purely visible-text changes; no logic touched.

Version 1.2.33.