### PR TITLE
fix(ui): token-backed severity notices, no palette drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.34] — 2026-07-04
+
+### Changed
+
+- Severity notices across the app now draw from theme tokens instead of
+  hardcoded palette colors, so they restain correctly in every color scheme. A
+  new shared Notice primitive (info / warning / error / success) backs the
+  panels in the PII warning, enclosure warning, NIST compliance, and update
+  modals, replacing three ambers, two oranges, and a blue that used to drift.
+  The PII warning header also drops its decorative red/amber gradient for a
+  flat, AA-contrast token color.
+
 ## [1.2.33] — 2026-07-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.33",
+  "version": "1.2.34",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/modals/EnclosureErrorModal.tsx
+++ b/src/components/modals/EnclosureErrorModal.tsx
@@ -16,6 +16,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Notice } from '@/components/ui/notice';
 import type { EnclosureError } from '@/services/pdf/mergeEnclosures';
 
 interface EnclosureErrorModalProps {
@@ -31,7 +32,7 @@ export function EnclosureErrorModal({ errors, open, onClose }: EnclosureErrorMod
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2 text-orange-600">
+          <DialogTitle className="flex items-center gap-2 text-warning">
             <AlertTriangle className="h-5 w-5" />
             Enclosure Warning{errors.length > 1 ? 's' : ''}
           </DialogTitle>
@@ -45,11 +46,8 @@ export function EnclosureErrorModal({ errors, open, onClose }: EnclosureErrorMod
 
         <div className="space-y-3 max-h-64 overflow-y-auto">
           {errors.map((error, index) => (
-            <div
-              key={index}
-              className="flex gap-3 p-3 bg-orange-50 dark:bg-orange-950/30 border border-orange-200 dark:border-orange-800 rounded-md"
-            >
-              <FileWarning className="h-5 w-5 text-orange-500 flex-shrink-0 mt-0.5" />
+            <Notice key={index} variant="warning" className="flex gap-3">
+              <FileWarning className="h-5 w-5 text-warning flex-shrink-0 mt-0.5" />
               <div className="flex-1 min-w-0">
                 <div className="font-medium text-sm text-foreground">
                   Enclosure ({error.enclosureNumber}): {error.title}
@@ -63,7 +61,7 @@ export function EnclosureErrorModal({ errors, open, onClose }: EnclosureErrorMod
                   </div>
                 )}
               </div>
-            </div>
+            </Notice>
           ))}
         </div>
 

--- a/src/components/modals/NISTComplianceModal.tsx
+++ b/src/components/modals/NISTComplianceModal.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Shield, Server, Lock, Wifi, Eye, Database, ExternalLink, AlertTriangle } from 'lucide-react';
+import { Notice } from '@/components/ui/notice';
 import { useUIStore } from '@/stores/uiStore';
 
 // Check if we're on an official .mil domain
@@ -100,17 +101,15 @@ export function NISTComplianceModal() {
                 <li>• Documents processed on government networks</li>
               </ul>
               {!isOfficialDomain && (
-                <div className="flex items-start gap-3 p-3 mt-3 rounded-lg bg-amber-500/10 border border-amber-500/30">
-                  <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
+                <Notice variant="warning" className="flex items-start gap-3 mt-3">
+                  <AlertTriangle className="h-4 w-4 text-warning mt-0.5 shrink-0" />
                   <div>
-                    {/* amber-800 (not 600, which is 2.9:1 here): a 14px "do not
-                        use for official correspondence" warning must clear AA. */}
-                    <p className="text-sm font-medium text-amber-800 dark:text-amber-300">Development Domain</p>
+                    <p className="text-sm font-medium text-warning">Development Domain</p>
                     <p className="text-xs text-muted-foreground">
                       This application is currently hosted on a non-government domain. Do not use for official correspondence or enter sensitive information. For official use, access this application through your authorized .mil network.
                     </p>
                   </div>
-                </div>
+                </Notice>
               )}
             </section>
 

--- a/src/components/modals/PIIWarningModal.tsx
+++ b/src/components/modals/PIIWarningModal.tsx
@@ -18,10 +18,13 @@ interface PIIWarningModalProps {
   onProceed: () => void;
 }
 
+// Severity tints driven by theme tokens (not hardcoded palette hues), so all
+// schemes restain from one source: high → destructive, medium → warning,
+// low → primary (info).
 const severityColors = {
-  high: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400 border-red-200 dark:border-red-800',
-  medium: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400 border-amber-200 dark:border-amber-800',
-  low: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 border-blue-200 dark:border-blue-800',
+  high: 'bg-destructive/10 text-destructive border-destructive/30',
+  medium: 'bg-warning/10 text-warning border-warning/30',
+  low: 'bg-primary/10 text-primary border-primary/30',
 };
 
 const typeIcons: Record<PIIType, string> = {
@@ -152,8 +155,10 @@ export function PIIWarningModal({ detectionResult, onCancel, onProceed }: PIIWar
       if (!open) handleClose();
     }}>
       <DialogContent className="sm:max-w-xl p-0 overflow-hidden" showCloseButton={false}>
-        {/* Warning Header */}
-        <div className={`px-6 py-5 ${totalHighSeverity > 0 ? 'bg-gradient-to-r from-red-600 to-orange-600' : 'bg-gradient-to-r from-amber-600 to-orange-500'} text-white`}>
+        {/* Warning Header — flat token color (no decorative gradient): the
+            destructive/warning tokens restain per scheme and carry AA-contrast
+            foregrounds, so red/amber palette drift is gone. */}
+        <div className={`px-6 py-5 ${totalHighSeverity > 0 ? 'bg-destructive text-destructive-foreground' : 'bg-warning text-warning-foreground'}`}>
           <div className="flex items-center gap-4">
             <div className="p-3 bg-white/20 rounded-xl">
               {totalHighSeverity > 0 ? (
@@ -166,7 +171,7 @@ export function PIIWarningModal({ detectionResult, onCancel, onProceed }: PIIWar
               <h2 className="text-xl font-bold">
                 {totalHighSeverity > 0 ? 'Sensitive Data Detected!' : 'Potential PII/PHI Detected'}
               </h2>
-              <p className="text-white/80 text-sm mt-1">
+              <p className="opacity-80 text-sm mt-1">
                 {findings.length} potential issue{findings.length !== 1 ? 's' : ''} found in your document
               </p>
             </div>

--- a/src/components/modals/UpdatePromptModal.tsx
+++ b/src/components/modals/UpdatePromptModal.tsx
@@ -15,6 +15,7 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Notice } from '@/components/ui/notice';
 
 interface UpdatePromptModalProps {
   open: boolean;
@@ -51,10 +52,10 @@ export function UpdatePromptModal({ open, onConfirm, onDismiss }: UpdatePromptMo
             </DialogDescription>
           </DialogHeader>
 
-          <div className="text-xs text-muted-foreground bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 rounded-md p-3 break-words">
+          <Notice variant="info" className="text-xs text-muted-foreground break-words">
             <strong>Note:</strong> PDF enclosure files and signature images will need
             to be re-attached after the update.
-          </div>
+          </Notice>
 
           <DialogFooter className="flex-col sm:flex-row gap-2 flex-shrink-0">
             <Button

--- a/src/components/ui/notice.tsx
+++ b/src/components/ui/notice.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * Token-backed severity notice. One flat tint + border per variant, driven by
+ * the theme CSS vars (--primary/--warning/--destructive/--success) so every
+ * scheme (default, navy, usmc, …) restains from one source instead of the
+ * hardcoded palette reds/ambers/oranges/blues that used to drift across modals.
+ * GOV.UK-style flat panel — no decorative gradients.
+ *
+ * The container carries the tint; give the leading icon and any heading the
+ * matching accent token so the whole notice reads as one severity:
+ *   info → text-primary · warning → text-warning · error → text-destructive ·
+ *   success → text-success
+ */
+const variantClasses = {
+  info: 'bg-primary/8 border-primary/25',
+  warning: 'bg-warning/10 border-warning/30',
+  error: 'bg-destructive/10 border-destructive/30',
+  success: 'bg-success/10 border-success/30',
+} as const;
+
+export type NoticeVariant = keyof typeof variantClasses;
+
+export function Notice({
+  variant = 'info',
+  className,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & { variant?: NoticeVariant }) {
+  return (
+    <div
+      data-slot="notice"
+      className={cn('rounded-md border p-3', variantClasses[variant], className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Why
Two HIGH findings (audit — modals / severity color):

- **PIIWarningModal** used a raw `bg-gradient-to-r from-red-600 to-orange-600` header and a `severityColors` map hardcoding red/amber/blue palette hues, bypassing the `--destructive`/`--warning` tokens.
- **Every modal invented its own severity color** — EnclosureErrorModal orange, NISTComplianceModal `amber-500/10`, UpdatePromptModal blue, PIIWarningModal red/amber/blue — three ambers, two oranges, and a blue with no shared primitive, so non-default schemes clashed.

## What
- New `src/components/ui/notice.tsx`: a token-backed `<Notice variant='info'|'warning'|'error'|'success'>` primitive (flat tint + border from `--primary`/`--warning`/`--destructive`/`--success`, GOV.UK-style, no gradients).
- Refactor all four modals onto it, with icons/headings using the matching `text-<token>` accent. The PII header drops the gradient for a flat `bg-destructive`/`bg-warning` with its AA-contrast foreground token. `--warning` already exists across all schemes.

## Verification
`tsc -b` + vite build + eslint clean; no hardcoded palette hues remain in any of the four modals. Live (NIST modal, dev-domain warning): dark scheme renders the warning Notice as `--warning/10` tint + `--warning/30` border with a bright-amber `text-warning` heading; the light-scheme heading resolves to `--warning` (oklch 0.55), which is defined for ≥4.5:1 on the light canvas. The PII header reuses the same `bg-destructive`/`text-destructive-foreground` pairing as the destructive button.

Version 1.2.34.