### PR TITLE
fix(ui): route the top notice strips through the warning token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.35] — 2026-07-04
+
+### Changed
+
+- The storage and backup notice strips and the beta banner now use the shared
+  warning color, so they restain correctly in every theme instead of a fixed
+  amber, and the banner text matches the strips' size.
+
+### Fixed
+
+- Stacked notice strips now read as separate: each carries a left accent bar
+  and a firmer divider instead of merging into one slab.
+- A notice's leading icon aligns to the first line when the message wraps, and
+  the dismiss/action controls have larger touch targets.
+
+### Accessibility
+
+- Blocked storage and failed-backup conditions are now announced assertively to
+  screen readers (role="alert") instead of politely, where they could be
+  missed; the benign heads-up cases stay polite.
+
 ## [1.2.34] — 2026-07-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.34",
+  "version": "1.2.35",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/BackupNotice.tsx
+++ b/src/components/BackupNotice.tsx
@@ -32,12 +32,16 @@ export function BackupNotice() {
   const actionLabel = needsPermission ? 'Reconnect' : 'Choose file';
   const onAction = needsPermission ? reconnect : setupBackup;
 
+  // A failed write means the backup is silently stale — announce it assertively;
+  // a permission drop on relaunch is expected and stays polite.
+  const role = status === 'error' ? 'alert' : 'status';
+
   return (
     <div
-      role="status"
-      className="flex items-center gap-2 border-b border-amber-500/25 bg-amber-500/10 px-4 py-1 text-xs text-foreground"
+      role={role}
+      className="flex items-start gap-2 border-b border-b-warning/30 border-l-2 border-l-warning bg-warning/10 px-4 py-1 text-xs text-foreground"
     >
-      <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
       <p className="min-w-0 flex-1">
         {message}
         {fileName ? <span className="text-muted-foreground"> ({fileName})</span> : null}
@@ -45,7 +49,7 @@ export function BackupNotice() {
       <button
         type="button"
         onClick={() => void onAction()}
-        className="shrink-0 rounded px-2 py-0.5 font-medium text-amber-700 underline-offset-2 outline-none hover:underline focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:text-amber-300"
+        className="-my-1.5 shrink-0 rounded px-2 py-1.5 font-medium text-warning underline-offset-2 outline-none hover:underline focus-visible:ring-[3px] focus-visible:ring-ring/50"
       >
         {actionLabel}
       </button>
@@ -53,7 +57,7 @@ export function BackupNotice() {
         type="button"
         onClick={() => setDismissedStatus(status)}
         aria-label="Dismiss backup notice"
-        className="shrink-0 rounded p-0.5 text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        className="-m-1.5 shrink-0 rounded p-1.5 text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
       >
         <X className="h-3.5 w-3.5" />
       </button>

--- a/src/components/StorageNotice.tsx
+++ b/src/components/StorageNotice.tsx
@@ -27,12 +27,16 @@ export function StorageNotice() {
       ? 'Reloading usually fixes it; if not, restore from a backup file.'
       : 'Use Download or Share to keep a permanent copy.';
 
+  // A blocked/unreadable store is a data-durability problem, so announce it
+  // assertively; the benign "best-effort" heads-up stays polite.
+  const role = storageHealth === 'unavailable' || storageHealth === 'unreadable' ? 'alert' : 'status';
+
   return (
     <div
-      role="status"
-      className="flex items-center gap-2 border-b border-amber-500/25 bg-amber-500/10 px-4 py-1 text-xs text-foreground"
+      role={role}
+      className="flex items-start gap-2 border-b border-b-warning/30 border-l-2 border-l-warning bg-warning/10 px-4 py-1 text-xs text-foreground"
     >
-      <Info className="h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-warning" />
       <p className="min-w-0 flex-1">
         {message} <span className="text-muted-foreground">{suffix}</span>
       </p>
@@ -40,7 +44,7 @@ export function StorageNotice() {
         type="button"
         onClick={dismiss}
         aria-label="Dismiss storage notice"
-        className="shrink-0 rounded p-0.5 text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        className="-m-1.5 shrink-0 rounded p-1.5 text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
       >
         <X className="h-3.5 w-3.5" />
       </button>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -635,11 +635,11 @@ export function Header({
     <header className="border-b border-border bg-card">
       {/* Dismissable beta release banner */}
       {!bannerDismissed && (
-        <div className="bg-amber-500/10 text-amber-700 dark:text-amber-300/90 text-[0.6875rem] font-medium py-0.5 text-center tracking-wide relative border-b border-amber-500/20">
+        <div className="bg-warning/10 text-warning text-xs font-medium py-0.5 text-center tracking-wide relative border-b border-warning/20">
           Not an official DoW website. Beta release — report issues on GitHub.
           <button
             onClick={dismissBanner}
-            className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 transition-colors"
+            className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-warning/20 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 transition-colors"
             aria-label="Dismiss banner"
           >
             <X className="h-3 w-3" />

--- a/tests/component/BackupNotice.test.tsx
+++ b/tests/component/BackupNotice.test.tsx
@@ -39,9 +39,22 @@ describe('BackupNotice', () => {
   it('shows a write-failure strip that offers to re-pick the file', () => {
     setStatus('error');
     render(<BackupNotice />);
-    expect(screen.getByRole('status').textContent).toContain("couldn't write");
+    // A failed write silently stales the backup — announce it assertively.
+    expect(screen.getByRole('alert').textContent).toContain("couldn't write");
     fireEvent.click(screen.getByRole('button', { name: 'Choose file' }));
     expect(useBackupStore.getState().setupBackup).toHaveBeenCalledOnce();
+  });
+
+  it('escalates only the write-failure to role=alert; the expected permission drop stays polite', () => {
+    setStatus('needs-permission');
+    const { rerender } = render(<BackupNotice />);
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.getByRole('status')).toBeTruthy();
+
+    setStatus('error');
+    rerender(<BackupNotice />);
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.queryByRole('status')).toBeNull();
   });
 
   it('dismissal is per-status: hiding needs-permission still lets a later error surface', () => {
@@ -53,6 +66,6 @@ describe('BackupNotice', () => {
 
     setStatus('error');
     rerender(<BackupNotice />);
-    expect(screen.getByRole('status').textContent).toContain("couldn't write"); // new status re-surfaces
+    expect(screen.getByRole('alert').textContent).toContain("couldn't write"); // new status re-surfaces
   });
 });


### PR DESCRIPTION
## Why
The storage notice, backup notice, and beta banner each hard-coded raw amber palette in a slightly different recipe, so they didn't adapt to the color schemes and the banner text was a different size (11px) than the strips (12px). A few smaller issues rode along: stacked strips merged into one slab, the leading icon floated to the middle of a wrapped message, the dismiss/action controls were tiny, and a genuine data-loss condition was announced only politely.

## What
- All three surfaces move onto the shared `--warning` token (tint, border, icon, action text).
- Each strip gains a solid left accent bar + a firmer bottom divider, so two active strips are visually distinct.
- `items-start` + icon `mt-0.5` so the icon sits on line 1 of a wrapped message.
- Dismiss/action controls get negative-margin hit padding (≥24px target) without thickening the slim strip.
- Blocked/unreadable storage and failed-backup now render `role="alert"` (assertive); the expected "best-effort" and "reconnect after relaunch" cases stay `role="status"`.

## Verification
`tsc -b` + build + eslint + `vitest --coverage` all green. Extended `BackupNotice.test.tsx` (now 5 tests) to assert the alert/status split. Live (dark): beta banner and storage strip render at `--warning/10` with a solid `--warning` left accent, `items-start`, and 12px text.

Version 1.2.35.