### PR TITLE
fix(editor): tell the user when an attached file is the wrong type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.36] — 2026-07-04
+
+### Fixed
+
+- Attaching an unsupported file now tells you why instead of doing nothing.
+  Dropping or picking a non-PDF for an enclosure, or a non-image for a
+  signature, silently ignored the file; it now shows a clear message naming the
+  skipped file, and valid files in the same drop still attach.
+
 ## [1.2.35] — 2026-07-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.35",
+  "version": "1.2.36",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -11,6 +11,8 @@ import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
+import { partitionFiles, rejectedFilesMessage, isPdfFile } from '@/lib/fileFilter';
+import { showAppAlert } from '@/stores/alertStore';
 import {
   Select,
   SelectContent,
@@ -69,8 +71,11 @@ function SortableEnclosure({
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file && file.type === 'application/pdf') {
+    if (!file) return;
+    if (isPdfFile(file)) {
       onAttachFile(file);
+    } else {
+      showAppAlert({ title: 'PDF files only', message: rejectedFilesMessage([file], 'PDF') });
     }
   };
 
@@ -273,12 +278,13 @@ export function EnclosuresManager() {
     e.stopPropagation();
     setIsDraggingOver(false);
 
-    const files = Array.from(e.dataTransfer.files);
-    const pdfFiles = files.filter((file) => file.type === 'application/pdf');
-
-    pdfFiles.forEach((file) => {
+    const { accepted, rejected } = partitionFiles(Array.from(e.dataTransfer.files), isPdfFile);
+    accepted.forEach((file) => {
       handleUploadNewEnclosure(file);
     });
+    if (rejected.length > 0) {
+      showAppAlert({ title: 'PDF files only', message: rejectedFilesMessage(rejected, 'PDF') });
+    }
   }, [handleUploadNewEnclosure]);
 
   return (
@@ -406,12 +412,11 @@ export function EnclosuresManager() {
                     accept=".pdf"
                     multiple
                     onChange={(e) => {
-                      const files = Array.from(e.target.files || []);
-                      files.forEach((file) => {
-                        if (file.type === 'application/pdf') {
-                          handleUploadNewEnclosure(file);
-                        }
-                      });
+                      const { accepted, rejected } = partitionFiles(Array.from(e.target.files || []), isPdfFile);
+                      accepted.forEach((file) => handleUploadNewEnclosure(file));
+                      if (rejected.length > 0) {
+                        showAppAlert({ title: 'PDF files only', message: rejectedFilesMessage(rejected, 'PDF') });
+                      }
                       e.target.value = '';
                     }}
                     className="hidden"

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -15,6 +15,7 @@ import { useUIStore } from '@/stores/uiStore';
 import { unfilled } from '@/lib/requiredField';
 import { FILE_LIMITS } from '@/lib/constants';
 import { showAppAlert } from '@/stores/alertStore';
+import { isImageFile, rejectedFilesMessage } from '@/lib/fileFilter';
 import type { DocTypeConfig, SignatureImage, SignatureType } from '@/types/document';
 import { ALL_SERVICE_RANKS, formatRank } from '@/data/ranks';
 import { getOfficeCode, OFFICE_CODES } from '@/data/officeCodes';
@@ -107,8 +108,8 @@ export function SignatureSection({ config }: SignatureSectionProps) {
 
   // Handle signature image upload
   const handleSignatureUpload = useCallback(async (file: File) => {
-    if (!file.type.startsWith('image/')) {
-      console.error('Only image files are supported');
+    if (!isImageFile(file)) {
+      showAppAlert({ title: 'Image files only', message: rejectedFilesMessage([file], 'image') });
       return;
     }
     // Signatures are stored base64 in localStorage; cap the size so they can't fill it.
@@ -157,8 +158,10 @@ export function SignatureSection({ config }: SignatureSectionProps) {
     e.preventDefault();
     setIsDragging(false);
 
+    // Hand any dropped file to the uploader; it validates the type and surfaces
+    // an error for non-images instead of the drop silently doing nothing.
     const file = e.dataTransfer.files[0];
-    if (file && file.type.startsWith('image/')) {
+    if (file) {
       handleSignatureUpload(file);
     }
   }, [handleSignatureUpload]);

--- a/src/lib/fileFilter.ts
+++ b/src/lib/fileFilter.ts
@@ -1,0 +1,31 @@
+/**
+ * Helpers for attach points (enclosures, signature) that accept only one file
+ * type. They split a dropped/picked list into the good files and the rejects so
+ * the caller can attach the good ones AND tell the user about the rest, instead
+ * of dropping an unsupported file silently — a "nothing happened" dead end.
+ */
+
+/** Partition a file list by a predicate. Pure; order-preserving. */
+export function partitionFiles(
+  files: File[],
+  accept: (file: File) => boolean
+): { accepted: File[]; rejected: File[] } {
+  const accepted: File[] = [];
+  const rejected: File[] = [];
+  for (const file of files) (accept(file) ? accepted : rejected).push(file);
+  return { accepted, rejected };
+}
+
+/**
+ * A human message for rejected files, given the accepted-type label (e.g.
+ * "PDF", "image"). Names the file when there's exactly one, counts otherwise.
+ */
+export function rejectedFilesMessage(rejected: File[], typeLabel: string): string {
+  if (rejected.length === 1) {
+    return `"${rejected[0].name}" isn't a ${typeLabel} file, so it was skipped.`;
+  }
+  return `${rejected.length} files weren't ${typeLabel} files, so they were skipped.`;
+}
+
+export const isPdfFile = (file: File): boolean => file.type === 'application/pdf';
+export const isImageFile = (file: File): boolean => file.type.startsWith('image/');

--- a/tests/unit/fileFilter.test.ts
+++ b/tests/unit/fileFilter.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  partitionFiles,
+  rejectedFilesMessage,
+  isPdfFile,
+  isImageFile,
+} from '@/lib/fileFilter';
+
+const mkFile = (name: string, type: string): File =>
+  new File([''], name, { type });
+
+describe('partitionFiles', () => {
+  it('splits into accepted and rejected, preserving order', () => {
+    const files = [
+      mkFile('a.pdf', 'application/pdf'),
+      mkFile('b.png', 'image/png'),
+      mkFile('c.pdf', 'application/pdf'),
+    ];
+    const { accepted, rejected } = partitionFiles(files, isPdfFile);
+    expect(accepted.map((f) => f.name)).toEqual(['a.pdf', 'c.pdf']);
+    expect(rejected.map((f) => f.name)).toEqual(['b.png']);
+  });
+
+  it('handles all-accepted and all-rejected without cross-contamination', () => {
+    const imgs = [mkFile('x.png', 'image/png'), mkFile('y.jpg', 'image/jpeg')];
+    expect(partitionFiles(imgs, isImageFile).rejected).toHaveLength(0);
+    expect(partitionFiles(imgs, isPdfFile).accepted).toHaveLength(0);
+  });
+
+  it('returns two empty lists for an empty input', () => {
+    expect(partitionFiles([], isPdfFile)).toEqual({ accepted: [], rejected: [] });
+  });
+});
+
+describe('rejectedFilesMessage', () => {
+  it('names the file when exactly one was rejected', () => {
+    const msg = rejectedFilesMessage([mkFile('resume.docx', 'application/msword')], 'PDF');
+    expect(msg).toContain('resume.docx');
+    expect(msg).toContain('PDF');
+  });
+
+  it('counts when more than one was rejected', () => {
+    const msg = rejectedFilesMessage(
+      [mkFile('a.txt', 'text/plain'), mkFile('b.txt', 'text/plain')],
+      'PDF'
+    );
+    expect(msg).toContain('2 files');
+  });
+});
+
+describe('type predicates', () => {
+  it('isPdfFile matches only the PDF mime', () => {
+    expect(isPdfFile(mkFile('a.pdf', 'application/pdf'))).toBe(true);
+    expect(isPdfFile(mkFile('a.png', 'image/png'))).toBe(false);
+  });
+
+  it('isImageFile matches any image/* mime', () => {
+    expect(isImageFile(mkFile('a.png', 'image/png'))).toBe(true);
+    expect(isImageFile(mkFile('a.gif', 'image/gif'))).toBe(true);
+    expect(isImageFile(mkFile('a.pdf', 'application/pdf'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why
Attaching an unsupported file failed completely silently. The enclosure attach points filtered to `application/pdf` with no `else`, and the signature dropzone only `console.error`'d — so dropping a `.docx` enclosure or a `.pdf` onto the signature box did *nothing*, with no message. On a tool people rely on, "nothing happened" reads as broken.

## What
- New `src/lib/fileFilter.ts`: pure `partitionFiles(files, accept)` + `rejectedFilesMessage(rejected, typeLabel)` + `isPdfFile`/`isImageFile` predicates.
- Wire a themed `showAppAlert` at all three enclosure attach points (single pick, drop, multi-pick) and both signature paths (upload + drop). Valid files in a mixed drop still attach; only the rejects are reported, named when there's one and counted otherwise.

## Verification
`tsc -b` + build + eslint + `vitest --coverage` all green. New `tests/unit/fileFilter.test.ts` (7 cases) covers the partition (order, all-accepted, all-rejected, empty), the 1-vs-N message, and both predicates.

Version 1.2.36.