### PR TITLE
fix(a11y): label reference/enclosure fields, ring the drag handles, add empty states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.37] — 2026-07-04
+
+### Accessibility
+
+- Reference and enclosure title/URL fields now have proper labels, so screen
+  readers announce which field they are instead of "edit text, blank".
+- The reorder drag handles show a keyboard focus ring and a hover surface.
+
+### Changed
+
+- The References and Enclosures sections now show a short line when empty
+  instead of just bare Add buttons, and a library-picker row highlights when a
+  control inside it is focused by keyboard.
+
 ## [1.2.36] — 2026-07-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.36",
+  "version": "1.2.37",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -94,7 +94,7 @@ function SortableEnclosure({
           aria-label={`Drag to reorder enclosure ${index + 1}`}
           {...attributes}
           {...listeners}
-          className="mt-2 cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground"
+          className="mt-2 cursor-grab rounded-sm text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 active:cursor-grabbing"
         >
           <GripVertical className="h-4 w-4" />
         </button>
@@ -110,6 +110,7 @@ function SortableEnclosure({
             value={enclosure.title}
             onChange={(e) => onUpdateTitle(e.target.value)}
             placeholder="Enclosure title..."
+            aria-label={`Enclosure (${index + 1}) title`}
           />
 
           {/* PDF attachment section */}
@@ -379,6 +380,12 @@ export function EnclosuresManager() {
                   ))}
                 </SortableContext>
               </DndContext>
+
+              {enclosures.length === 0 && (
+                <p className="mt-1 mb-2 text-sm text-muted-foreground">
+                  No enclosures yet. Add one, then attach its PDF.
+                </p>
+              )}
 
               <div className="space-y-2 mt-2">
                 <Button

--- a/src/components/editor/ReferencesManager.tsx
+++ b/src/components/editor/ReferencesManager.tsx
@@ -80,7 +80,7 @@ const SortableReference = memo(function SortableReference({
           aria-label={`Drag to reorder reference ${index + 1}`}
           {...attributes}
           {...listeners}
-          className="mt-2 cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground"
+          className="mt-2 cursor-grab rounded-sm text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 active:cursor-grabbing"
         >
           <GripVertical className="h-4 w-4" />
         </button>
@@ -96,6 +96,7 @@ const SortableReference = memo(function SortableReference({
             value={reference.title}
             onChange={(e) => updateReference(index, { title: e.target.value })}
             placeholder="Reference title..."
+            aria-label={`Reference (${reference.letter}) title`}
           />
           {urlInvalid && (
             <div
@@ -121,6 +122,7 @@ const SortableReference = memo(function SortableReference({
               onChange={(e) => updateReference(index, { url: e.target.value })}
               placeholder="URL (optional)"
               className={`text-sm ${urlInvalid ? 'border-destructive focus-visible:ring-destructive' : ''}`}
+              aria-label={`Reference (${reference.letter}) URL`}
               aria-invalid={urlInvalid}
               aria-describedby={urlInvalid ? urlWarningId : undefined}
             />
@@ -176,7 +178,7 @@ export function ReferencesManager() {
   };
 
   return (
-    <Accordion type="single" collapsible>
+    <Accordion data-tour="references" type="single" collapsible>
       <AccordionItem value="references">
         <AccordionTrigger>
           <span className="flex items-center gap-2">
@@ -239,8 +241,15 @@ export function ReferencesManager() {
                 </SortableContext>
               </DndContext>
 
+              {references.length === 0 && (
+                <p className="mt-1 mb-2 text-sm text-muted-foreground">
+                  No references yet. Add one, or browse the library.
+                </p>
+              )}
+
               <div className="flex flex-wrap gap-2 mt-2">
                 <Button
+                  data-tour="reference-add"
                   variant="outline"
                   size="sm"
                   onClick={() => addReference('')}
@@ -249,6 +258,7 @@ export function ReferencesManager() {
                   Add reference
                 </Button>
                 <Button
+                  data-tour="reference-library"
                   variant="outline"
                   size="sm"
                   onClick={() => setReferenceLibraryOpen(true)}

--- a/src/components/modals/ReferenceLibraryPicker.tsx
+++ b/src/components/modals/ReferenceLibraryPicker.tsx
@@ -94,7 +94,7 @@ export function ReferenceLibraryPicker({
                   return (
                     <div
                       key={ref.id}
-                      className="flex items-center justify-between p-2 rounded-md hover:bg-secondary/50 group"
+                      className="flex items-center justify-between p-2 rounded-md hover:bg-secondary/50 focus-within:bg-secondary/50 group"
                     >
                       <span className="text-sm">{citation}</span>
                       <Button


### PR DESCRIPTION
## Why
A cluster of accessibility and empty-state gaps in the References and Enclosures managers:
- Title/URL inputs were placeholder-only — screen readers announced "edit text, blank".
- The reorder drag handles had no `focus-visible` ring or hover surface, so a keyboard user tabbing onto one to start a keyboard drag got no indication.
- An opened section with zero items showed only naked Add buttons.
- References had no `data-tour` anchors (Enclosures did), so a walkthrough couldn't point at it.
- Library-picker rows had no visible focus affordance.

## What
- Index-aware `aria-label`s on the reference title/URL and enclosure title inputs (`Reference (a) title`, `Enclosure (1) title`, …).
- Drag handles get `rounded-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 hover:bg-accent/50` (the house recipe).
- A muted empty-state line above the Add buttons in each manager.
- `data-tour="references"` / `reference-add` / `reference-library` anchors.
- `focus-within:bg-secondary/50` on library-picker rows.

## Verification
`tsc -b` + build + eslint + `vitest --coverage` all green. Live: expanded References with zero items shows the empty-state line and both `data-tour` anchors; after adding a row the inputs carry `Reference (a) title` / `Reference (a) URL` and the drag handle has the focus-ring/hover classes (the ring only paints on real keyboard focus, not programmatic).

Version 1.2.37.