### PR TITLE
feat(pdf): download button in the viewer toolbar; larger buttons and clearer toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.39] — 2026-07-04
+
+### Added
+
+- The PDF preview toolbar now has a Download button, so you can save the
+  rendered PDF straight from the viewer instead of only opening it in a new tab.
+
+### Changed
+
+- Preview-toolbar buttons are a bit larger (32px) for easier tapping, the
+  Fit-width/Fit-page toggles now show a filled background when active (not just
+  a color tint), and the zoom percentage stays visible on narrower panels.
+
 ## [1.2.38] — 2026-07-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.38",
+  "version": "1.2.39",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/pdf/PdfViewer.tsx
+++ b/src/components/pdf/PdfViewer.tsx
@@ -123,6 +123,17 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
     window.open(pdfUrl, '_blank', 'noopener');
   }, [pdfUrl]);
 
+  const downloadPdf = useCallback(() => {
+    // pdfUrl is a same-origin blob URL, so a plain download anchor is enough on
+    // desktop (the mobile modal has its own iOS-aware path).
+    const a = document.createElement('a');
+    a.href = pdfUrl;
+    a.download = 'correspondence.pdf';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  }, [pdfUrl]);
+
   const goToPage = useCallback(
     (delta: 1 | -1) => {
       activeLayerRef.current?.scrollToPage(pageInView - 1 + delta, !reducedMotion);
@@ -258,6 +269,7 @@ export default function PdfViewer({ pdfUrl, className, showFullscreen = true }: 
         onZoomFitWidth={zoomFitWidth}
         onZoomFitPage={zoomFitPage}
         onOpenInTab={openInTab}
+        onDownload={downloadPdf}
         fullscreen={showFullscreen && fullscreen.available ? fullscreen : null}
       />
       <div className="flex min-h-0 flex-1">

--- a/src/components/pdf/PdfViewerToolbar.tsx
+++ b/src/components/pdf/PdfViewerToolbar.tsx
@@ -1,6 +1,7 @@
 import {
   ChevronDown,
   ChevronUp,
+  Download,
   ExternalLink,
   Maximize2,
   Minimize2,
@@ -29,6 +30,7 @@ interface PdfViewerToolbarProps {
   onZoomFitWidth: () => void;
   onZoomFitPage: () => void;
   onOpenInTab: () => void;
+  onDownload: () => void;
   fullscreen?: { isFullscreen: boolean; toggle: () => void } | null;
   className?: string;
 }
@@ -53,7 +55,12 @@ function ToolButton({
           type="button"
           variant="ghost"
           size="icon"
-          className="h-7 w-7"
+          className={cn(
+            'h-8 w-8',
+            // A pressed toggle gets a toned fill, not just an icon tint, so the
+            // selected state reads without relying on color alone.
+            pressed && 'bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary'
+          )}
           aria-label={label}
           aria-pressed={pressed}
           onClick={onClick}
@@ -83,6 +90,7 @@ export function PdfViewerToolbar({
   onZoomFitWidth,
   onZoomFitPage,
   onOpenInTab,
+  onDownload,
   fullscreen,
   className,
 }: PdfViewerToolbarProps) {
@@ -114,7 +122,7 @@ export function PdfViewerToolbar({
           onClick={thumbnails.toggle}
           pressed={thumbnails.open}
         >
-          <PanelLeft className={cn('h-4 w-4', thumbnails.open && 'text-primary')} />
+          <PanelLeft className="h-4 w-4" />
         </ToolButton>
       )}
       <ToolButton label="Previous page" onClick={onPrevPage} disabled={page <= 1}>
@@ -148,17 +156,17 @@ export function PdfViewerToolbar({
       <ToolButton label="Zoom out" onClick={onZoomOut}>
         <ZoomOut className="h-4 w-4" />
       </ToolButton>
-      <span className="tnum hidden min-w-[3rem] text-center text-xs text-muted-foreground @[420px]:block">
+      <span className="tnum hidden min-w-[3rem] text-center text-xs text-muted-foreground @[300px]:block">
         {zoomPercent}%
       </span>
       <ToolButton label="Zoom in" onClick={onZoomIn}>
         <ZoomIn className="h-4 w-4" />
       </ToolButton>
       <ToolButton label="Fit width" onClick={onZoomFitWidth} pressed={fitMode === 'width'}>
-        <MoveHorizontal className={cn('h-4 w-4', fitMode === 'width' && 'text-primary')} />
+        <MoveHorizontal className="h-4 w-4" />
       </ToolButton>
       <ToolButton label="Fit page" onClick={onZoomFitPage} pressed={fitMode === 'page'}>
-        <RectangleVertical className={cn('h-4 w-4', fitMode === 'page' && 'text-primary')} />
+        <RectangleVertical className="h-4 w-4" />
       </ToolButton>
 
       <div className="mx-1 hidden h-4 w-px bg-border @[420px]:block" />
@@ -171,6 +179,9 @@ export function PdfViewerToolbar({
           {fullscreen.isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
         </ToolButton>
       )}
+      <ToolButton label="Download PDF" onClick={onDownload}>
+        <Download className="h-4 w-4" />
+      </ToolButton>
       <ToolButton label="Open in browser tab" onClick={onOpenInTab}>
         <ExternalLink className="h-4 w-4" />
       </ToolButton>


### PR DESCRIPTION
## Why
Four gaps in the PDF preview toolbar. The biggest is functional: the desktop viewer's only export affordance was "Open in browser tab" — **no download**, even though the mobile modal has one, so the two surfaces disagreed. Plus the icon buttons were 28px (below the app's own 32px icon-sm and the touch floor), the Fit-width/Fit-page toggles signalled "pressed" with icon color alone (fails for color-blind users), and the zoom-percentage readout vanished below 420px — exactly the mobile-modal width.

## What
- **Download button** next to Open-in-tab, wired to a same-origin `blob:` download anchor (`correspondence.pdf`). The mobile modal keeps its own iOS-aware `downloadPdfBlob` path.
- Toolbar buttons `h-7 w-7` → `h-8 w-8`.
- `ToolButton` pressed state gets a toned `bg-primary/10` fill (with matching hover), and the redundant per-icon `text-primary` tints are dropped in favor of the button's `currentColor`.
- Zoom-% reveal threshold `@[420px]` → `@[300px]` so it shows on the mobile toolbar.

(The zoom-preset dropdown and page skeletons — the other two items in this area — are a separate follow-up.)

## Verification
`tsc -b` + build + eslint + `vitest --coverage` all green (tsc validates the new required `onDownload` prop across all callers). Live, with a compiled PDF: the Download button renders and clicking it produces an anchor `download="correspondence.pdf"` at the `blob:` URL; buttons measure 32px; the active Fit-width toggle computes `bg-primary/10`; the zoom "51%" readout shows.

Version 1.2.39.