### PR TITLE
fix(ui): one active indicator, shared micro-label size, and focus rings in the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.40] — 2026-07-04
+
+### Changed
+
+- The active document in the Recents sidebar now shows a single indicator (the
+  scarlet left bar, matching the section outline above) instead of also filling
+  the row, so the two lists speak the same visual language.
+- Sidebar micro-labels (section headers, doc-type chips, timestamps) now use one
+  shared type size instead of three slightly different hand-set sizes, and the
+  recency group labels ("Today", "Pinned") are a touch more legible.
+
+### Accessibility
+
+- The sidebar's collapse, expand, and New buttons now show a keyboard focus ring.
+- The per-row "…" actions menu rests faintly visible and reveals on row
+  hover/focus instead of popping into view row-by-row while tabbing; it's always
+  visible on touch.
+- The mobile Recents pin and delete buttons are now full 44px touch targets with
+  a gap between them, so the destructive delete is harder to hit by mistake.
+
 ## [1.2.39] — 2026-07-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.39",
+  "version": "1.2.40",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/layout/EditorSidebar.tsx
+++ b/src/components/layout/EditorSidebar.tsx
@@ -208,7 +208,7 @@ export function EditorSidebar() {
           onClick={toggleSidebar}
           aria-label="Expand sidebar"
           aria-expanded={false}
-          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
         >
           <PanelLeftOpen className="h-4 w-4" />
         </button>
@@ -216,7 +216,7 @@ export function EditorSidebar() {
           type="button"
           onClick={newDocument}
           aria-label="New document"
-          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
         >
           <Plus className="h-4 w-4" />
         </button>
@@ -235,7 +235,7 @@ export function EditorSidebar() {
       {/* On this page: section outline (collapse control shares the label row) */}
       <div className="px-2 pb-2 border-b border-border">
         <div className="flex items-center justify-between px-2.5 pt-2 pb-1">
-          <span className="text-[10px] font-semibold tracking-[0.06em] uppercase text-muted-foreground">
+          <span className="text-2xs font-semibold tracking-[0.06em] uppercase text-muted-foreground">
             On this page
           </span>
           <button
@@ -256,7 +256,7 @@ export function EditorSidebar() {
       {/* Recent: document library */}
       <div className="flex min-h-0 flex-1 flex-col pt-2">
         <div className="flex items-center justify-between px-3 pb-1.5">
-          <span className="text-[10px] font-semibold tracking-[0.06em] uppercase text-muted-foreground">Recent</span>
+          <span className="text-2xs font-semibold tracking-[0.06em] uppercase text-muted-foreground">Recent</span>
           <div className="flex items-center gap-1">
             <button
               type="button"
@@ -282,7 +282,7 @@ export function EditorSidebar() {
               ref={newBtnRef}
               type="button"
               onClick={newDocument}
-              className="inline-flex items-center gap-1 rounded-md border border-border bg-card px-2 py-1 text-xs text-foreground hover:bg-muted transition-colors"
+              className="inline-flex items-center gap-1 rounded-md border border-border bg-card px-2 py-1 text-xs text-foreground outline-none transition-colors hover:bg-muted focus-visible:ring-[3px] focus-visible:ring-ring/50"
             >
               <Plus className="h-3.5 w-3.5" />
               New
@@ -394,17 +394,19 @@ export function EditorSidebar() {
           ) : (
             groups.map((g) => (
               <div key={g.label} className="mb-1.5">
-                <div className="px-2.5 py-1 text-[10px] font-semibold tracking-[0.06em] uppercase text-muted-foreground/80">{g.label}</div>
+                <div className="px-2.5 py-1 text-2xs font-semibold tracking-[0.06em] uppercase text-muted-foreground">{g.label}</div>
                 <ul className="space-y-0.5">
                   {g.items.map((m) => {
                     const active = m.id === currentId;
                     const isSelected = selected.has(m.id);
-                    const highlight = selectMode ? isSelected : active;
                     return (
                       <li
                         key={m.id}
                         className={`group relative flex items-center rounded-md pr-1 transition-colors ${
-                          highlight ? 'bg-primary/10' : 'hover:bg-muted/60'
+                          // Active (non-select) already shows the 3px scarlet bar +
+                          // text-primary like the section rail above, so no row fill
+                          // here — the fill is reserved for the selection-checked state.
+                          selectMode && isSelected ? 'bg-primary/10' : 'hover:bg-muted/60'
                         }`}
                       >
                         {active && !selectMode && (
@@ -461,7 +463,7 @@ export function EditorSidebar() {
                           >
                             <span
                               aria-hidden="true"
-                              className={`inline-flex h-4 shrink-0 items-center justify-center rounded px-1 text-[9px] font-semibold uppercase leading-none tracking-wide ${
+                              className={`inline-flex h-4 shrink-0 items-center justify-center rounded px-1 text-2xs font-semibold uppercase leading-none tracking-wide ${
                                 active ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'
                               }`}
                               style={{ minWidth: '2.4rem' }}
@@ -475,7 +477,7 @@ export function EditorSidebar() {
                               >
                                 {m.title}
                               </span>
-                              <span className="block truncate text-[11px] text-muted-foreground tnum">
+                              <span className="block truncate text-2xs text-muted-foreground tnum">
                                 {relTime(m.updatedAt)}
                               </span>
                             </span>
@@ -490,7 +492,10 @@ export function EditorSidebar() {
                               <button
                                 type="button"
                                 aria-label={`Actions for ${m.title}`}
-                                className="shrink-0 rounded p-1 text-muted-foreground opacity-0 outline-none transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:ring-[3px] focus-visible:ring-ring/50 group-hover:opacity-100 data-[state=open]:opacity-100"
+                                // Rest at 40% (not fully hidden) and reveal on
+                                // row-level hover/focus so tabbing doesn't pop each
+                                // '…' 0→100 in turn; always shown on touch (no hover).
+                                className="shrink-0 rounded p-1 text-muted-foreground opacity-40 outline-none transition-opacity hover:text-foreground focus-visible:opacity-100 focus-visible:ring-[3px] focus-visible:ring-ring/50 group-hover:opacity-100 group-focus-within:opacity-100 data-[state=open]:opacity-100 [@media(hover:none)]:opacity-100"
                               >
                                 <MoreHorizontal className="h-3.5 w-3.5" />
                               </button>

--- a/src/components/layout/MobileRecents.tsx
+++ b/src/components/layout/MobileRecents.tsx
@@ -119,7 +119,7 @@ export function MobileRecents() {
                     >
                       <span
                         aria-hidden="true"
-                        className={`inline-flex h-5 shrink-0 items-center justify-center rounded px-1 text-[10px] font-semibold uppercase leading-none tracking-wide ${
+                        className={`inline-flex h-5 shrink-0 items-center justify-center rounded px-1 text-2xs font-semibold uppercase leading-none tracking-wide ${
                           active ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'
                         }`}
                         style={{ minWidth: '2.6rem' }}
@@ -133,7 +133,7 @@ export function MobileRecents() {
                         >
                           {m.title}
                         </span>
-                        <span className="block truncate text-[11px] text-muted-foreground tnum">
+                        <span className="block truncate text-2xs text-muted-foreground tnum">
                           {relTime(m.updatedAt)}
                         </span>
                       </span>
@@ -143,7 +143,7 @@ export function MobileRecents() {
                       type="button"
                       onClick={() => togglePin(m.id)}
                       aria-label={m.pinned ? `Unpin ${m.title}` : `Pin ${m.title}`}
-                      className="shrink-0 rounded p-2 text-muted-foreground hover:text-foreground"
+                      className="inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
                     >
                       {m.pinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}
                     </button>
@@ -151,7 +151,7 @@ export function MobileRecents() {
                       type="button"
                       onClick={() => remove(m.id)}
                       aria-label={`Remove ${m.title}`}
-                      className="shrink-0 rounded p-2 text-muted-foreground hover:text-destructive"
+                      className="ml-0.5 inline-flex min-h-11 min-w-11 shrink-0 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:text-destructive focus-visible:ring-[3px] focus-visible:ring-ring/50"
                     >
                       <Trash2 className="h-4 w-4" />
                     </button>

--- a/src/index.css
+++ b/src/index.css
@@ -160,6 +160,12 @@
   --shadow-lg: 0 0 0 1px rgb(18 27 46 / 0.04), 0 6px 12px -3px rgb(18 27 46 / 0.10), 0 16px 24px -6px rgb(18 27 46 / 0.12);
   --shadow-xl: 0 0 0 1px rgb(18 27 46 / 0.04), 0 12px 20px -6px rgb(18 27 46 / 0.12), 0 28px 40px -10px rgb(18 27 46 / 0.18);
 
+  /* One step below text-xs for micro-labels (eyebrow captions, doc-type chips,
+     timestamps) — replaces the scattered text-[9px]/[10px]/[11px] arbitraries. */
+  --text-2xs: 0.6875rem;
+  --text-2xs--line-height: 1rem;
+  --text-2xs--letter-spacing: 0.01em;
+
   /* Optical tracking ladder: large display text compresses, body/small relaxes. */
   --text-xs--letter-spacing: 0.01em;
   --text-sm--letter-spacing: 0.005em;


### PR DESCRIPTION
## Why
Several inconsistencies in the documents sidebar:
- The **active Recents row** got both a filled `bg-primary/10` tint *and* a 3px scarlet left bar, while the section outline right above it deliberately uses a single sliding bar with no fill — two contradictory "active" languages stacked in one sidebar.
- **Three hand-set micro-label sizes** (9/10/11px) for the same tier, with no token; the group labels were also gratuitously lighter (`muted-foreground/80`), pushing 10px text toward the contrast floor.
- The **collapse, expand, and New** buttons had no `focus-visible` ring.
- The per-row **"…" actions** button flashed 0→100 row-by-row while tabbing and was invisible on touch.
- The **mobile pin/delete** controls were ~32px, below the touch target, with the destructive delete abutting pin.

## What
- Active (non-select) row keeps only the bar + `text-primary`; `bg-primary/10` is reserved for the selection-checked state.
- New `--text-2xs` (11px) token; the 9/10/11px arbitraries across `EditorSidebar` and `MobileRecents` collapse onto it; group labels drop `/80`.
- Focus rings on the collapse/expand/New buttons (house `ring-[3px]` recipe).
- Row "…" rests at `opacity-40`, reveals on `group-hover`/`group-focus-within`, always shown on touch (`@media(hover:none)`).
- Mobile pin/delete → `min-h-11 min-w-11` (44px) with a gap and focus rings.

## Verification
`tsc -b` + build + eslint + `vitest --coverage` all green (the build caught a now-unused `highlight` local, removed). Live: `text-2xs` computes to 11px; the active row's background is transparent (bar-only); the "Today" group label is full `muted-foreground`; the New button carries the ring; no console errors.

Version 1.2.40.