### PR TITLE
fix(a11y): classification icons, POC-email validation, CUI color, chip target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.41] — 2026-07-04
+
+### Accessibility
+
+- The Classification section's decorative icons are now hidden from screen
+  readers, and its advisory banners carry a spoken "Warning:"/"Important:"
+  prefix so their intent is clear without the icon.
+- The Classified POC email fields now validate: a malformed address shows an
+  inline error and is flagged to assistive tech, clearing once it's valid.
+- The custom-classification preset chips are a little taller so they clear the
+  minimum touch-target size.
+
+### Fixed
+
+- The CUI Configuration heading uses the official CUI color (and a dark-mode
+  variant) instead of a generic purple, matching the classification swatches
+  elsewhere.
+
 ## [1.2.40] — 2026-07-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.40",
+  "version": "1.2.41",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/ClassificationSection.tsx
+++ b/src/components/editor/ClassificationSection.tsx
@@ -48,6 +48,10 @@ const CLASSIFICATION_PRESETS = [
   { value: 'TOP SECRET//SCI', label: 'TOP SECRET//SCI', color: 'text-[#756808] dark:text-[#FCE83A]', bg: 'bg-[#FCE83A]/20 dark:bg-[#FCE83A]/20 border-[#A8920E]/40 hover:bg-[#FCE83A]/40 dark:hover:bg-[#FCE83A]/30' },
 ];
 
+// Official CUI banner color (#502B85 / dark #9572D4), matching the level/preset
+// swatches above — not a generic purple.
+const CUI_TEXT_COLOR = 'text-[#502B85] dark:text-[#9572D4]';
+
 const CUI_CATEGORIES = [
   'Privacy',
   'Proprietary Business Information',
@@ -130,12 +134,19 @@ export function ClassificationSection() {
 
   const isCustom = classLevel === 'custom';
 
+  // Both POC-email inputs bind the same field and only one shows at a time, so
+  // one validity check covers both. Flag a non-empty value that isn't a basic
+  // address; an empty field is a normal "not filled in yet" state.
+  const pocEmail = (formData.classifiedPocEmail || '').trim();
+  const pocEmailInvalid = pocEmail !== '' && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(pocEmail);
+
   return (
     <Accordion data-tour="classification" type="single" collapsible>
       <AccordionItem value="classification">
         <AccordionTrigger>
           <div className="flex items-center gap-2">
             <Shield
+              aria-hidden="true"
               className={`h-4 w-4 ${classLevel === 'custom' ? 'text-gray-600' : currentLevel?.color || 'text-foreground'}`}
               style={{ fill: 'currentColor', fillOpacity: 0.2 }}
             />
@@ -163,9 +174,9 @@ export function ClassificationSection() {
                 level list, so the default panel stays clean like the design. */}
             {isDomainRestricted && (
               <div className="flex items-start gap-2 border-l-2 border-blue-300 dark:border-blue-800 pl-3">
-                <Info className="h-4 w-4 text-blue-600 dark:text-blue-400 mt-0.5 shrink-0" />
+                <Info aria-hidden="true" className="h-4 w-4 text-blue-600 dark:text-blue-400 mt-0.5 shrink-0" />
                 <div className="text-sm text-blue-800 dark:text-blue-300">
-                  <p className="font-medium">Domain Restrictions</p>
+                  <p className="font-medium"><span className="sr-only">Important: </span>Domain Restrictions</p>
                   <p className="text-xs mt-1">{restrictionMessage}</p>
                 </div>
               </div>
@@ -197,9 +208,9 @@ export function ClassificationSection() {
             {/* Warning for classified documents */}
             {isClassified && (
               <div className="flex items-start gap-2 p-3 rounded-md bg-destructive/10 border border-destructive/20">
-                <AlertTriangle className="h-4 w-4 text-destructive mt-0.5 shrink-0" />
+                <AlertTriangle aria-hidden="true" className="h-4 w-4 text-destructive mt-0.5 shrink-0" />
                 <div className="text-sm text-destructive">
-                  <p className="font-medium">Classified Document Warning</p>
+                  <p className="font-medium"><span className="sr-only">Warning: </span>Classified Document Warning</p>
                   <p className="text-xs mt-1">
                     This document will contain classified markings. Ensure proper handling
                     procedures are followed per applicable security regulations.
@@ -217,9 +228,9 @@ export function ClassificationSection() {
                 <p className="text-sm font-medium">Custom Classification</p>
 
                 <div className="flex items-start gap-2 p-3 rounded-md bg-amber-50 border border-amber-200 dark:bg-amber-950/30 dark:border-amber-800">
-                  <AlertTriangle className="h-4 w-4 text-amber-700 dark:text-amber-400 mt-0.5 shrink-0" />
+                  <AlertTriangle aria-hidden="true" className="h-4 w-4 text-amber-700 dark:text-amber-400 mt-0.5 shrink-0" />
                   <div className="text-sm text-amber-800 dark:text-amber-300">
-                    <p className="font-medium">Classification handling — non-accredited system</p>
+                    <p className="font-medium"><span className="sr-only">Warning: </span>Classification handling — non-accredited system</p>
                     <p className="text-xs mt-1">
                       Per DoDM 5200.01 Vol 3 and EO 13526, classified
                       information (CONFIDENTIAL, SECRET, TOP SECRET, TS//SCI)
@@ -264,7 +275,7 @@ export function ClassificationSection() {
                             key={preset.value}
                             type="button"
                             onClick={() => setField('customClassification', preset.value)}
-                            className={`px-2 py-0.5 text-xs font-medium rounded-md border transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 ${preset.color} ${preset.bg} ${active ? 'ring-2 ring-offset-1 ring-offset-background ring-current' : ''}`}
+                            className={`px-2 py-1 text-xs font-medium rounded-md border transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 ${preset.color} ${preset.bg} ${active ? 'ring-2 ring-offset-1 ring-offset-background ring-current' : ''}`}
                             title={`Set marking to "${preset.value}"`}
                           >
                             {preset.label}
@@ -377,7 +388,14 @@ export function ClassificationSection() {
                     value={formData.classifiedPocEmail || ''}
                     onChange={(e) => setField('classifiedPocEmail', e.target.value)}
                     placeholder="john.doe@usmc.mil"
+                    aria-invalid={pocEmailInvalid || undefined}
+                    aria-describedby={pocEmailInvalid ? 'customClassifiedPocEmail-error' : undefined}
                   />
+                  {pocEmailInvalid && (
+                    <p id="customClassifiedPocEmail-error" role="alert" className="text-xs text-destructive">
+                      Enter a valid email address (e.g. john.doe@usmc.mil).
+                    </p>
+                  )}
                 </div>
               </div>
             )}
@@ -385,7 +403,7 @@ export function ClassificationSection() {
             {/* CUI fields, shown only when CUI is the selected level. */}
             {isCUI && (
               <div className="space-y-4 p-3 rounded-md border bg-muted/30">
-                <p className="text-sm font-medium text-purple-600">CUI Configuration</p>
+                <p className={`text-sm font-medium ${CUI_TEXT_COLOR}`}>CUI Configuration</p>
 
                 <div className="space-y-2">
                   <Label htmlFor="cuiControlledBy">Controlled By</Label>
@@ -498,7 +516,14 @@ export function ClassificationSection() {
                     value={formData.classifiedPocEmail || ''}
                     onChange={(e) => setField('classifiedPocEmail', e.target.value)}
                     placeholder="john.doe@usmc.mil"
+                    aria-invalid={pocEmailInvalid || undefined}
+                    aria-describedby={pocEmailInvalid ? 'classifiedPocEmail-error' : undefined}
                   />
+                  {pocEmailInvalid && (
+                    <p id="classifiedPocEmail-error" role="alert" className="text-xs text-destructive">
+                      Enter a valid email address (e.g. john.doe@usmc.mil).
+                    </p>
+                  )}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Why
Four accessibility/consistency gaps in the Classification section:
- Decorative Shield/Info/AlertTriangle icons had no `aria-hidden`, unlike the rest of the codebase.
- The two Classified POC email fields were `type=email` but had no visible validation, `aria-invalid`, or error message.
- The CUI Configuration heading used a generic `text-purple-600` (no dark variant) instead of the official CUI color used by the level/preset swatches.
- The custom-classification preset chips were ~22px tall (`py-0.5`), under the WCAG 2.5.8 24px minimum.

## What
- `aria-hidden="true"` on the decorative icons; a visually-hidden "Warning:"/"Important:" prefix on the advisory banner headings so their intent survives without the icon.
- One `pocEmailInvalid` check (both inputs bind the same field, only one shows at a time) driving `aria-invalid` + an inline `role="alert"` error on a basic email regex.
- A hoisted `CUI_TEXT_COLOR` const (`text-[#502B85] dark:text-[#9572D4]`) on the CUI heading.
- Preset chip `py-0.5` → `py-1`.

The three **advisory-banner visual-unification** findings (border-l-2 vs boxed destructive/10 vs boxed amber-50) are deferred — they need a callout-primitive decision.

## Verification
`tsc -b` + build + eslint + `vitest --coverage` all green. Live, in Custom mode: 7 section icons carry `aria-hidden`; the preset chips measure 26px; typing `notanemail` in the POC field sets `aria-invalid="true"` with a wired `role="alert"` error, and `john.doe@usmc.mil` clears both; no console errors.

Version 1.2.41.