### PR TITLE
fix(editor): keep the @-menu selection in view, flip the floating toolbar, unify shadows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.42] — 2026-07-04
+
+### Fixed
+
+- In the body editor, the @-insert menu now scrolls the highlighted option into
+  view when you arrow past the visible rows or wrap top-to-bottom.
+- The floating bold/italic/underline toolbar no longer clips off the top of the
+  screen when the selected text is near the top — it flips below the selection
+  when there isn't room above.
+
+### Changed
+
+- The @-menu, its "create variable" panel, and the floating toolbar now share
+  one shadow depth instead of three different ones.
+
 ## [1.2.41] — 2026-07-04
 
 ### Accessibility

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.41",
+  "version": "1.2.42",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -272,6 +272,14 @@ interface SuggestionListRef {
 const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
   ({ items, command, query }, ref) => {
     const [selectedIndex, setSelectedIndex] = useState(0);
+    // Keep the keyboard-selected row visible: arrowing past the fold (or wrapping
+    // top↔bottom) would otherwise highlight an off-screen option.
+    const listRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+      listRef.current
+        ?.querySelector('[aria-selected="true"]')
+        ?.scrollIntoView({ block: 'nearest' });
+    }, [selectedIndex]);
     // Reset selection to 0 whenever `items` changes (e.g. user keeps typing
     // and the autocomplete narrows). Done via the React-recommended "store-
     // previous-value-and-compare" pattern during render rather than a
@@ -334,7 +342,7 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
     // If no matches and user typed something, offer to create custom variable
     if (items.length === 0 && query.trim()) {
       return (
-        <div className="bg-popover border border-border rounded-lg shadow-lg overflow-hidden w-[280px]">
+        <div className="bg-popover border border-border rounded-lg shadow-md overflow-hidden w-[280px]">
           <div className="px-3 py-2 border-b border-border bg-muted/50">
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <span className="text-base font-medium text-blue-500">@</span>
@@ -362,7 +370,7 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
 
     if (items.length === 0) {
       return (
-        <div className="bg-popover border border-border rounded-lg shadow-lg overflow-hidden w-[280px]">
+        <div className="bg-popover border border-border rounded-lg shadow-md overflow-hidden w-[280px]">
           <div className="px-3 py-3 text-sm text-muted-foreground text-center">
             Type a variable name...
           </div>
@@ -375,7 +383,7 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
         <div className="px-3 pt-2.5 pb-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
           Insert
         </div>
-        <div className="max-h-[280px] overflow-y-auto px-1 pb-1.5" role="listbox" aria-label="Insert variable">
+        <div ref={listRef} className="max-h-[280px] overflow-y-auto px-1 pb-1.5" role="listbox" aria-label="Insert variable">
           {items.map((item, idx) => {
             const Icon = iconForItem(item);
             const active = idx === selectedIndex;
@@ -664,7 +672,7 @@ export function VariableChipEditor({
 }: VariableChipEditorProps) {
   const [isFocused, setIsFocused] = useState(false);
   // Floating B/I/U toolbar position when text is selected in block mode.
-  const [selBox, setSelBox] = useState<{ top: number; left: number } | null>(null);
+  const [selBox, setSelBox] = useState<{ top: number; bottom: number; left: number } | null>(null);
   const lastValue = useRef(value);
   const currentValue = useRef(value);
 
@@ -855,7 +863,7 @@ export function VariableChipEditor({
         setSelBox(null);
         return;
       }
-      setSelBox({ top: rect.top, left: rect.left + rect.width / 2 });
+      setSelBox({ top: rect.top, bottom: rect.bottom, left: rect.left + rect.width / 2 });
     },
   });
 
@@ -906,13 +914,20 @@ export function VariableChipEditor({
         )}
         {selBox &&
           editor &&
-          createPortal(
+          (() => {
+            // Sit above the selection, but flip below when the selection is near
+            // the top of the viewport so the bar never clips off-screen.
+            const placeAbove = selBox.top >= 48;
+            const style: React.CSSProperties = placeAbove
+              ? { position: 'fixed', top: selBox.top - 8, left: selBox.left, transform: 'translate(-50%, -100%)', zIndex: 60 }
+              : { position: 'fixed', top: selBox.bottom + 8, left: selBox.left, transform: 'translate(-50%, 0)', zIndex: 60 };
+            return createPortal(
             <div
               role="toolbar"
               aria-label="Text formatting"
               onMouseDown={(e) => e.preventDefault()}
-              style={{ position: 'fixed', top: selBox.top - 8, left: selBox.left, transform: 'translate(-50%, -100%)', zIndex: 60 }}
-              className="flex gap-0.5 rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-elevated"
+              style={style}
+              className="flex gap-0.5 rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
             >
               {fmtBtns.map(({ cmd, glyph, cls }) => (
                 <button
@@ -937,7 +952,8 @@ export function VariableChipEditor({
               ))}
             </div>,
             document.body
-          )}
+          );
+          })()}
       </div>
     );
   }


### PR DESCRIPTION
## Why
Three rough edges in the body editor's inline surfaces:
- The @-insert menu wraps on the arrow keys but never scrolled the active row into view — arrowing past the fold highlighted an off-screen option.
- The floating bold/italic/underline toolbar was always positioned 8px above the selection with no boundary check, so a selection near the top of the viewport pushed it off-screen.
- The @-menu, its "create variable" panel, and the floating toolbar each used a different shadow — the transient ~30px toolbar carried the heaviest modal-tier `shadow-elevated`.

## What
- `scrollIntoView({ block: 'nearest' })` on the selected option whenever `selectedIndex` changes.
- The toolbar flips below the selection (`selBox.bottom + 8`, no `-100%` transform) when `selBox.top < 48`; otherwise it stays above. `selBox` now carries `bottom`.
- All three surfaces standardize on `shadow-md`.

(The @-menu open/close animation and the portion-marking chip — the other two items here — need bigger decisions and are deferred.)

## Verification
`tsc -b` + `tsc --noEmit` + build + eslint + `vitest --coverage` all green. Live on a fresh dev server: the block editor mounts with content and **no console errors** (an earlier "Failed to reload" was Vite HMR unable to hot-patch the structural change — the production build and a clean reload are both clean). These are DOM-measurement behaviors that don't reproduce under happy-dom, so they're build-validated + standard patterns.

Version 1.2.42.