### PR TITLE
fix(editor): underline deep paragraph labels to match the printed page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.43] — 2026-07-04
+
+### Fixed
+
+- Deeply-nested body paragraphs (levels 5–8) now show an underlined label in the
+  editor, matching the printed PDF. The label pattern repeats every four levels
+  per SECNAV Ch 7, so without the underline a level-8 "(a)" looked identical to
+  a level-4 "(a)" in the editor even though the exported document distinguished
+  them correctly.
+
 ## [1.2.42] — 2026-07-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.42",
+  "version": "1.2.43",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/BlockParagraphsEditor.tsx
+++ b/src/components/editor/BlockParagraphsEditor.tsx
@@ -204,9 +204,13 @@ const BlockRow = memo(function BlockRow({
         <GripVertical className="h-4 w-4" />
       </button>
 
-      {/* Gutter label — tabular, serif, like the printed page. */}
+      {/* Gutter label — tabular, serif, like the printed page. The label pattern
+          cycles every 4 levels (1./a./(1)/(a)); per SECNAV Ch 7 the deeper
+          levels 4–7 repeat those patterns but underlined, which is exactly what
+          the LaTeX/PDF renders — mirror it here so "(a)" at level 3 and level 7
+          aren't indistinguishable in the editor. */}
       <div className="select-none pt-0.5 pr-2.5 text-right font-serif text-[15px] leading-relaxed text-muted-foreground tnum">
-        {label}
+        <span className={level >= 4 ? 'underline' : undefined}>{label}</span>
       </div>
 
       <div className="min-w-0">


### PR DESCRIPTION
## Why
The body-paragraph label pattern cycles every four levels — `1.` / `a.` / `(1)` / `(a)`. Per SECNAV Ch 7, the deeper subdivision levels (5–8) repeat those same patterns but **underlined**, and the LaTeX/PDF renderer already does exactly that (`\uline{…}` at level ≥ 4). The editor's gutter label, however, rendered the plain cycled pattern with no underline — so a level-8 `(a)` looked identical to a level-4 `(a)` on screen, even though the exported document distinguished them.

## What
Wrap the editor's gutter label in a span that gets `underline` at `level >= 4`, mirroring the LaTeX generator's threshold. The shared `getParagraphLabel`/`calculateLabels` cycling is untouched (and already correct — it's what the PDF uses).

## Verification
`tsc -b` + build + eslint + `vitest --coverage` all green. The existing `paragraphUtils.property.test.ts` already locks in the cycling (incl. `getParagraphLabel(7,1) === '(a)'`). Live: the level-0 label `1.` is not underlined (no regression to the common case); the deep-level underline is the same conditional. DOCX is unaffected — it inherits the correct labels through the LaTeX/pandoc path.

Version 1.2.43.