### PR TITLE
fix(editor): letterhead + addressing field polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.44] — 2026-07-04
+
+### Changed
+
+- The Letterhead section opens with a one-line description like every other
+  section, and the color picker shows a small swatch next to Blue/Black.
+
+### Fixed
+
+- The ZIP field now accepts only digits and the ZIP+4 hyphen (up to 10
+  characters) instead of arbitrary text.
+- The Seal picker has a help tip explaining the DoW vs DoD choice, since the
+  wrong one produces an officially incorrect letterhead.
+
+### Accessibility
+
+- Required-field markers are now consistent across the addressing and signature
+  fields, the Via routing drag handle has a proper label and keyboard focus
+  ring, and the salutation field only shows its error once you've tried to
+  export, matching every other field.
+
 ## [1.2.43] — 2026-07-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.43",
+  "version": "1.2.44",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/AddressingSection.tsx
+++ b/src/components/editor/AddressingSection.tsx
@@ -23,6 +23,7 @@ import { HelpTip } from '@/components/ui/help-tip';
 import { useDocumentStore } from '@/stores/documentStore';
 import { useUIStore } from '@/stores/uiStore';
 import { unfilled } from '@/lib/requiredField';
+import { RequiredMark } from '@/components/ui/required-mark';
 import { SSICLookupModal } from '@/components/modals/SSICLookupModal';
 import { UnitLookupModal } from '@/components/modals/UnitLookupModal';
 import { expandUnitName, insertUnitInto, type UnitInfo } from '@/data/unitDirectory';
@@ -66,8 +67,10 @@ function SortableViaItem({ id, index, value, onChange, onRemove, onLookup, canRe
       <button
         {...attributes}
         {...listeners}
-        className="cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground"
         type="button"
+        aria-label={`Drag to reorder via routing ${index + 1}`}
+        title="Drag to reorder"
+        className="cursor-grab rounded-sm text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 active:cursor-grabbing"
       >
         <GripVertical className="h-4 w-4" />
       </button>
@@ -247,7 +250,7 @@ export function AddressingSection({ config }: AddressingSectionProps) {
                       {!config.ssic && <span className="text-xs font-normal text-muted-foreground ml-1">(N/A)</span>}
                       {config.ssic && isSSICOptional && <span className="text-xs font-normal text-muted-foreground ml-1">(optional)</span>}
                     </Label>
-                    <div className="flex gap-1">
+                    <div className="flex gap-2">
                       <Input
                         id="ssic"
                         value={formData.ssic || ''}
@@ -321,9 +324,9 @@ export function AddressingSection({ config }: AddressingSectionProps) {
             {docType === 'mf' && (
               <div className="space-y-2">
                 <Label htmlFor="to">
-                  Memorandum For <span className="text-destructive">*</span>
+                  Memorandum For <RequiredMark />
                 </Label>
-                <div className="flex gap-1">
+                <div className="flex gap-2">
                   <div className="flex-1">
                     <InputWithVariables
                       id="to"
@@ -388,7 +391,7 @@ export function AddressingSection({ config }: AddressingSectionProps) {
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="to">To</Label>
-                  <div className="flex gap-1">
+                  <div className="flex gap-2">
                     <div className="flex-1">
                       <InputWithVariables
                         id="to"
@@ -466,19 +469,17 @@ export function AddressingSection({ config }: AddressingSectionProps) {
             {/* Salutation - Required for business letters in compliant mode */}
             {requiresSalutation && (
               <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <Label htmlFor="salutation">Salutation</Label>
-                  <span className="text-xs text-destructive">* Required</span>
-                </div>
+                <Label htmlFor="salutation">Salutation<RequiredMark /></Label>
                 <Input
                   id="salutation"
                   value={formData.salutation || ''}
                   onChange={(e) => setField('salutation', e.target.value)}
                   placeholder="Dear Sir or Madam:"
-                  className={!formData.salutation?.trim() ? 'border-destructive' : ''}
+                  aria-invalid={validationVisible && unfilled(formData.salutation) ? true : undefined}
+                  aria-describedby={validationVisible && unfilled(formData.salutation) ? 'salutation-error' : undefined}
                 />
-                {!formData.salutation?.trim() && (
-                  <p className="text-xs text-destructive flex items-center gap-1">
+                {validationVisible && unfilled(formData.salutation) && (
+                  <p id="salutation-error" role="alert" className="text-xs text-destructive flex items-center gap-1">
                     <AlertCircle className="h-3 w-3" />
                     Per SECNAV M-5216.5 Ch 11: Business letters require a salutation
                   </p>

--- a/src/components/editor/LetterheadSection.tsx
+++ b/src/components/editor/LetterheadSection.tsx
@@ -120,6 +120,9 @@ export function LetterheadSection() {
           </AccordionTrigger>
           <AccordionContent>
             <div className={`space-y-4 pt-2 ${isDisabled ? 'opacity-50 pointer-events-none select-none' : ''}`}>
+              <p className="-mt-1 text-xs text-muted-foreground">
+                Unit name, address, seal, and color that appear at the top of the page.
+              </p>
               {/* Responsive row: the editor column width is independent of the
                   viewport (collapsible sidebar + resizable preview), so flex-wrap
                   lets it wrap rather than overflow at a narrow column. */}
@@ -128,7 +131,17 @@ export function LetterheadSection() {
                     break and min-w-0 lets the cells shrink rather than overflow. */}
                 <div className="grid grid-cols-2 gap-3 min-w-0 sm:basis-52 sm:grow-0 sm:shrink">
                   <div className="space-y-2 min-w-0">
-                    <Label>Seal</Label>
+                    <Label className="flex items-center gap-1.5">
+                      Seal
+                      <HelpTip>
+                        <p className="text-xs">
+                          Which seal prints on the letterhead. <strong>DoW</strong> is the
+                          Department of War seal (the current default); <strong>DoD</strong>
+                          {' '}is the older Department of Defense seal. Picking the wrong one
+                          produces an officially incorrect document.
+                        </p>
+                      </HelpTip>
+                    </Label>
                     <Select
                       value={formData.sealType || 'dow'}
                       onValueChange={(v) => setField('sealType', v)}
@@ -153,8 +166,18 @@ export function LetterheadSection() {
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="blue">Blue</SelectItem>
-                        <SelectItem value="black">Black</SelectItem>
+                        <SelectItem value="blue">
+                          <span className="flex items-center gap-2">
+                            <span className="h-3 w-3 shrink-0 rounded-full border border-border bg-brand-accent" aria-hidden="true" />
+                            Blue
+                          </span>
+                        </SelectItem>
+                        <SelectItem value="black">
+                          <span className="flex items-center gap-2">
+                            <span className="h-3 w-3 shrink-0 rounded-full border border-border bg-black" aria-hidden="true" />
+                            Black
+                          </span>
+                        </SelectItem>
                       </SelectContent>
                     </Select>
                   </div>
@@ -310,8 +333,12 @@ export function LetterheadSection() {
                     <Input
                       id="addressZip"
                       value={addressParts.zip}
-                      onChange={(e) => updateAddressPart('zip', e.target.value)}
+                      // Keep only digits and the ZIP+4 hyphen, capped at 10 chars
+                      // ("#####-####"); `pattern` alone never fires without a
+                      // native submit, which this form doesn't do.
+                      onChange={(e) => updateAddressPart('zip', e.target.value.replace(/[^0-9-]/g, '').slice(0, 10))}
                       placeholder="28533-0050"
+                      maxLength={10}
                       inputMode="numeric"
                       pattern="[0-9-]*"
                     />

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -16,6 +16,7 @@ import { unfilled } from '@/lib/requiredField';
 import { FILE_LIMITS } from '@/lib/constants';
 import { showAppAlert } from '@/stores/alertStore';
 import { isImageFile, rejectedFilesMessage } from '@/lib/fileFilter';
+import { RequiredMark } from '@/components/ui/required-mark';
 import type { DocTypeConfig, SignatureImage, SignatureType } from '@/types/document';
 import { ALL_SERVICE_RANKS, formatRank } from '@/data/ranks';
 import { getOfficeCode, OFFICE_CODES } from '@/data/officeCodes';
@@ -197,10 +198,7 @@ export function SignatureSection({ config }: SignatureSectionProps) {
             {/* Complimentary Close - Required for business letters in compliant mode */}
             {requiresComplimentaryClose && (
               <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <Label htmlFor="complimentaryClose">Complimentary Close</Label>
-                  <span className="text-xs text-destructive">* Required</span>
-                </div>
+                <Label htmlFor="complimentaryClose">Complimentary Close<RequiredMark /></Label>
                 <Input
                   id="complimentaryClose"
                   value={formData.complimentaryClose || ''}

--- a/src/components/ui/required-mark.tsx
+++ b/src/components/ui/required-mark.tsx
@@ -1,0 +1,13 @@
+/**
+ * The red asterisk that marks a required field. One shared marker so every form
+ * uses the same convention (a bare " *") instead of a mix of "*" and
+ * "* Required". The required state is also conveyed to assistive tech by the
+ * field's own aria-invalid / required attributes; this glyph is the visual cue.
+ */
+export function RequiredMark() {
+  return (
+    <span className="text-destructive" aria-hidden="true">
+      {' '}*
+    </span>
+  );
+}


### PR DESCRIPTION
## Why
Eight small field-level inconsistencies across the Letterhead and Addressing sections.

**Letterhead:** no intro line (jumps straight into the seal row); the ZIP input accepted arbitrary non-digit text (the `pattern` attr never fires without a native submit); the color picker was text-only with no swatch; and the Seal `DoD`/`DoW` acronyms had no hint despite a wrong pick producing an officially incorrect document.

**Addressing:** required markers were a mix of `*` and `* Required`; the Via drag handle had no accessible name, tooltip, or focus ring; three field-to-lookup rows sat at 4px off the section's 8px grid; and the salutation error used an always-on `border-destructive` that flagged the instant the section opened, unlike every sibling gated behind `validationVisible`.

## What
- Muted intro `<p>`; ZIP `maxLength={10}` + `replace(/[^0-9-]/g,'').slice(0,10)`; color swatch inside each `SelectItem` (Radix mirrors it into the trigger); `HelpTip` on the Seal label.
- New shared `RequiredMark` used in Addressing + Signature; Via handle gets `aria-label`/`title`/focus ring; the three `gap-1` rows → `gap-2`; salutation gated on `validationVisible && unfilled(...)` with `aria-invalid` + `role="alert"`.

## Verification
`tsc -b` + build + eslint + `vitest --coverage` all green. Live (Letterhead): the intro renders; typing `abc12345678xyz` in ZIP yields `12345678` (`maxLength` 10); the color trigger shows a swatch; the Seal label carries a HelpTip. `RequiredMark` is a trivial presentational component (no test needed per the repo's testing rule). No console errors.

Version 1.2.44.