### PR TITLE
fix(ui): modal chrome consistency across dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.45] — 2026-07-05
+
+### Changed
+
+- Modal chrome is more consistent: dialogs and confirmation dialogs now open and
+  close at the same speed, the Update and Profile close buttons match the
+  standard one, the Share "copy link" button shows a copy icon (not a key), and
+  the About dialog scrolls within a capped height so its footer can't clip on
+  short screens.
+
+### Accessibility
+
+- The Find & Replace, Unit Directory, and Office Code dialogs now carry a
+  description for screen readers (and no longer trip a console warning).
+
 ## [1.2.44] — 2026-07-04
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.44",
+  "version": "1.2.45",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/modals/AboutModal.tsx
+++ b/src/components/modals/AboutModal.tsx
@@ -4,6 +4,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Shield, Zap, FileText, Lock, Plane, ExternalLink } from 'lucide-react';
@@ -20,7 +21,7 @@ export function AboutModal() {
 
   return (
     <Dialog open={aboutModalOpen} onOpenChange={setAboutModalOpen}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-lg max-h-[85vh]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-3">
             <FileText className="h-6 w-6 text-primary" />
@@ -31,6 +32,7 @@ export function AboutModal() {
           </DialogTitle>
         </DialogHeader>
 
+        <ScrollArea className="max-h-[70vh] pr-4">
         <div className="space-y-5">
           <p className="text-muted-foreground italic border-l-2 border-primary pl-3">
             Professional document generation for Marines, by Marines.
@@ -111,6 +113,7 @@ export function AboutModal() {
             </div>
           </div>
         </div>
+        </ScrollArea>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/modals/FindReplaceModal.tsx
+++ b/src/components/modals/FindReplaceModal.tsx
@@ -3,6 +3,7 @@ import { Search, Replace, ChevronDown, ChevronUp } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
@@ -195,6 +196,9 @@ export function FindReplaceModal() {
             <Search className="h-5 w-5" />
             Find & Replace
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Search the document body for text and optionally replace matches.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">

--- a/src/components/modals/OfficeCodeLookupModal.tsx
+++ b/src/components/modals/OfficeCodeLookupModal.tsx
@@ -3,6 +3,7 @@ import { Search, X, Briefcase } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
@@ -59,6 +60,9 @@ export function OfficeCodeLookupModal({ open, onOpenChange, onSelect }: OfficeCo
             <Briefcase className="h-5 w-5" />
             Office Code Reference
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Look up a standard office code and insert it into the signature block.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="relative">

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -350,8 +350,8 @@ export function ProfileModal() {
               </DialogTitle>
               <Button
                 variant="ghost"
-                size="icon"
-                className="h-7 w-7 rounded-sm opacity-70 hover:opacity-100"
+                size="icon-sm"
+                className="rounded-md text-muted-foreground opacity-70 hover:bg-muted hover:opacity-100"
                 onClick={handleClose}
               >
                 <X className="h-4 w-4" />

--- a/src/components/modals/ShareModal.tsx
+++ b/src/components/modals/ShareModal.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState, useCallback } from 'react';
-import { Link2, KeyRound, Check, Loader2, ShieldAlert, AlertTriangle } from 'lucide-react';
+import { Link2, Copy, Check, Loader2, ShieldAlert, AlertTriangle } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -239,7 +239,7 @@ export function ShareModal({
                   {copied ? (
                     <Check className="h-4 w-4 text-success" />
                   ) : (
-                    <KeyRound className="h-4 w-4" />
+                    <Copy className="h-4 w-4" />
                   )}
                 </Button>
               </div>

--- a/src/components/modals/UnitLookupModal.tsx
+++ b/src/components/modals/UnitLookupModal.tsx
@@ -3,6 +3,7 @@ import { Search, X, Building2, MapPin, Loader2 } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
@@ -114,6 +115,9 @@ export function UnitLookupModal({ open, onOpenChange, onSelect }: UnitLookupModa
               </Badge>
             )}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Search the unit directory and insert a unit&apos;s name and address.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="relative">

--- a/src/components/modals/UpdatePromptModal.tsx
+++ b/src/components/modals/UpdatePromptModal.tsx
@@ -5,7 +5,7 @@
  * Allows them to update now or later, preserving their work.
  */
 
-import { RefreshCw, Clock, X } from 'lucide-react';
+import { RefreshCw, Clock } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -25,21 +25,14 @@ interface UpdatePromptModalProps {
 
 export function UpdatePromptModal({ open, onConfirm, onDismiss }: UpdatePromptModalProps) {
   return (
-    <Dialog open={open}>
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onDismiss(); }}>
       <DialogContent
         className="sm:max-w-md w-[calc(100vw-2rem)] overflow-hidden"
+        // Escape / outside stay disabled so dismissal is an explicit choice; the
+        // shared corner × routes through onOpenChange above.
         onInteractOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
-        showCloseButton={false}
       >
-        {/* Custom close button that calls onDismiss */}
-        <button
-          onClick={onDismiss}
-          className="absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-        >
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </button>
         <div className="flex flex-col gap-4 overflow-hidden">
           <DialogHeader className="min-w-0">
             <DialogTitle className="flex items-center gap-2 min-w-0">

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -60,7 +60,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-primary/10 p-6 shadow-elevated duration-300 outline-none sm:max-w-lg",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-primary/10 p-6 shadow-elevated duration-200 outline-none sm:max-w-lg",
           className
         )}
         {...props}


### PR DESCRIPTION
## Why
A batch of modal inconsistencies (Primary + Utility modal findings):
- Dialog (`duration-300`) and AlertDialog (`duration-200`) animated at different speeds — visible when a Profile confirm opens over the Profile dialog.
- UpdatePromptModal and ProfileModal hand-rolled close buttons that diverged from the shared one (wrong size, radius, hover, focus ring, `focus:` vs `focus-visible:`).
- FindReplace, UnitLookup, and OfficeCodeLookup shipped no `DialogDescription`, so Radix warned and SRs got no `aria-describedby`.
- AboutModal had no `max-h`/scroll container — its footer clipped on short screens.
- ShareModal's re-copy button showed a `KeyRound` glyph at rest instead of `Copy`.

## What
- `dialog.tsx` `duration-300` → `duration-200` (matches AlertDialog).
- UpdatePromptModal: wire `onOpenChange` → `onDismiss` and reuse the shared close (escape/outside stay prevented); drop the custom button.
- ProfileModal close → `size=icon-sm rounded-md hover:bg-muted`.
- `DialogDescription className="sr-only"` on the three modals.
- AboutModal: `max-h-[85vh]` + body wrapped in `ScrollArea` (NIST pattern), so the close button stays pinned while the body scrolls.
- ShareModal: `KeyRound` → `Copy`.

The ReferenceLibraryPicker "Add" hover-only finding was already resolved by an earlier PR. Deferred: the ProfileModal segmented control and the PIIWarningModal download-friction (both behavior changes needing a decision).

## Verification
`tsc -b` + build + eslint + `vitest --coverage` all green. Live: opening Find & Replace now sets `aria-describedby` → the sr-only description, and the console shows **no** Radix "Missing Description" warning (only unrelated pre-existing tiptap warnings). Remaining changes are deterministic class/attr swaps.

Version 1.2.45.