### PR TITLE
fix(a11y): route warning surfaces through the theme token and fix its AA contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.47] — 2026-07-05
+
+### Accessibility
+
+- Caution/warning surfaces now draw from the theme's warning color instead of a
+  hard-coded amber, so they track light/dark and every color scheme and stay
+  legible. The warning color was also darkened slightly in light mode so warning
+  text clears the WCAG AA 4.5:1 contrast ratio on its own tinted background
+  (previously ~4.06:1) — this also sharpens the storage and backup banners.
+
+### Changed
+
+- The PII/PHI and encryption notices in Share, the reference/enclosure
+  "not applicable to this document type" notices, the batch "some failed"
+  summary, the browser-compatibility notice, the status-message helper, and the
+  "Clear fields" confirm button all route through the semantic warning/success
+  tokens now.
+
 ## [1.2.46] — 2026-07-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.46",
+  "version": "1.2.47",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/BrowserCompatibilityNotice.tsx
+++ b/src/components/BrowserCompatibilityNotice.tsx
@@ -171,8 +171,8 @@ export function BrowserCompatibilityNotice() {
         {/* Header */}
         <div className="flex items-start justify-between p-4 border-b border-border">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-amber-500/10 rounded-full">
-              <AlertTriangle className="h-6 w-6 text-amber-500" />
+            <div className="p-2 bg-warning/10 rounded-full">
+              <AlertTriangle className="h-6 w-6 text-warning" />
             </div>
             <div>
               <h2 className="font-semibold text-lg">Limited Browser Support</h2>

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -321,9 +321,9 @@ export function EnclosuresManager() {
           <div className="pt-2">
             {/* Compliance restriction notice */}
             {enclosuresNotAllowed && (
-              <div className="flex items-start gap-2 p-3 mb-3 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg text-sm">
-                <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
-                <div className="text-amber-800 dark:text-amber-200">
+              <div className="flex items-start gap-2 p-3 mb-3 bg-warning/10 border border-warning/30 rounded-lg text-sm">
+                <AlertTriangle className="h-4 w-4 text-warning mt-0.5 flex-shrink-0" />
+                <div className="text-warning">
                   <span className="font-medium">Per {config.regulations.ref}:</span>{' '}
                   This document type does not include formal enclosure listings. Enclosures should be mentioned within the body text instead.
                   {enclosures.length > 0 && (

--- a/src/components/editor/ReferencesManager.tsx
+++ b/src/components/editor/ReferencesManager.tsx
@@ -209,9 +209,9 @@ export function ReferencesManager() {
           <div className="pt-2">
             {/* Compliance restriction notice */}
             {referencesNotAllowed && (
-              <div className="flex items-start gap-2 p-3 mb-3 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg text-sm">
-                <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
-                <div className="text-amber-800 dark:text-amber-200">
+              <div className="flex items-start gap-2 p-3 mb-3 bg-warning/10 border border-warning/30 rounded-lg text-sm">
+                <AlertTriangle className="h-4 w-4 text-warning mt-0.5 flex-shrink-0" />
+                <div className="text-warning">
                   <span className="font-medium">Per {config.regulations.ref}:</span>{' '}
                   This document type does not include formal reference lines. References should be mentioned within the body text instead.
                   {references.length > 0 && (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1270,7 +1270,7 @@ export function Header({
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleClearFields} className="bg-orange-600 text-white hover:bg-orange-700">
+            <AlertDialogAction onClick={handleClearFields} className="bg-warning text-warning-foreground hover:bg-warning/90">
               Clear fields
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -1099,12 +1099,12 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
 
                     {/* Results Summary */}
                     {lastResults && (
-                      <div className={`p-4 rounded-lg border shadow-sm transition-colors duration-300 ${lastResults.failed > 0 ? 'border-amber-500/30 bg-amber-500/10' : 'border-success/30 bg-success/10'}`}>
+                      <div className={`p-4 rounded-lg border shadow-sm transition-colors duration-300 ${lastResults.failed > 0 ? 'border-warning/30 bg-warning/10' : 'border-success/30 bg-success/10'}`}>
                         <div className="flex items-center gap-2 mb-2">
                           {lastResults.failed === 0 ? (
                             <CheckCircle className="h-5 w-5 text-success" />
                           ) : (
-                            <AlertCircle className="h-5 w-5 text-amber-500" />
+                            <AlertCircle className="h-5 w-5 text-warning" />
                           )}
                           <span className="font-medium">
                             Generation Complete: {lastResults.succeeded}/{lastResults.total} succeeded

--- a/src/components/modals/ShareModal.tsx
+++ b/src/components/modals/ShareModal.tsx
@@ -162,14 +162,14 @@ export function ShareModal({
         </DialogHeader>
 
         <div
-          className="flex gap-3 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-sm text-amber-800 dark:border-amber-400/30 dark:bg-amber-500/10 dark:text-amber-200"
+          className="flex gap-3 rounded-md border border-warning/40 bg-warning/10 px-3 py-2.5 text-sm text-warning"
           role="status"
           aria-live="polite"
         >
-          <ShieldAlert className="h-5 w-5 flex-shrink-0 mt-0.5 text-amber-600 dark:text-amber-400" />
+          <ShieldAlert className="h-5 w-5 flex-shrink-0 mt-0.5 text-warning" />
           <div>
             <p className="font-medium mb-0.5">How encryption works</p>
-            <p className="text-muted-foreground dark:text-amber-200/90">
+            <p className="text-muted-foreground">
               Encryption is done in your browser only. Your password is never sent to any server.
               The link contains data encrypted with AES-GCM using a key derived from your password (PBKDF2).
               Share the link and the password separately; anyone with both can decrypt and open the document.
@@ -253,12 +253,12 @@ export function ShareModal({
           )}
 
           {!isImport && piiFindings && (
-            <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm dark:border-amber-800 dark:bg-amber-950/30" role="alert">
+            <div className="rounded-md border border-warning/40 bg-warning/10 p-3 text-sm" role="alert">
               <div className="flex items-start gap-2">
-                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
                 <div className="min-w-0">
-                  <p className="font-medium text-amber-800 dark:text-amber-300">This document may contain PII/PHI</p>
-                  <p className="mt-0.5 text-amber-700 dark:text-amber-400/90">
+                  <p className="font-medium text-warning">This document may contain PII/PHI</p>
+                  <p className="mt-0.5 text-warning">
                     Found {piiFindings.findings.length} potential item{piiFindings.findings.length === 1 ? '' : 's'} (
                     {[...new Set(piiFindings.findings.map((f) => getPIITypeLabel(f.type)))].join(', ')}). The link is
                     password-encrypted, but it still leaves your device — share it only if you mean to.

--- a/src/hooks/useStatusMessage.ts
+++ b/src/hooks/useStatusMessage.ts
@@ -113,11 +113,11 @@ export function getMessageClasses(type: MessageType): string {
 
   switch (type) {
     case 'success':
-      return `${baseClasses} text-green-600 bg-green-100 dark:text-green-400 dark:bg-green-900/30`;
+      return `${baseClasses} text-success bg-success/10`;
     case 'error':
-      return `${baseClasses} text-red-600 bg-red-100 dark:text-red-400 dark:bg-red-900/30`;
+      return `${baseClasses} text-destructive bg-destructive/10`;
     case 'warning':
-      return `${baseClasses} text-amber-600 bg-amber-100 dark:text-amber-400 dark:bg-amber-900/30`;
+      return `${baseClasses} text-warning bg-warning/10`;
     case 'info':
     default:
       return `${baseClasses} text-blue-600 bg-blue-100 dark:text-blue-400 dark:bg-blue-900/30`;

--- a/src/index.css
+++ b/src/index.css
@@ -201,7 +201,7 @@
   --destructive-foreground: oklch(0.99 0 0); /* label on a destructive fill */
   --success: oklch(0.63 0.17 149);         /* ~green-600 — status/compliance tint */
   --success-foreground: oklch(0.99 0 0);
-  --warning: oklch(0.55 0.13 65);          /* ~amber-700 — ≥4.5:1 as text on the light canvas */
+  --warning: oklch(0.50 0.13 65);          /* ~amber-800 — ≥4.5:1 as text on both the light canvas and its own 10% tint */
   --warning-foreground: oklch(0.99 0 0);
   --border: oklch(0.88 0.02 250);          /* Navy-tinted border */
   --input: oklch(0.95 0.01 250);
@@ -477,7 +477,7 @@
     --destructive-foreground: #ffffff;
     --success: #15803d;
     --success-foreground: #ffffff;
-    --warning: #b45309;
+    --warning: #92400e;
     --warning-foreground: #ffffff;
     --border: #ced9e5;
     --input: #eaeff5;


### PR DESCRIPTION
## Why
Two related problems on caution/warning UI:
1. Several surfaces still hard-coded raw `amber-*`/`orange-*`/`green-*` instead of the semantic tokens, so they didn't track the color schemes and re-introduced palette drift.
2. More importantly — measuring live, `text-warning` on `bg-warning/10` in the **light** scheme was **~4.06:1**, under WCAG AA (4.5:1). The `--warning` token was tuned to clear 4.5:1 on the *plain canvas* (4.62) but not on its own 10% tint. The already-shipped storage/backup banners use exactly this pair, so they were affected too.

## What
- **Token fix (`index.css`)**: light `--warning` `oklch(0.55)` → `oklch(0.50)` (sRGB fallback `#b45309` amber-700 → `#92400e` amber-800). Dark scheme unchanged (already 9.67:1 on tint).
- **Repoint to tokens**: ShareModal PII/PHI + "how encryption works" notices, References/Enclosures "not applicable to this document type" notices, BatchModal's some-failed summary (which already used `bg-success/10` for the success case — now symmetric), BrowserCompatibilityNotice, `useStatusMessage` (success→success, warning→warning, error→destructive), and the "Clear fields" confirm (`bg-warning text-warning-foreground`).

## Verification (measured live via canvas rasterization of the resolved oklch tokens)
| scheme | text on canvas | text on `bg-warning/10` tint | `warning-foreground` on solid fill |
|---|---|---|---|
| light | 5.67 | **4.91** ✅ (was 4.06 ❌) | 6.01 |
| dark  | 11.44 | 9.67 | 10.23 |

All ≥ 4.5:1. `tsc -b` + build + eslint + `check-no-cdn` green; **1586/1586** tests pass.

**Deliberately not touched** (domain colors, not warnings): classification markings, the USCG service tint, category swatches, doc-type accents, and the lightbulb *tip* callouts (a different semantic with no dedicated token).

Version 1.2.47.