### PR TITLE
feat(a11y): themed IconTip tooltip for the addressing lookup buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.48] — 2026-07-05
+
+### Accessibility
+
+- The "look up a unit" and "browse SSIC codes" buttons in the addressing section
+  now use a proper themed tooltip that appears on keyboard focus and carries a
+  real accessible name, instead of a native browser tooltip that keyboard and
+  touch users never saw.
+
 ## [1.2.47] — 2026-07-05
 
 ### Accessibility

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.47",
+  "version": "1.2.48",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/AddressingSection.tsx
+++ b/src/components/editor/AddressingSection.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/accordion';
 import { InputWithVariables } from '@/components/ui/variable-autocomplete';
 import { HelpTip } from '@/components/ui/help-tip';
+import { IconTip } from '@/components/ui/icon-tip';
 import { useDocumentStore } from '@/stores/documentStore';
 import { useUIStore } from '@/stores/uiStore';
 import { unfilled } from '@/lib/requiredField';
@@ -83,16 +84,17 @@ function SortableViaItem({ id, index, value, onChange, onRemove, onLookup, canRe
         placeholder="Commanding Officer, 6th Marine Regiment"
         className="flex-1"
       />
-      <Button
-        type="button"
-        variant="outline"
-        size="icon"
-        onClick={onLookup}
-        title="Look up a unit"
-        className="shrink-0"
-      >
-        <Building2 className="h-4 w-4" />
-      </Button>
+      <IconTip label="Look up a unit">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          onClick={onLookup}
+          className="shrink-0"
+        >
+          <Building2 className="h-4 w-4" />
+        </Button>
+      </IconTip>
       <Button
         type="button"
         variant="ghost"
@@ -258,15 +260,16 @@ export function AddressingSection({ config }: AddressingSectionProps) {
                         placeholder="5216"
                         className="flex-1"
                       />
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon"
-                        onClick={() => setSSICModalOpen(true)}
-                        title="Browse SSIC Codes"
-                      >
-                        <BookOpen className="h-4 w-4" />
-                      </Button>
+                      <IconTip label="Browse SSIC codes">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          onClick={() => setSSICModalOpen(true)}
+                        >
+                          <BookOpen className="h-4 w-4" />
+                        </Button>
+                      </IconTip>
                     </div>
                   </div>
                 <div className={`space-y-2 ${!config.ssic ? 'opacity-50 pointer-events-none select-none' : ''}`}>
@@ -336,16 +339,17 @@ export function AddressingSection({ config }: AddressingSectionProps) {
                       placeholder="Distribution List, or the receiving office/official"
                     />
                   </div>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={() => setUnitLookup('to')}
-                    title="Look up a unit"
-                    className="shrink-0"
-                  >
-                    <Building2 className="h-4 w-4" />
-                  </Button>
+                  <IconTip label="Look up a unit">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      onClick={() => setUnitLookup('to')}
+                      className="shrink-0"
+                    >
+                      <Building2 className="h-4 w-4" />
+                    </Button>
+                  </IconTip>
                 </div>
                 <p className="text-xs text-muted-foreground">
                   Completes the title line: MEMORANDUM FOR [addressee] (SECNAV M-5216.5 Ch 10).
@@ -401,16 +405,17 @@ export function AddressingSection({ config }: AddressingSectionProps) {
                         placeholder="Commanding General... (type @ for variables)"
                       />
                     </div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      onClick={() => setUnitLookup('to')}
-                      title="Look up a unit"
-                      className="shrink-0"
-                    >
-                      <Building2 className="h-4 w-4" />
-                    </Button>
+                    <IconTip label="Look up a unit">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={() => setUnitLookup('to')}
+                        className="shrink-0"
+                      >
+                        <Building2 className="h-4 w-4" />
+                      </Button>
+                    </IconTip>
                   </div>
                 </div>
               </div>

--- a/src/components/ui/icon-tip.tsx
+++ b/src/components/ui/icon-tip.tsx
@@ -1,0 +1,42 @@
+import { cloneElement, isValidElement, type ReactElement } from 'react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+type TriggerProps = { 'aria-label'?: string; 'aria-labelledby'?: string };
+
+/**
+ * A themed tooltip for a single interactive control (usually an icon-only
+ * button). Use this instead of the native `title=` attribute: `title` tooltips
+ * are un-themed, ~500ms-delayed, and — critically — invisible to keyboard focus
+ * and touch, so the hint never reaches those users.
+ *
+ * Radix's Tooltip only wires `aria-describedby` (a *description*); an icon-only
+ * trigger still needs an accessible *name*. So we inject `aria-label` from the
+ * same `label` unless the caller already set a name, letting one prop cover the
+ * visible tooltip, the description, and the name.
+ *
+ * Relies on the single app-root <TooltipProvider> for delay/skip coordination —
+ * do not nest a Provider here.
+ */
+export function IconTip({
+  label,
+  side,
+  children,
+}: {
+  label: string;
+  side?: 'top' | 'right' | 'bottom' | 'left';
+  children: ReactElement<TriggerProps>;
+}) {
+  const trigger =
+    isValidElement(children) &&
+    !children.props['aria-label'] &&
+    !children.props['aria-labelledby']
+      ? cloneElement(children, { 'aria-label': label })
+      : children;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+      <TooltipContent side={side}>{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/tests/component/IconTip.test.tsx
+++ b/tests/component/IconTip.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Component tests for <IconTip>.
+ *
+ * IconTip replaces native `title=` on icon-only controls with a themed Radix
+ * tooltip. The subtle-but-important part: Radix only wires `aria-describedby`
+ * (a description), so an icon-only trigger would have NO accessible *name* once
+ * `title` is removed. IconTip injects `aria-label` from the same `label` unless
+ * the caller already provided a name — that injection is what these lock in.
+ */
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import type { ReactElement } from 'react';
+import { render, screen } from '@testing-library/react';
+import { IconTip } from '@/components/ui/icon-tip';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+// IconTip relies on the single app-root <TooltipProvider> (App.tsx) rather than
+// nesting its own, so tests supply one.
+function renderTip(ui: ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+describe('IconTip — accessible name injection', () => {
+  it('gives an unlabelled icon button its accessible name from the label', () => {
+    renderTip(
+      <IconTip label="Look up a unit">
+        <button type="button">
+          <svg aria-hidden="true" />
+        </button>
+      </IconTip>
+    );
+    const btn = screen.getByRole('button', { name: 'Look up a unit' });
+    expect(btn.getAttribute('aria-label')).toBe('Look up a unit');
+  });
+
+  it('does not override a caller-supplied accessible name', () => {
+    renderTip(
+      <IconTip label="Browse SSIC codes">
+        <button type="button" aria-label="Custom name">
+          <svg aria-hidden="true" />
+        </button>
+      </IconTip>
+    );
+    // The explicit name wins; the tooltip label does not clobber it.
+    expect(screen.getByRole('button', { name: 'Custom name' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Browse SSIC codes' })).toBeNull();
+  });
+
+  it('renders the child element as the tooltip trigger', () => {
+    renderTip(
+      <IconTip label="Search office codes">
+        <button type="button" data-testid="trigger" />
+      </IconTip>
+    );
+    const btn = screen.getByTestId('trigger');
+    expect(btn.tagName).toBe('BUTTON');
+    // asChild keeps the caller's element as the single trigger — no extra button wrapper.
+    expect(screen.getAllByRole('button').length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Why
Icon-only controls used the native `title=` attribute for their hints. Native `title` tooltips are un-themed, ~500ms-delayed, and — the real problem — **invisible to keyboard focus and touch**, so the hint never reaches those users. The addressing section's unit-lookup and SSIC-browse buttons also had **no accessible name at all** except that flaky `title`.

## What
- New shared **`IconTip`** (`src/components/ui/icon-tip.tsx`) — promotes the pattern Header already used locally (`HeaderTip`) into a reusable component: `<IconTip label="…"><Button/></IconTip>`.
- Correctness detail: Radix Tooltip only wires `aria-describedby` (a *description*), so an icon-only trigger would lose its accessible *name* when `title` is removed. `IconTip` injects `aria-label` from the same `label` **unless the caller already set a name**, so one prop covers the visible tooltip, the description, and the name. Relies on the single app-root `<TooltipProvider>` (no nested provider).
- Adopted for AddressingSection's four lookup buttons (letterhead unit lookup, "to" unit lookup ×2, SSIC browse); casing normalized to sentence case (`Browse SSIC codes`).

This is the **first** of the icon-button sections to move onto `IconTip`; the block-editor toolbar, ProfileBar, signature/office-code, and the form sections' SSIC buttons follow in separate PRs (ProfileBar and the drag handles need care around dropdown-trigger / drag-listener `asChild` nesting).

## Verification
- Live: the converted buttons now expose `aria-label` ("Look up a unit" / "Browse SSIC codes") with **no** `title` attribute; zero leftover raw-`title` lookup buttons. Tooltip rendering is unchanged Radix structure identical to the production `HeaderTip` (synthetic pointer/focus events don't drive Radix tooltips, so hover/focus rendering is verified by structural equivalence, not simulation).
- New `IconTip` component tests lock in the name-injection logic (injects when unlabelled, preserves a caller-supplied name, keeps a single trigger).
- `tsc -b` + build + eslint + `check-no-cdn` green; **1589/1589** tests pass.

Version 1.2.48.