### PR TITLE
feat(a11y): adopt IconTip for the remaining lookup buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.49] — 2026-07-05
+
+### Accessibility
+
+- The remaining lookup buttons — browse SSIC codes (joint / MOA letters, the
+  6105 counseling form, and command profiles), browse the unit directory and
+  reference library on the 6105 form, and search/clear the signature office code
+  — now use the themed tooltip that appears on keyboard focus and carries a real
+  accessible name, matching the addressing section. Their labels were also
+  normalized to sentence case.
+
 ## [1.2.48] — 2026-07-05
 
 ### Accessibility

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.48",
+  "version": "1.2.49",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -4,6 +4,7 @@ import { BookOpen, Building2, Library } from 'lucide-react';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { IconTip } from '@/components/ui/icon-tip';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
   DropdownMenu,
@@ -150,14 +151,15 @@ export function Form6105Section() {
                     onChange={(e) => setNavmc10274Field('ssicFileNo', e.target.value)}
                     placeholder="e.g., 1610"
                   />
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    onClick={() => setSSICModalOpen(true)}
-                    title="Browse SSIC Codes"
-                  >
-                    <BookOpen className="h-4 w-4" />
-                  </Button>
+                  <IconTip label="Browse SSIC codes">
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={() => setSSICModalOpen(true)}
+                    >
+                      <BookOpen className="h-4 w-4" />
+                    </Button>
+                  </IconTip>
                 </div>
               </div>
               <div className="space-y-2">
@@ -207,15 +209,16 @@ export function Form6105Section() {
                     placeholders={NAVMC_10274_PLACEHOLDERS}
                     commonVariables={COMMON_FORM_VARS}
                   />
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    onClick={() => setUnitModalOpen(true)}
-                    title="Browse Unit Directory"
-                    className="h-auto self-stretch"
-                  >
-                    <Building2 className="h-4 w-4" />
-                  </Button>
+                  <IconTip label="Browse unit directory">
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={() => setUnitModalOpen(true)}
+                      className="h-auto self-stretch"
+                    >
+                      <Building2 className="h-4 w-4" />
+                    </Button>
+                  </IconTip>
                 </div>
               </div>
             </div>
@@ -309,15 +312,16 @@ export function Form6105Section() {
                   placeholders={NAVMC_10274_PLACEHOLDERS}
                   commonVariables={COMMON_FORM_VARS}
                 />
-                <Button
-                  variant="outline"
-                  size="icon"
-                  onClick={() => setReferenceModalOpen(true)}
-                  title="Browse Reference Library"
-                  className="h-auto self-stretch"
-                >
-                  <Library className="h-4 w-4" />
-                </Button>
+                <IconTip label="Browse reference library">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={() => setReferenceModalOpen(true)}
+                    className="h-auto self-stretch"
+                  >
+                    <Library className="h-4 w-4" />
+                  </Button>
+                </IconTip>
               </div>
             </div>
 

--- a/src/components/editor/JointLetterSection.tsx
+++ b/src/components/editor/JointLetterSection.tsx
@@ -3,6 +3,7 @@ import { Building2, BookOpen, Type, Shield } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
+import { IconTip } from '@/components/ui/icon-tip';
 import { DatePicker } from '@/components/ui/date-picker';
 import { Textarea } from '@/components/ui/textarea';
 import {
@@ -269,15 +270,16 @@ export function JointLetterSection() {
                       placeholder="5216"
                       className="flex-1"
                     />
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      onClick={() => setJuniorSSICModalOpen(true)}
-                      title="Browse SSIC Codes"
-                    >
-                      <BookOpen className="h-4 w-4" />
-                    </Button>
+                    <IconTip label="Browse SSIC codes">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={() => setJuniorSSICModalOpen(true)}
+                      >
+                        <BookOpen className="h-4 w-4" />
+                      </Button>
+                    </IconTip>
                   </div>
                 </div>
                 <div className="space-y-2">

--- a/src/components/editor/MOASection.tsx
+++ b/src/components/editor/MOASection.tsx
@@ -3,6 +3,7 @@ import { Building2, BookOpen, Shield } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
+import { IconTip } from '@/components/ui/icon-tip';
 import { DatePicker } from '@/components/ui/date-picker';
 import {
   Select,
@@ -146,15 +147,16 @@ export function MOASection() {
                       placeholder="5216"
                       className="flex-1"
                     />
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      onClick={() => setSeniorSSICModalOpen(true)}
-                      title="Browse SSIC Codes"
-                    >
-                      <BookOpen className="h-4 w-4" />
-                    </Button>
+                    <IconTip label="Browse SSIC codes">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={() => setSeniorSSICModalOpen(true)}
+                      >
+                        <BookOpen className="h-4 w-4" />
+                      </Button>
+                    </IconTip>
                   </div>
                 </div>
                 <div className="space-y-2">
@@ -294,15 +296,16 @@ export function MOASection() {
                       placeholder="5216"
                       className="flex-1"
                     />
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      onClick={() => setJuniorSSICModalOpen(true)}
-                      title="Browse SSIC Codes"
-                    >
-                      <BookOpen className="h-4 w-4" />
-                    </Button>
+                    <IconTip label="Browse SSIC codes">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={() => setJuniorSSICModalOpen(true)}
+                      >
+                        <BookOpen className="h-4 w-4" />
+                      </Button>
+                    </IconTip>
                   </div>
                 </div>
                 <div className="space-y-2">

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -3,6 +3,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
+import { IconTip } from '@/components/ui/icon-tip';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Accordion, AccordionContent, AccordionItem, AccordionTrigger, } from '@/components/ui/accordion';
@@ -373,28 +374,30 @@ export function SignatureSection({ config }: SignatureSectionProps) {
                           onClick={() => setOfficeCodeModalOpen(true)}
                         />
                         {formData.officeCode && (
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="absolute right-1 top-1/2 -translate-y-1/2 h-6 w-6"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setField('officeCode', '');
-                            }}
-                            title="Clear office code"
-                          >
-                            <X className="h-3 w-3" />
-                          </Button>
+                          <IconTip label="Clear office code">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="absolute right-1 top-1/2 -translate-y-1/2 h-6 w-6"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setField('officeCode', '');
+                              }}
+                            >
+                              <X className="h-3 w-3" />
+                            </Button>
+                          </IconTip>
                         )}
                       </div>
-                      <Button
-                        variant="outline"
-                        size="icon"
-                        onClick={() => setOfficeCodeModalOpen(true)}
-                        title="Search office codes"
-                      >
-                        <Search className="h-4 w-4" />
-                      </Button>
+                      <IconTip label="Search office codes">
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          onClick={() => setOfficeCodeModalOpen(true)}
+                        >
+                          <Search className="h-4 w-4" />
+                        </Button>
+                      </IconTip>
                     </div>
                   )}
                 </div>

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -19,6 +19,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
+import { IconTip } from '@/components/ui/icon-tip';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -447,15 +448,16 @@ export function ProfileModal() {
                         placeholder="5216"
                         className="flex-1"
                       />
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon"
-                        onClick={() => setShowSSICLookup(true)}
-                        title="Browse SSIC Codes"
-                      >
-                        <BookOpen className="h-4 w-4" />
-                      </Button>
+                      <IconTip label="Browse SSIC codes">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          onClick={() => setShowSSICLookup(true)}
+                        >
+                          <BookOpen className="h-4 w-4" />
+                        </Button>
+                      </IconTip>
                     </div>
                   </div>
                   <div className="space-y-2 col-span-2">


### PR DESCRIPTION
## Why
Follow-up to the addressing-section conversion — the same native `title=` a11y gap (invisible to keyboard/touch, no accessible name on the icon button) remained on every other lookup/browse button.

## What
Wraps the following in the shared `IconTip` (already on main), dropping `title=` and normalizing casing to sentence case:
- **Browse SSIC codes** — MOASection (senior + junior), JointLetterSection, Form6105Section, ProfileModal.
- **Browse unit directory** / **Browse reference library** — Form6105Section.
- **Search office codes** / **Clear office code** — SignatureSection.

`IconTip` injects `aria-label` from the label (Radix only wires `aria-describedby`), so these icon buttons gain a real accessible name for the first time. Pure adoption — no new logic (IconTip and its tests already landed in the previous PR).

## Verification
- Live (naval letter): the Signature "Search office codes" and Addressing "Browse SSIC codes" buttons now expose `aria-label` with **zero** leftover raw `title=` lookup buttons app-wide. The Form6105-only buttons (unit directory / reference library) are build- and type-validated.
- `tsc -b` + `tsc --noEmit` + build + eslint + `check-no-cdn` green; IconTip tag balance verified (3/3 in Form6105); **1589/1589** tests pass. (A transient Vite HMR "failed to reload" on Form6105 is the known structural-JSX hot-patch artifact — the production build and type-check are clean and the page renders.)

Remaining `title=` sites for later: ProfileBar (needs care around the `DropdownMenuTrigger asChild` nesting), the block-editor toolbar, ReadinessMeter, and drag handles.

Version 1.2.49.