### PR TITLE
fix(ui): use a real ellipsis in placeholder and loading microcopy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.50] — 2026-07-05
+
+### Changed
+
+- Placeholder and loading text now use a real ellipsis character (…) instead of
+  three periods (...) everywhere, for consistent, properly-typeset microcopy.
+- The "via" address row numbers are the same width and use the same tabular
+  figures as the reference and enclosure row numbers, so the columns line up.
+
 ## [1.2.49] — 2026-07-05
 
 ### Accessibility

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.49",
+  "version": "1.2.50",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/AddressingSection.tsx
+++ b/src/components/editor/AddressingSection.tsx
@@ -75,7 +75,7 @@ function SortableViaItem({ id, index, value, onChange, onRemove, onLookup, canRe
       >
         <GripVertical className="h-4 w-4" />
       </button>
-      <Badge variant="secondary" className="shrink-0 min-w-[36px] justify-center">
+      <Badge variant="secondary" className="shrink-0 min-w-[32px] justify-center tnum">
         ({index + 1})
       </Badge>
       <Input
@@ -390,7 +390,7 @@ export function AddressingSection({ config }: AddressingSectionProps) {
                     value={formData.from || ''}
                     onValueChange={(v) => setField('from', v)}
                     aria-invalid={validationVisible && unfilled(formData.from) ? true : undefined}
-                    placeholder="Commanding Officer... (type @ for variables)"
+                    placeholder="Commanding Officer… (type @ for variables)"
                   />
                 </div>
                 <div className="space-y-2">
@@ -402,7 +402,7 @@ export function AddressingSection({ config }: AddressingSectionProps) {
                         value={formData.to || ''}
                         onValueChange={(v) => setField('to', v)}
                         aria-invalid={validationVisible && unfilled(formData.to) ? true : undefined}
-                        placeholder="Commanding General... (type @ for variables)"
+                        placeholder="Commanding General… (type @ for variables)"
                       />
                     </div>
                     <IconTip label="Look up a unit">
@@ -510,8 +510,8 @@ export function AddressingSection({ config }: AddressingSectionProps) {
                 aria-invalid={validationVisible && unfilled(formData.subject) ? true : undefined}
                 placeholder={
                   isEndorsement
-                    ? "Subject of the basic letter being endorsed..."
-                    : 'SUBJECT LINE... (type @ for variables)'
+                    ? 'Subject of the basic letter being endorsed…'
+                    : 'SUBJECT LINE… (type @ for variables)'
                 }
                 className="uppercase"
               />

--- a/src/components/editor/ClassificationSection.tsx
+++ b/src/components/editor/ClassificationSection.tsx
@@ -303,7 +303,7 @@ export function ClassificationSection() {
                     onValueChange={(v) => setField('cuiCategory', v)}
                   >
                     <SelectTrigger>
-                      <SelectValue placeholder="Select category..." />
+                      <SelectValue placeholder="Select category…" />
                     </SelectTrigger>
                     <SelectContent>
                       {CUI_CATEGORIES.map((cat) => (
@@ -330,7 +330,7 @@ export function ClassificationSection() {
                     onValueChange={(v) => setField('cuiDistStatement', v)}
                   >
                     <SelectTrigger>
-                      <SelectValue placeholder="Select statement..." />
+                      <SelectValue placeholder="Select statement…" />
                     </SelectTrigger>
                     <SelectContent>
                       {DISTRIBUTION_STATEMENTS.map((stmt) => (
@@ -422,7 +422,7 @@ export function ClassificationSection() {
                     onValueChange={(v) => setField('cuiCategory', v)}
                   >
                     <SelectTrigger>
-                      <SelectValue placeholder="Select category..." />
+                      <SelectValue placeholder="Select category…" />
                     </SelectTrigger>
                     <SelectContent>
                       {CUI_CATEGORIES.map((cat) => (
@@ -449,7 +449,7 @@ export function ClassificationSection() {
                     onValueChange={(v) => setField('cuiDistStatement', v)}
                   >
                     <SelectTrigger>
-                      <SelectValue placeholder="Select statement..." />
+                      <SelectValue placeholder="Select statement…" />
                     </SelectTrigger>
                     <SelectContent>
                       {DISTRIBUTION_STATEMENTS.map((stmt) => (

--- a/src/components/editor/CopyToManager.tsx
+++ b/src/components/editor/CopyToManager.tsx
@@ -45,7 +45,7 @@ export function CopyToManager() {
                 <Input
                   value={ct.text}
                   onChange={(e) => updateCopyTo(index, e.target.value)}
-                  placeholder="Recipient..."
+                  placeholder="Recipient…"
                 />
                 <Button
                   variant="ghost"

--- a/src/components/editor/DistributionManager.tsx
+++ b/src/components/editor/DistributionManager.tsx
@@ -45,7 +45,7 @@ export function DistributionManager() {
                 <Input
                   value={d.text}
                   onChange={(e) => updateDistribution(index, e.target.value)}
-                  placeholder="Action addressee..."
+                  placeholder="Action addressee…"
                 />
                 <Button
                   variant="ghost"

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -109,7 +109,7 @@ function SortableEnclosure({
           <Input
             value={enclosure.title}
             onChange={(e) => onUpdateTitle(e.target.value)}
-            placeholder="Enclosure title..."
+            placeholder="Enclosure title…"
             aria-label={`Enclosure (${index + 1}) title`}
           />
 
@@ -174,7 +174,7 @@ function SortableEnclosure({
           </div>
           {enclosure.hasCoverPage && (
             <Textarea
-              placeholder="Optional description for page..."
+              placeholder="Optional description for page…"
               value={enclosure.coverPageDescription || ''}
               onChange={(e) => onUpdateCoverDescription(e.target.value)}
               className="text-xs min-h-[60px]"

--- a/src/components/editor/EndorsementBasicLetterSection.tsx
+++ b/src/components/editor/EndorsementBasicLetterSection.tsx
@@ -207,7 +207,7 @@ export function EndorsementBasicLetterSection() {
                 onValueChange={(v) => setField('endorsementOrdinal', v)}
               >
                 <SelectTrigger id="endorsementOrdinal" className="w-full">
-                  <SelectValue placeholder="Select position in routing chain..." />
+                  <SelectValue placeholder="Select position in routing chain…" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="FIRST">FIRST</SelectItem>

--- a/src/components/editor/Form11811Section.tsx
+++ b/src/components/editor/Form11811Section.tsx
@@ -169,7 +169,7 @@ export function Form11811Section() {
                 <VariableChipEditor
                   value={navmc11811.remarksText}
                   onChange={(v) => setNavmc11811Field('remarksText', v)}
-                  placeholder="Type @ or click + for variables. Example: On {{ENTRY_DATE}}, {{NAME}} [describe the incident]..."
+                  placeholder="Type @ or click + for variables. Example: On {{ENTRY_DATE}}, {{NAME}} [describe the incident]…"
                   rows={16}
                   tabInsertsSpaces
                 />
@@ -179,7 +179,7 @@ export function Form11811Section() {
                 <VariableChipEditor
                   value={navmc11811.remarksTextRight || ''}
                   onChange={(v) => setNavmc11811Field('remarksTextRight', v)}
-                  placeholder="[Continuation or additional entry...] (type @ or click + for variables)"
+                  placeholder="[Continuation or additional entry…] (type @ or click + for variables)"
                   rows={16}
                   tabInsertsSpaces
                 />

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -274,7 +274,7 @@ export function Form6105Section() {
               <VariableChipEditor
                 value={navmc10274.supplementalInfo}
                 onChange={(v) => setNavmc10274Field('supplementalInfo', v)}
-                placeholder="Full counseling statement (type @ or click + for variables)..."
+                placeholder="Full counseling statement (type @ or click + for variables)…"
                 rows={12}
                 tabInsertsSpaces
               />
@@ -331,7 +331,7 @@ export function Form6105Section() {
                 id="enclosures"
                 value={navmc10274.enclosures}
                 onValueChange={(v) => setNavmc10274Field('enclosures', v)}
-                placeholder="e.g., (1) Previous counseling dated... (type @ for variables)"
+                placeholder="e.g., (1) Previous counseling dated… (type @ for variables)"
                 placeholders={NAVMC_10274_PLACEHOLDERS}
                 commonVariables={COMMON_FORM_VARS}
               />

--- a/src/components/editor/MOASection.tsx
+++ b/src/components/editor/MOASection.tsx
@@ -200,7 +200,7 @@ export function MOASection() {
                       onValueChange={(v) => setField('seniorSigRank', v)}
                     >
                       <SelectTrigger id="seniorSigRank">
-                        <SelectValue placeholder="Select rank..." />
+                        <SelectValue placeholder="Select rank…" />
                       </SelectTrigger>
                       <SelectContent className="max-h-[300px]">
                         {ALL_SERVICE_RANKS.map((service) => (
@@ -349,7 +349,7 @@ export function MOASection() {
                       onValueChange={(v) => setField('juniorSigRank', v)}
                     >
                       <SelectTrigger id="juniorSigRank">
-                        <SelectValue placeholder="Select rank..." />
+                        <SelectValue placeholder="Select rank…" />
                       </SelectTrigger>
                       <SelectContent className="max-h-[300px]">
                         {ALL_SERVICE_RANKS.map((service) => (

--- a/src/components/editor/ReferencesManager.tsx
+++ b/src/components/editor/ReferencesManager.tsx
@@ -95,7 +95,7 @@ const SortableReference = memo(function SortableReference({
           <Input
             value={reference.title}
             onChange={(e) => updateReference(index, { title: e.target.value })}
-            placeholder="Reference title..."
+            placeholder="Reference title…"
             aria-label={`Reference (${reference.letter}) title`}
           />
           {urlInvalid && (

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -285,7 +285,7 @@ export function SignatureSection({ config }: SignatureSectionProps) {
                       onValueChange={(v) => setField('sigRank', v)}
                     >
                       <SelectTrigger id="sigRank">
-                        <SelectValue placeholder="Select rank..." />
+                        <SelectValue placeholder="Select rank…" />
                       </SelectTrigger>
                       <SelectContent className="max-h-[300px]">
                         {ALL_SERVICE_RANKS.map((service) => (
@@ -369,7 +369,7 @@ export function SignatureSection({ config }: SignatureSectionProps) {
                           id="officeCode"
                           value={officeCodeDisplay}
                           readOnly
-                          placeholder="Optional - click search..."
+                          placeholder="Optional - click search…"
                           className="pr-8 cursor-pointer"
                           onClick={() => setOfficeCodeModalOpen(true)}
                         />

--- a/src/components/layout/PreviewPanel.tsx
+++ b/src/components/layout/PreviewPanel.tsx
@@ -70,9 +70,9 @@ export function PreviewPanel({ pdfUrl, isCompiling, isWarmingUp = false, preview
           {/* Aria-live region for compilation status - WCAG 4.1.3 */}
           <div aria-live="polite" aria-atomic="true" className="sr-only">
             {isWarmingUp
-              ? 'Warming up the typesetter, one-time setup...'
+              ? 'Warming up the typesetter, one-time setup…'
               : isCompiling
-                ? 'Compiling document...'
+                ? 'Compiling document…'
                 : 'Compilation complete'}
           </div>
           {/* Compile state reads as a quiet label plus the slim sweep below —

--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -849,7 +849,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
                 <div className="flex gap-2 flex-wrap items-center">
                   <Select value={selectedVariable} onValueChange={setSelectedVariable}>
                     <SelectTrigger className="w-[180px]">
-                      <SelectValue placeholder="Select variable..." />
+                      <SelectValue placeholder="Select variable…" />
                     </SelectTrigger>
                     <SelectContent>
                       {suggestedPlaceholders.map((p) => (
@@ -861,7 +861,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
                   </Select>
                   <Select value={targetField} onValueChange={setTargetField}>
                     <SelectTrigger className="w-[180px]">
-                      <SelectValue placeholder="Add to field..." />
+                      <SelectValue placeholder="Add to field…" />
                     </SelectTrigger>
                     <SelectContent>
                       {/*
@@ -1028,7 +1028,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
                               onValueChange={(v) => updateColumnMapping(idx, v === SKIP_COLUMN ? '' : v)}
                             >
                               <SelectTrigger className="h-8 flex-1">
-                                <SelectValue placeholder="Select variable..." />
+                                <SelectValue placeholder="Select variable…" />
                               </SelectTrigger>
                               <SelectContent>
                                 <SelectItem value={SKIP_COLUMN}>— Skip —</SelectItem>

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -414,7 +414,7 @@ function ExamplesTab({ onClose }: { onClose: () => void }) {
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
-            placeholder="Search examples..."
+            placeholder="Search examples…"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="pl-9"

--- a/src/components/modals/FindReplaceModal.tsx
+++ b/src/components/modals/FindReplaceModal.tsx
@@ -210,7 +210,7 @@ export function FindReplaceModal() {
                 id="find"
                 value={findText}
                 onChange={(e) => setFindText(e.target.value)}
-                placeholder="Search text..."
+                placeholder="Search text…"
                 autoFocus
               />
               <Button variant="outline" size="icon" onClick={handleFindPrevious} disabled={totalMatches === 0}>
@@ -237,7 +237,7 @@ export function FindReplaceModal() {
                 id="replace"
                 value={replaceText}
                 onChange={(e) => setReplaceText(e.target.value)}
-                placeholder="Replacement text..."
+                placeholder="Replacement text…"
               />
               <Button variant="outline" onClick={handleReplace} disabled={totalMatches === 0}>
                 <Replace className="h-4 w-4 mr-1" />

--- a/src/components/modals/OfficeCodeLookupModal.tsx
+++ b/src/components/modals/OfficeCodeLookupModal.tsx
@@ -68,7 +68,7 @@ export function OfficeCodeLookupModal({ open, onOpenChange, onSelect }: OfficeCo
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
-            placeholder="Search by code or description..."
+            placeholder="Search by code or description…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="pl-9 pr-9"

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -548,7 +548,7 @@ export function ProfileModal() {
                         onValueChange={(v) => updateField('sigRank', v)}
                       >
                         <SelectTrigger id="sigRank">
-                          <SelectValue placeholder="Select rank..." />
+                          <SelectValue placeholder="Select rank…" />
                         </SelectTrigger>
                         <SelectContent className="max-h-[300px]">
                           {ALL_SERVICE_RANKS.map((service) => (

--- a/src/components/modals/ReferenceLibraryPicker.tsx
+++ b/src/components/modals/ReferenceLibraryPicker.tsx
@@ -68,7 +68,7 @@ export function ReferenceLibraryPicker({
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
-            placeholder="Search references..."
+            placeholder="Search references…"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="pl-9"

--- a/src/components/modals/SSICLookupModal.tsx
+++ b/src/components/modals/SSICLookupModal.tsx
@@ -64,7 +64,7 @@ export function SSICLookupModal({ open, onOpenChange, onSelect }: SSICLookupModa
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
-            placeholder="Search by code or description..."
+            placeholder="Search by code or description…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="pl-9 pr-9"

--- a/src/components/modals/TemplateLoaderModal.tsx
+++ b/src/components/modals/TemplateLoaderModal.tsx
@@ -221,7 +221,7 @@ export function TemplateLoaderModal() {
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
-              placeholder="Search templates by name, description, or SSIC..."
+              placeholder="Search templates by name, description, or SSIC…"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="pl-9"

--- a/src/components/modals/UnitLookupModal.tsx
+++ b/src/components/modals/UnitLookupModal.tsx
@@ -123,7 +123,7 @@ export function UnitLookupModal({ open, onOpenChange, onSelect }: UnitLookupModa
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
-            placeholder="Search by unit name, abbreviation, MCC, or location..."
+            placeholder="Search by unit name, abbreviation, MCC, or location…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="pl-9 pr-9"


### PR DESCRIPTION
## Why
Placeholders were inconsistent: ~34 used ASCII `...` while only three used the real `…` glyph — a visible typesetting inconsistency in a document-quality tool. Two unrelated microcopy nits rode along.

## What
- **Ellipsis normalization** — every `placeholder="…"` value across the editor and modals now uses `…`. Applied via a scoped transform that only touches text *inside* `placeholder="…"` (so JS spread `...` is never affected), plus two dynamic cases the literal regex couldn't reach: the subject-field ternary placeholder (both branches) and the PreviewPanel `aria-live` compile-status strings (`Compiling document…`).
- **Via badge** — the "via" address row index badge was a `min-w-[36px]` non-tabular outlier; aligned it to the `min-w-[32px] … tnum` used by the reference and enclosure row badges so the digit columns line up.

## Verification
- Live: rendered input placeholders now show `…` (`Reference title…`, `Commanding Officer…`, `SUBJECT LINE…`), **zero** ASCII `...` remaining in any rendered placeholder.
- No test queries by the old placeholder text (verified). `tsc -b` + build + eslint + `check-no-cdn` green; **1589/1589** tests pass.

Deliberately left for a separate pass (more judgment-heavy): empty-state sentence punctuation and remaining button-casing.

Version 1.2.50.