### PR TITLE
fix(a11y): standardize the profile bar controls to 32px with themed tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.51] — 2026-07-05
+
+### Accessibility
+
+- The profile bar's controls (profile picker, create, edit, and more) are now the
+  standard 32px size instead of 28px, easier to hit, and the icon buttons use the
+  themed tooltip that reaches keyboard and touch users and carries an accessible
+  name. Their labels were normalized to sentence case.
+
 ## [1.2.50] — 2026-07-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.50",
+  "version": "1.2.51",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/ProfileBar.tsx
+++ b/src/components/editor/ProfileBar.tsx
@@ -1,5 +1,6 @@
 import { Plus, Pencil, Trash2, Upload, Download, MoreHorizontal } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { IconTip } from '@/components/ui/icon-tip';
 import {
   Select,
   SelectContent,
@@ -135,11 +136,11 @@ export function ProfileBar() {
   return (
     <div data-tour="profiles" className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border bg-secondary/20">
       <Select value={selectedProfile || '__none__'} onValueChange={handleProfileChange}>
-        <SelectTrigger className="w-[200px] h-7 text-xs">
-          <SelectValue placeholder="Select Profile" />
+        <SelectTrigger size="sm" className="w-[200px] text-xs">
+          <SelectValue placeholder="Select profile" />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="__none__">No Profile</SelectItem>
+          <SelectItem value="__none__">No profile</SelectItem>
           {profileNames.map((name) => (
             <SelectItem key={name} value={name}>
               {name}
@@ -148,44 +149,46 @@ export function ProfileBar() {
         </SelectContent>
       </Select>
 
-      <Button
-        data-tour="profile-create"
-        variant="ghost"
-        size="icon"
-        className="h-7 w-7"
-        onClick={() => {
-          // selectProfile persists via compressedLocalStorage, which rethrows on
-          // quota — guard so a near-full store degrades (logs) instead of throwing
-          // out of the click handler into the ErrorBoundary. The modal still opens.
-          try {
-            selectProfile(null);
-          } catch (err) {
-            debug.error('Profile', 'Failed to clear profile selection (storage may be full)', err);
-          }
-          setProfileModalOpen(true);
-        }}
-        title="Create New Profile"
-      >
-        <Plus className="h-3.5 w-3.5" />
-      </Button>
+      <IconTip label="Create profile">
+        <Button
+          data-tour="profile-create"
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => {
+            // selectProfile persists via compressedLocalStorage, which rethrows on
+            // quota — guard so a near-full store degrades (logs) instead of throwing
+            // out of the click handler into the ErrorBoundary. The modal still opens.
+            try {
+              selectProfile(null);
+            } catch (err) {
+              debug.error('Profile', 'Failed to clear profile selection (storage may be full)', err);
+            }
+            setProfileModalOpen(true);
+          }}
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
+      </IconTip>
 
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-7 w-7"
-        onClick={() => setProfileModalOpen(true)}
-        disabled={!selectedProfile}
-        title="Edit Profile"
-      >
-        <Pencil className="h-3.5 w-3.5" />
-      </Button>
+      <IconTip label="Edit profile">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => setProfileModalOpen(true)}
+          disabled={!selectedProfile}
+        >
+          <Pencil className="h-4 w-4" />
+        </Button>
+      </IconTip>
 
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon" className="h-7 w-7" title="More profile options">
-            <MoreHorizontal className="h-3.5 w-3.5" />
-          </Button>
-        </DropdownMenuTrigger>
+        <IconTip label="More options">
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon-sm">
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+        </IconTip>
         <DropdownMenuContent align="start">
           <DropdownMenuItem
             onClick={handleDelete}
@@ -193,16 +196,16 @@ export function ProfileBar() {
             className="text-destructive focus:text-destructive"
           >
             <Trash2 className="h-4 w-4 mr-2" />
-            Delete Profile
+            Delete profile
           </DropdownMenuItem>
           <DropdownMenuItem onClick={handleExport}>
             <Download className="h-4 w-4 mr-2" />
-            Export Profiles
+            Export profiles
           </DropdownMenuItem>
           <DropdownMenuItem asChild>
             <label className="cursor-pointer">
               <Upload className="h-4 w-4 mr-2" />
-              Import Profiles
+              Import profiles
               <input
                 type="file"
                 accept=".json"


### PR DESCRIPTION
## Why
The profile bar's controls were forced to 28px (`h-7`) — below the shadcn `sm` floor (32px) and hard to hit — and used native `title=` (invisible to keyboard/touch, no accessible name on the icon buttons) with Title-Case labels.

## What (single file: `ProfileBar.tsx`)
- Profile `Select` → `size="sm"` (h-8, 32px); create/edit/more icon buttons → `size="icon-sm"` (size-8, 32px), glyphs bumped 3.5→4.
- Native `title=` → `IconTip` (themed tooltip + injected `aria-label`). The **More** button is the tricky one — it's a `DropdownMenuTrigger asChild`; nesting `IconTip` → `DropdownMenuTrigger asChild` → `Button` composes both behaviors. Verified live: it now reports `aria-label="More options"` **and** keeps `aria-haspopup="menu"` / `aria-expanded`.
- Sentence-case labels: Create/Edit profile, More options, Delete/Export/Import profile(s), Select profile / No profile.

## Verification
Live: all four controls measure 32px; create/edit/more expose `aria-label` with no `title`; the More dropdown still opens (haspopup/expanded intact). `tsc -b` + build + eslint + `check-no-cdn` green; **1589/1589** tests pass.

**Verified already-resolved during triage** (stale ledger entries, not touched): the ActivationChecklist collapse/hide buttons already carry `focus-visible:ring-[3px] ring-ring/50` (the WCAG 2.4.7 finding is fixed), and the StorageNotice/BackupNotice dismiss ✕ already use `-m-1.5 p-1.5` hit-padding + focus ring. Deferred: `max-sm` 44px hit-padding on the profile bar (nitpick refinement) and the block-editor toolbar tooltips.

Version 1.2.51.