### PR TITLE
feat(a11y): themed tooltips for the block editor's paragraph controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.52] — 2026-07-05
+
+### Accessibility
+
+- The per-paragraph controls in the body editor (indent, outdent, move up, move
+  down, delete) now use the themed tooltip that appears on keyboard focus and
+  carries an accessible name with its keyboard shortcut, instead of a native
+  browser tooltip that keyboard and touch users never saw.
+
 ## [1.2.51] — 2026-07-05
 
 ### Accessibility

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.51",
+  "version": "1.2.52",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/BlockParagraphsEditor.tsx
+++ b/src/components/editor/BlockParagraphsEditor.tsx
@@ -7,6 +7,7 @@ import { CSS } from '@dnd-kit/utilities';
 import {
   GripVertical, Plus, Trash2, ChevronRight, ChevronLeft, ArrowUp, ArrowDown, AlertTriangle, Library } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { IconTip } from '@/components/ui/icon-tip';
 import { Input } from '@/components/ui/input';
 import {
   Accordion,
@@ -270,39 +271,48 @@ const BlockRow = memo(function BlockRow({
           )}
           {!disableIndent && (
             <>
-              <Button variant="ghost" size="icon" className="h-6 w-6" disabled={level === 0} onClick={() => outdentParagraph(index)} title="Outdent (Shift+Tab)">
-                <ChevronLeft className="h-3.5 w-3.5" />
-              </Button>
-              <Button variant="ghost" size="icon" className="h-6 w-6" disabled={!canIndent} onClick={() => indentParagraph(index)} title="Indent (Tab)">
-                <ChevronRight className="h-3.5 w-3.5" />
-              </Button>
+              <IconTip label="Outdent (Shift+Tab)">
+                <Button variant="ghost" size="icon" className="h-6 w-6" disabled={level === 0} onClick={() => outdentParagraph(index)}>
+                  <ChevronLeft className="h-3.5 w-3.5" />
+                </Button>
+              </IconTip>
+              <IconTip label="Indent (Tab)">
+                <Button variant="ghost" size="icon" className="h-6 w-6" disabled={!canIndent} onClick={() => indentParagraph(index)}>
+                  <ChevronRight className="h-3.5 w-3.5" />
+                </Button>
+              </IconTip>
             </>
           )}
-          <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => onMove(-1)} title="Move up (⌘↑)">
-            <ArrowUp className="h-3.5 w-3.5" />
-          </Button>
-          <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => onMove(1)} title="Move down (⌘↓)">
-            <ArrowDown className="h-3.5 w-3.5" />
-          </Button>
+          <IconTip label="Move up (⌘↑)">
+            <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => onMove(-1)}>
+              <ArrowUp className="h-3.5 w-3.5" />
+            </Button>
+          </IconTip>
+          <IconTip label="Move down (⌘↓)">
+            <Button variant="ghost" size="icon" className="h-6 w-6" onClick={() => onMove(1)}>
+              <ArrowDown className="h-3.5 w-3.5" />
+            </Button>
+          </IconTip>
           <div className="flex-1" />
           <span className="mr-0.5 text-[11px] text-muted-foreground tnum">{countWords(text)} w</span>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-6 w-6 text-muted-foreground hover:text-destructive"
-            onClick={() => {
-              const total = useDocumentStore.getState().paragraphs.length;
-              if (total <= 1) {
-                updateParagraph(index, { text: '', header: '' });
-              } else {
-                removeParagraph(index);
-                requestFocus(Math.max(0, index - 1));
-              }
-            }}
-            title="Delete paragraph"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-          </Button>
+          <IconTip label="Delete paragraph">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 text-muted-foreground hover:text-destructive"
+              onClick={() => {
+                const total = useDocumentStore.getState().paragraphs.length;
+                if (total <= 1) {
+                  updateParagraph(index, { text: '', header: '' });
+                } else {
+                  removeParagraph(index);
+                  requestFocus(Math.max(0, index - 1));
+                }
+              }}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </IconTip>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Why
The body editor's per-paragraph controls used native `title=` (invisible to keyboard/touch) and, being icon-only, had no accessible name.

## What
Wraps the five icon-only controls — **outdent, indent, move up, move down, delete** — in `IconTip`, dropping `title=`. The tooltip carries the keyboard shortcut (`Outdent (Shift+Tab)`, `Move up (⌘↑)`, …) and `IconTip` injects the `aria-label`.

**Intentionally left with native `title`:**
- The **drag handle** already has an `aria-label`, and it carries the dnd-kit pointer `{...listeners}` — wrapping it in a `TooltipTrigger asChild` risks interfering with the drag.
- The **+heading** and **portion-marking** buttons have visible text labels, so a tooltip would just duplicate them.

## Verification
Live (naval letter body): the five controls now expose `aria-label` (`Move up (⌘↑)`, `Delete paragraph`, `Indent (Tab)`, …) with **zero** leftover raw `title` among them; no console errors; the drag handle still drags. IconTip tag balance 5/5. `tsc -b` + build + eslint + `check-no-cdn` green; **1589/1589** tests pass.

Version 1.2.52.