### PR TITLE
feat(a11y): themed tooltips for the sidebar and readiness controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.53] — 2026-07-05
+
+### Accessibility
+
+- The document sidebar's sort and multi-select buttons and the preview's
+  readiness "jump to the first incomplete section" control now use the themed
+  tooltip that appears on keyboard focus, instead of a native browser tooltip
+  that keyboard and touch users never saw.
+
 ## [1.2.52] — 2026-07-05
 
 ### Accessibility

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.52",
+  "version": "1.2.53",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/layout/EditorSidebar.tsx
+++ b/src/components/layout/EditorSidebar.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { IconTip } from '@/components/ui/icon-tip';
 import { SectionRail } from './SectionRail';
 import { getSectionError, getFormSectionError, useEditorSections, ERROR_BEARING_IDS } from './editorSections';
 import { useDocumentStore } from '@/stores/documentStore';
@@ -258,26 +259,29 @@ export function EditorSidebar() {
         <div className="flex items-center justify-between px-3 pb-1.5">
           <span className="text-2xs font-semibold tracking-[0.06em] uppercase text-muted-foreground">Recent</span>
           <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={() => setSort((s) => (s === 'recent' ? 'name' : 'recent'))}
-              aria-label={sort === 'recent' ? 'Sort by name' : 'Sort by most recent'}
-              title={sort === 'recent' ? 'Sorted by most recent — switch to A–Z' : 'Sorted A–Z — switch to most recent'}
-              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 transition-colors"
-            >
-              {sort === 'recent' ? <Clock className="h-3.5 w-3.5" /> : <ArrowDownAZ className="h-3.5 w-3.5" />}
-            </button>
-            <button
-              type="button"
-              onClick={() => (selectMode ? exitSelectMode() : setSelectMode(true))}
-              aria-pressed={selectMode}
-              title={selectMode ? 'Exit selection' : 'Select multiple documents'}
-              className={`inline-flex h-7 w-7 items-center justify-center rounded-md outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 transition-colors ${
-                selectMode ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-              }`}
-            >
-              <CheckSquare className="h-3.5 w-3.5" />
-            </button>
+            <IconTip label={sort === 'recent' ? 'Sorted by most recent — switch to A–Z' : 'Sorted A–Z — switch to most recent'}>
+              <button
+                type="button"
+                onClick={() => setSort((s) => (s === 'recent' ? 'name' : 'recent'))}
+                aria-label={sort === 'recent' ? 'Sort by name' : 'Sort by most recent'}
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground outline-none hover:bg-muted hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 transition-colors"
+              >
+                {sort === 'recent' ? <Clock className="h-3.5 w-3.5" /> : <ArrowDownAZ className="h-3.5 w-3.5" />}
+              </button>
+            </IconTip>
+            <IconTip label={selectMode ? 'Exit selection' : 'Select multiple documents'}>
+              <button
+                type="button"
+                onClick={() => (selectMode ? exitSelectMode() : setSelectMode(true))}
+                aria-pressed={selectMode}
+                aria-label={selectMode ? 'Exit selection' : 'Select multiple documents'}
+                className={`inline-flex h-7 w-7 items-center justify-center rounded-md outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 transition-colors ${
+                  selectMode ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                }`}
+              >
+                <CheckSquare className="h-3.5 w-3.5" />
+              </button>
+            </IconTip>
             <button
               ref={newBtnRef}
               type="button"

--- a/src/components/layout/ReadinessMeter.tsx
+++ b/src/components/layout/ReadinessMeter.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Check, ShieldCheck } from 'lucide-react';
+import { IconTip } from '@/components/ui/icon-tip';
 import { useDocumentStore } from '@/stores/documentStore';
 import { useEditorOutlineStore } from '@/stores/editorOutlineStore';
 import { useDocumentCompleteness } from './editorSections';
@@ -91,15 +92,16 @@ export function ReadinessMeter() {
       )}
 
       {canJump ? (
-        <button
-          type="button"
-          onClick={() => jump(missing[0])}
-          title={`${complete} of ${required} required sections complete — jump to the first incomplete one`}
-          aria-label={`Document readiness: Drafting, ${complete} of ${required} required sections complete. Jump to the first incomplete section.`}
-          className="flex items-center gap-1.5 rounded outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
-        >
-          {inner}
-        </button>
+        <IconTip label={`${complete} of ${required} required sections complete — jump to the first incomplete one`}>
+          <button
+            type="button"
+            onClick={() => jump(missing[0])}
+            aria-label={`Document readiness: Drafting, ${complete} of ${required} required sections complete. Jump to the first incomplete section.`}
+            className="flex items-center gap-1.5 rounded outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          >
+            {inner}
+          </button>
+        </IconTip>
       ) : (
         <div
           className="flex items-center gap-1.5"

--- a/tests/component/ReadinessMeter.test.tsx
+++ b/tests/component/ReadinessMeter.test.tsx
@@ -7,7 +7,18 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import { ReadinessMeter } from '@/components/layout/ReadinessMeter';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import { useDocumentStore } from '@/stores/documentStore';
+
+// The meter's "jump to first incomplete" control is wrapped in IconTip, which
+// relies on the app-root TooltipProvider (App.tsx) — supply one in tests.
+function renderMeter() {
+  return render(
+    <TooltipProvider>
+      <ReadinessMeter />
+    </TooltipProvider>
+  );
+}
 
 function configure(formData: Record<string, string>, paragraphs: { text: string }[]) {
   useDocumentStore.setState({
@@ -27,7 +38,7 @@ describe('ReadinessMeter — driven by the single completeness rule', () => {
   });
 
   it('reads "Drafting" while required sections are unfilled', () => {
-    render(<ReadinessMeter />);
+    renderMeter();
     const meter = screen.getByLabelText(/Document readiness/i);
     expect(meter.getAttribute('aria-label')).toMatch(/Drafting/);
     expect(screen.getByText('Drafting')).toBeTruthy();
@@ -44,12 +55,12 @@ describe('ReadinessMeter — driven by the single completeness rule', () => {
       },
       [{ text: 'The Marine requests special liberty.' }]
     );
-    render(<ReadinessMeter />);
+    renderMeter();
     expect(screen.getByText('Ready to sign')).toBeTruthy();
   });
 
   it('shows the Compliant pill in compliant mode', () => {
-    render(<ReadinessMeter />);
+    renderMeter();
     expect(screen.getByText('Compliant')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Why
The last interactive controls still using native `title=` (invisible to keyboard/touch): the editor sidebar's recent-docs **sort** and **multi-select** toggles, and the preview readiness meter's **jump-to-first-incomplete** button.

## What
Wraps those three interactive buttons in `IconTip`, dropping `title=`. Each keeps a concise `aria-label` for SR while the longer hint shows on focus/hover. The multi-select toggle had relied on `title` for its accessible name, so an explicit `aria-label` was added.

**Intentionally kept native `title`:**
- ReadinessMeter's **Compliant chip** and the **all-complete indicator** — non-interactive `<span>`/`<div>`; `title` is the standard treatment there, and wrapping them would add a focus stop with no action.
- The recent-doc name `title={m.title}` — a native *truncation* tooltip on a text span, not an interactive hint.

## Verification
`tsc -b` + build + eslint + `check-no-cdn` green; **1589/1589** tests pass. The ReadinessMeter component test now wraps renders in `TooltipProvider` (the jump button is an `IconTip` in the drafting state). Grep confirms the only remaining `title=` in both files are the intended non-interactive/truncation ones.

This **completes the native-`title` → themed-tooltip sweep** for interactive controls.

Version 1.2.53.