### PR TITLE
fix(ui): migrate arbitrary micro-text sizes to the --text-2xs token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.54] — 2026-07-05
+
+### Changed
+
+- Small UI labels (badges, group headers, keycaps, counts, and similar micro-text)
+  now all draw from one shared type step instead of a scatter of hand-picked 9px,
+  10px, and 11px sizes. The smallest 9px and 10px labels move up to a consistent,
+  more legible size, and the masthead subtitle is a touch larger and less faint.
+
 ## [1.2.53] — 2026-07-05
 
 ### Accessibility

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.53",
+  "version": "1.2.54",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/BlockParagraphsEditor.tsx
+++ b/src/components/editor/BlockParagraphsEditor.tsx
@@ -294,7 +294,7 @@ const BlockRow = memo(function BlockRow({
             </Button>
           </IconTip>
           <div className="flex-1" />
-          <span className="mr-0.5 text-[11px] text-muted-foreground tnum">{countWords(text)} w</span>
+          <span className="mr-0.5 text-2xs text-muted-foreground tnum">{countWords(text)} w</span>
           <IconTip label="Delete paragraph">
             <Button
               variant="ghost"
@@ -454,7 +454,7 @@ export function BlockParagraphsEditor() {
             </Button>
           </PopoverTrigger>
           <PopoverContent align="start" className="w-80 p-0">
-            <div className="border-b border-border px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+            <div className="border-b border-border px-3 py-2 text-2xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
               Insert a clause
             </div>
             <ul className="max-h-64 overflow-y-auto p-1">
@@ -469,7 +469,7 @@ export function BlockParagraphsEditor() {
                       className="min-w-0 flex-1 rounded-md px-2 py-1.5 text-left outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
                     >
                       <span className="block truncate text-sm text-foreground">{sn.name}</span>
-                      <span className="block truncate text-[11px] text-muted-foreground">{sn.text}</span>
+                      <span className="block truncate text-2xs text-muted-foreground">{sn.text}</span>
                     </button>
                     <button
                       type="button"

--- a/src/components/editor/EndorsementBasicLetterSection.tsx
+++ b/src/components/editor/EndorsementBasicLetterSection.tsx
@@ -153,7 +153,7 @@ export function EndorsementBasicLetterSection() {
                             onClick={() => applyBasicLetter(d.meta)}
                             className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left outline-none hover:bg-muted/60 focus-visible:ring-[3px] focus-visible:ring-ring/50"
                           >
-                            <span className="inline-flex h-4 shrink-0 items-center justify-center rounded bg-muted px-1 text-[9px] font-semibold uppercase tracking-wide text-muted-foreground" style={{ minWidth: '2.4rem' }}>
+                            <span className="inline-flex h-4 shrink-0 items-center justify-center rounded bg-muted px-1 text-2xs font-semibold uppercase tracking-wide text-muted-foreground" style={{ minWidth: '2.4rem' }}>
                               {docTypeChip(d.meta.docType)}
                             </span>
                             <span className="min-w-0 flex-1 truncate text-sm text-foreground">{d.meta.title}</span>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -678,7 +678,7 @@ export function Header({
               <h1 className="text-base font-semibold tracking-[-0.01em] text-foreground leading-tight truncate">
                 DonDocs
               </h1>
-              <span className="text-[10px] text-muted-foreground hidden sm:block leading-tight truncate">Naval correspondence &amp; forms</span>
+              <span className="text-xs text-foreground/70 hidden sm:block leading-tight truncate">Naval correspondence &amp; forms</span>
             </div>
           </div>
           {/* NIST 800-171 Compliance Badge - icon only below lg, full badge on lg+ */}

--- a/src/components/layout/ReadinessMeter.tsx
+++ b/src/components/layout/ReadinessMeter.tsx
@@ -83,7 +83,7 @@ export function ReadinessMeter() {
     <div className="flex items-center gap-2 text-xs">
       {documentMode === 'compliant' && (
         <span
-          className="hidden items-center gap-1 rounded-full border border-border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground md:inline-flex"
+          className="hidden items-center gap-1 rounded-full border border-border px-1.5 py-0.5 text-2xs font-medium text-muted-foreground md:inline-flex"
           title="Built to the SECNAV M-5216.5 / MCO 5216.19A compliant format"
         >
           <ShieldCheck className="h-3 w-3" aria-hidden="true" />

--- a/src/components/modals/CommandPalette.tsx
+++ b/src/components/modals/CommandPalette.tsx
@@ -166,7 +166,7 @@ export function CommandPalette({
           ) : (
             filtered.map((g) => (
               <div key={g.label} className="mb-1">
-                <div className="px-2.5 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                <div className="px-2.5 pb-1 pt-2 text-2xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
                   {g.label}
                 </div>
                 {g.items.map((it) => {
@@ -191,7 +191,7 @@ export function CommandPalette({
                       <Icon className={cn('h-4 w-4 shrink-0', active ? 'text-current' : 'text-muted-foreground')} />
                       <span className="flex-1 truncate text-sm">{it.label}</span>
                       {it.hint && (
-                        <span className={cn('text-[11px]', active ? 'text-current opacity-85' : 'text-muted-foreground')}>
+                        <span className={cn('text-2xs', active ? 'text-current opacity-85' : 'text-muted-foreground')}>
                           {it.hint}
                         </span>
                       )}
@@ -205,7 +205,7 @@ export function CommandPalette({
         </div>
 
         {/* Persistent action hints + result count. */}
-        <div className="flex items-center justify-between gap-3 border-t border-primary/10 px-4 py-2 text-[11px] text-muted-foreground">
+        <div className="flex items-center justify-between gap-3 border-t border-primary/10 px-4 py-2 text-2xs text-muted-foreground">
           <div className="flex items-center gap-3">
             <span className="flex items-center gap-1"><Kbd>↵</Kbd> Run</span>
             <span className="flex items-center gap-1"><Kbd>↑</Kbd><Kbd>↓</Kbd> Navigate</span>

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -142,7 +142,7 @@ function DocumentFinder({ onSelectGuide }: { onSelectGuide: (guideId: string) =>
                         </Badge>
                       )}
                       {cite && (
-                        <Badge variant="outline" className="text-[10px] font-normal text-muted-foreground">
+                        <Badge variant="outline" className="text-2xs font-normal text-muted-foreground">
                           {cite}
                         </Badge>
                       )}

--- a/src/components/modals/TemplateLoaderModal.tsx
+++ b/src/components/modals/TemplateLoaderModal.tsx
@@ -285,7 +285,7 @@ export function TemplateLoaderModal() {
           <div className="p-4 grid gap-2">
             {userTemplateList.length > 0 && (
               <>
-                <div className="px-1 text-[10px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                <div className="px-1 text-2xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
                   Your templates
                 </div>
                 {userTemplateList.map((t) => (
@@ -331,7 +331,7 @@ export function TemplateLoaderModal() {
                     </button>
                   </div>
                 ))}
-                <div className="mt-2 px-1 text-[10px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                <div className="mt-2 px-1 text-2xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
                   Built-in templates
                 </div>
               </>

--- a/src/components/modals/VersionHistoryModal.tsx
+++ b/src/components/modals/VersionHistoryModal.tsx
@@ -77,7 +77,7 @@ export function VersionHistoryModal() {
                   <span className="block truncate text-foreground">
                     {snap.session.formData?.subject?.trim() || 'Untitled version'}
                   </span>
-                  <span className="block text-[11px] text-muted-foreground tnum">
+                  <span className="block text-2xs text-muted-foreground tnum">
                     {fmt(snap.ts)}
                     {i === 0 ? ' · latest' : ''}
                   </span>

--- a/src/components/onboarding/ActivationChecklist.tsx
+++ b/src/components/onboarding/ActivationChecklist.tsx
@@ -242,7 +242,7 @@ export function ActivationChecklist() {
               </div>
               {!row.done &&
                 (row.badge ? (
-                  <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
+                  <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-2xs font-medium tabular-nums text-muted-foreground">
                     {row.badge}
                   </span>
                 ) : (
@@ -433,7 +433,7 @@ export function ActivationChecklist() {
 
         {/* Footer */}
         <div className="border-t border-border px-4 py-2.5">
-          <p className="text-[11px] text-muted-foreground">Reopen anytime from the Help menu.</p>
+          <p className="text-2xs text-muted-foreground">Reopen anytime from the Help menu.</p>
         </div>
       </div>
     </div>

--- a/src/components/onboarding/ProgressRing.tsx
+++ b/src/components/onboarding/ProgressRing.tsx
@@ -37,7 +37,7 @@ export function ProgressRing({ size, done, total }: { size: number; done: number
           className="text-primary transition-[stroke-dashoffset] duration-500 ease-out motion-reduce:transition-none"
         />
       </svg>
-      <span className="absolute inline-flex items-center justify-center text-[11px] font-semibold tabular-nums leading-none text-foreground">
+      <span className="absolute inline-flex items-center justify-center text-2xs font-semibold tabular-nums leading-none text-foreground">
         {complete ? <Check className="h-3 w-3 text-success" /> : `${done}/${total}`}
       </span>
     </span>

--- a/src/components/pdf/PdfPageLayer.tsx
+++ b/src/components/pdf/PdfPageLayer.tsx
@@ -317,7 +317,7 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
                   </div>
                   <span
                     className={cn(
-                      'tnum text-[10px]',
+                      'tnum text-2xs',
                       currentPage === i + 1 ? 'font-medium text-foreground' : 'text-muted-foreground'
                     )}
                   >

--- a/src/components/ui/kbd.tsx
+++ b/src/components/ui/kbd.tsx
@@ -18,7 +18,7 @@ export function Kbd({
   return (
     <kbd
       className={cn(
-        'inline-flex h-[18px] min-w-[16px] items-center justify-center rounded-[5px] border px-[5px] font-mono text-[11px] font-medium leading-none',
+        'inline-flex h-[18px] min-w-[16px] items-center justify-center rounded-[5px] border px-[5px] font-mono text-2xs font-medium leading-none',
         active
           ? 'border-current/25 bg-current/15 text-current'
           : 'border-border bg-muted/60 text-muted-foreground',

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -380,7 +380,7 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
 
     return (
       <div className="bg-popover text-popover-foreground border border-border rounded-lg shadow-md overflow-hidden w-[300px]">
-        <div className="px-3 pt-2.5 pb-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        <div className="px-3 pt-2.5 pb-1 text-2xs font-semibold uppercase tracking-wider text-muted-foreground">
           Insert
         </div>
         <div ref={listRef} className="max-h-[280px] overflow-y-auto px-1 pb-1.5" role="listbox" aria-label="Insert variable">


### PR DESCRIPTION
## Why
Micro-labels used a scatter of arbitrary font sizes — `text-[9px]` (below the legibility floor), `text-[10px]`, and `text-[11px]` — bypassing the type scale, with no shared tracking/line-height. `--text-2xs` (0.6875rem/11px, with paired line-height + 0.01em tracking) already exists for exactly this.

## What
- Migrated **19 sites across 13 files** — `text-[9px]` (1), `text-[10px]` (8), `text-[11px]` (10) → `text-2xs`. The sub-11px labels (the 9px badge, the 10px group headers / chips / PDF page number / masthead) promote **up** to 11px (the legibility gain); the 11px sites are identical in size and pick up the token's tracking.
- **Masthead subtitle** gets its own documented treatment (it was flagged as fine print): `text-[10px] text-muted-foreground` → `text-xs text-foreground/70` (12px, lifted off muted).

## Verification (live)
- `text-2xs` resolves to **11px** with the token's letter-spacing; the masthead subtitle now computes **12px** at `foreground/70` (`oklab(0.98 0 0 / 0.7)`).
- `tsc -b` + build + eslint + `check-no-cdn` green; **1589/1589** tests pass. Grep confirms zero `text-[9/10/11px]` literals remain.

Version 1.2.54.