### PR TITLE
fix(signature): normalize non-PNG signature uploads to PNG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.55] — 2026-07-05
+
+### Fixed
+
+- Signature images uploaded as JPG or GIF now render correctly in the preview and
+  in the exported PDF. Previously they were stored and embedded as if they were
+  PNG, so a JPG or GIF signature could render wrong or fail to appear on the
+  document. Every non-PNG signature upload is now converted to PNG when you add
+  it (existing letters are unaffected until you re-upload).
+
 ## [1.2.54] — 2026-07-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.54",
+  "version": "1.2.55",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -14,6 +14,7 @@ import { HelpTip } from '@/components/ui/help-tip';
 import { useDocumentStore } from '@/stores/documentStore';
 import { useUIStore } from '@/stores/uiStore';
 import { unfilled } from '@/lib/requiredField';
+import { loadSignatureAsPngBase64 } from '@/lib/signatureImage';
 import { FILE_LIMITS } from '@/lib/constants';
 import { showAppAlert } from '@/stores/alertStore';
 import { isImageFile, rejectedFilesMessage } from '@/lib/fileFilter';
@@ -22,16 +23,6 @@ import type { DocTypeConfig, SignatureImage, SignatureType } from '@/types/docum
 import { ALL_SERVICE_RANKS, formatRank } from '@/data/ranks';
 import { getOfficeCode, OFFICE_CODES } from '@/data/officeCodes';
 import { OfficeCodeLookupModal } from '@/components/modals/OfficeCodeLookupModal';
-
-// Convert ArrayBuffer to base64
-function arrayBufferToBase64(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer);
-  let binary = '';
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
-}
 
 // Convert base64 to data URL for display
 function base64ToDataUrl(base64: string, mimeType: string): string {
@@ -123,8 +114,16 @@ export function SignatureSection({ config }: SignatureSectionProps) {
       return;
     }
 
-    const buffer = await file.arrayBuffer();
-    const base64 = arrayBufferToBase64(buffer);
+    let base64: string;
+    try {
+      base64 = await loadSignatureAsPngBase64(file);
+    } catch (err) {
+      showAppAlert({
+        title: "Couldn't read that image",
+        message: err instanceof Error ? err.message : 'Please try a different file.',
+      });
+      return;
+    }
 
     const signatureImage: SignatureImage = {
       name: file.name,

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -42,16 +42,7 @@ import type { Profile, SignatureImage } from '@/types/document';
 import type { UnitInfo } from '@/data/unitDirectory';
 import { ALL_SERVICE_RANKS, formatRank } from '@/data/ranks';
 import { canonicalizeUnitAddress } from '@/lib/unitAddress';
-
-// Convert ArrayBuffer to base64
-function arrayBufferToBase64(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer);
-  let binary = '';
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
-}
+import { loadSignatureAsPngBase64 } from '@/lib/signatureImage';
 
 // Convert base64 to data URL for display
 function base64ToDataUrl(base64: string, mimeType: string): string {
@@ -275,8 +266,16 @@ export function ProfileModal() {
       return;
     }
 
-    const buffer = await file.arrayBuffer();
-    const base64 = arrayBufferToBase64(buffer);
+    let base64: string;
+    try {
+      base64 = await loadSignatureAsPngBase64(file);
+    } catch (err) {
+      showAppAlert({
+        title: "Couldn't read that image",
+        message: err instanceof Error ? err.message : 'Please try a different file.',
+      });
+      return;
+    }
 
     const signatureImage: SignatureImage = {
       name: file.name,

--- a/src/lib/signatureImage.ts
+++ b/src/lib/signatureImage.ts
@@ -1,0 +1,56 @@
+/**
+ * Signature-image normalization.
+ *
+ * Uploaded signatures are embedded into the exported PDF via pdflatex's
+ * `\includegraphics`, which reads only PNG/JPG (never GIF) and picks the format
+ * from the file *extension* — and the compile pipeline always writes the bytes
+ * as `attachments/signature.png` with `\setSignatureImage{signature.png}`. So a
+ * JPG or GIF upload stored under that name renders wrong or fails the compile,
+ * and the in-app preview (which also assumed PNG) was equally wrong.
+ *
+ * Normalizing every non-PNG upload to real PNG bytes at load time makes
+ * `signature.png` / `image/png` honest everywhere at once — no per-format
+ * extension plumbing, and formats pdflatex can't embed (GIF, WebP) just work.
+ */
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('The image could not be decoded.'));
+    img.src = src;
+  });
+}
+
+/**
+ * Read an uploaded signature file and return PNG-encoded base64 (no data-URL
+ * prefix). PNG uploads pass through untouched; JPG/GIF/WebP are repainted onto a
+ * canvas and re-encoded as PNG with transparency preserved. Rejects if the image
+ * can't be decoded or a 2D canvas isn't available.
+ */
+export async function loadSignatureAsPngBase64(file: File): Promise<string> {
+  const buffer = await file.arrayBuffer();
+  if (file.type === 'image/png') return arrayBufferToBase64(buffer);
+
+  const url = URL.createObjectURL(new Blob([buffer], { type: file.type || 'application/octet-stream' }));
+  try {
+    const img = await loadImage(url);
+    const canvas = document.createElement('canvas');
+    canvas.width = img.naturalWidth || img.width;
+    canvas.height = img.naturalHeight || img.height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Image conversion is not available in this browser.');
+    ctx.drawImage(img, 0, 0);
+    const dataUrl = canvas.toDataURL('image/png');
+    return dataUrl.slice(dataUrl.indexOf(',') + 1);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/tests/unit/signatureImage.test.ts
+++ b/tests/unit/signatureImage.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { loadSignatureAsPngBase64 } from '@/lib/signatureImage';
+
+// The JPG/GIF→PNG canvas re-encode needs a real 2D canvas (unavailable in
+// happy-dom) and is verified in the browser. Here we lock in the PNG
+// pass-through: a PNG upload must be stored verbatim, not round-tripped.
+describe('loadSignatureAsPngBase64 — PNG pass-through', () => {
+  it('returns the input bytes as base64 for a PNG upload', async () => {
+    // PNG magic bytes + a little payload.
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4]);
+    const file = new File([bytes], 'signature.png', { type: 'image/png' });
+
+    const b64 = await loadSignatureAsPngBase64(file);
+
+    const decoded = atob(b64);
+    expect(decoded.length).toBe(bytes.length);
+    // Still a PNG (magic byte intact) — proves no re-encode happened.
+    expect(decoded.charCodeAt(0)).toBe(0x89);
+    expect(decoded.charCodeAt(1)).toBe(0x50);
+  });
+});


### PR DESCRIPTION
## Why — a real export bug
The signature-image pipeline assumed PNG end to end:
- both previews built the data URL with a hardcoded `image/png` (`ProfileModal`, `SignatureSection`),
- the compile writes the bytes to `attachments/signature.png` (App.tsx ×3) and emits `\setSignatureImage{signature.png}` (`generator.ts`).

But the upload `accept` allows `image/jpeg` and `image/gif`. pdflatex's `\includegraphics` picks the format from the **file extension** and **cannot embed GIF at all** — so a JPG or GIF signature stored under the `.png` name rendered wrong (or failed the compile), and the in-app preview was equally wrong.

## What
New `src/lib/signatureImage.ts` → `loadSignatureAsPngBase64(file)`: PNG uploads pass through untouched; JPG/GIF/WebP are repainted onto a canvas and re-encoded as **real PNG** (transparency preserved). Both upload handlers call it and show a themed alert if an image can't be decoded. Now `signature.png` / `image/png` are honest everywhere — no per-format extension plumbing, and formats pdflatex can't embed just work.

Existing stored signatures are left as-is (can't reliably re-decode at load); they normalize on the next re-upload.

## Verification
- **Live (real browser):** a JPEG built in-canvas (magic `ffd8`) run through the exact helper path comes out **valid PNG** (magic `89 50 4e 47`).
- Unit test locks in the PNG pass-through (no needless re-encode). `tsc -b` + build + eslint + `check-no-cdn` green; **1590/1590** tests pass.

Version 1.2.55.