### PR TITLE
fix(profile): surface an error when a non-image signature file is chosen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.56] — 2026-07-05
+
+### Fixed
+
+- Dropping or selecting a non-image file for a profile's signature now shows a
+  clear "image files only" message instead of silently doing nothing.
+
 ## [1.2.55] — 2026-07-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.55",
+  "version": "1.2.56",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -43,6 +43,7 @@ import type { UnitInfo } from '@/data/unitDirectory';
 import { ALL_SERVICE_RANKS, formatRank } from '@/data/ranks';
 import { canonicalizeUnitAddress } from '@/lib/unitAddress';
 import { loadSignatureAsPngBase64 } from '@/lib/signatureImage';
+import { isImageFile, rejectedFilesMessage } from '@/lib/fileFilter';
 
 // Convert base64 to data URL for display
 function base64ToDataUrl(base64: string, mimeType: string): string {
@@ -253,8 +254,8 @@ export function ProfileModal() {
 
   // Handle signature image upload
   const handleSignatureUpload = useCallback(async (file: File) => {
-    if (!file.type.startsWith('image/')) {
-      console.error('Only image files are supported');
+    if (!isImageFile(file)) {
+      showAppAlert({ title: 'Image files only', message: rejectedFilesMessage([file], 'image') });
       return;
     }
     // Signatures are stored base64 in localStorage; cap the size so they can't fill it.
@@ -310,8 +311,10 @@ export function ProfileModal() {
     e.preventDefault();
     setIsDragging(false);
 
+    // Hand any dropped file to the uploader; it validates the type and surfaces
+    // an error for non-images instead of the drop silently doing nothing.
     const file = e.dataTransfer.files[0];
-    if (file && file.type.startsWith('image/')) {
+    if (file) {
       handleSignatureUpload(file);
     }
   }, [handleSignatureUpload]);


### PR DESCRIPTION
## Why
Tier 1 #2 (silent file rejection). Triage found most of it already covered: EnclosuresManager's three attach points already guard via `partitionFiles`/`rejectedFilesMessage`, and SignatureSection's upload+drop already alert via `isImageFile`. The one remaining gap was **ProfileModal's signature**: the upload handler only `console.error`'d on a non-image (silent to the user) and the drop handler `if (file && file.type.startsWith('image/'))` silently ignored anything else.

## What (single file)
- `handleSignatureUpload`: `!file.type.startsWith('image/')` + `console.error` → `!isImageFile(file)` + `showAppAlert({ title: 'Image files only', message: rejectedFilesMessage([file], 'image') })`.
- `handleDrop`: drop the `.startsWith('image/')` gate so any dropped file reaches the (now-alerting) uploader — matching SignatureSection.

## Verification
`tsc -b` + build + eslint + `check-no-cdn` green; **1590/1590** tests pass. Uses the same fileFilter helpers already covered by `tests/unit/fileFilter.test.ts`; the alert path is identical to SignatureSection's.

Version 1.2.56.