### PR TITLE
fix(classification): remove classified levels from the custom quick-fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.57] — 2026-07-05
+
+### Fixed
+
+- The Custom Classification "quick fill" no longer offers CONFIDENTIAL, SECRET,
+  TOP SECRET, or TOP SECRET//SCI as one-click markings. This browser tool is not
+  accredited for classified processing, and those one-click presets let an
+  otherwise-unclassified document be stamped with a classified banner, bypassing
+  the domain check that keeps classified levels out of the main dropdown. The
+  quick fill now offers only unclassified caveats (Unclassified, CUI, For
+  Official Use Only). Classified levels remain available only through the
+  domain-gated Classification Level dropdown, on accredited networks. (A new
+  document still correctly defaults to Unclassified with no marking.)
+
 ## [1.2.56] — 2026-07-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.56",
+  "version": "1.2.57",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/ClassificationSection.tsx
+++ b/src/components/editor/ClassificationSection.tsx
@@ -39,13 +39,18 @@ const CLASSIFICATION_LEVELS = [
 // Quick-fill presets for the Custom Classification field. Tinted backgrounds use
 // the CNSI/ISOO banner colors so each button reads as a mini banner; the TOP
 // SECRET / SCI label text uses the darkened AA-safe variants from above.
+// Custom-mode quick-fill markings. Deliberately UNCLASSIFIED-only: this is a
+// browser-based tool that is NOT accredited for classified processing, and the
+// custom-mode warning says as much. The classified levels (CONFIDENTIAL, SECRET,
+// TOP SECRET, TS//SCI) are intentionally absent — they were previously offered
+// here as one-click presets, which let an unclassified document be stamped with
+// a classified banner and bypassed the domain-accreditation gate that removes
+// those levels from the Classification Level dropdown. Classified levels remain
+// selectable ONLY via that gated dropdown, on accredited domains.
 const CLASSIFICATION_PRESETS = [
-  { value: 'UNCLASSIFIED',    label: 'Unclassified',    color: 'text-[#007A33] dark:text-[#3DBE6B]', bg: 'bg-[#007A33]/10 dark:bg-[#007A33]/20 border-[#007A33]/30 hover:bg-[#007A33]/20 dark:hover:bg-[#007A33]/30' },
-  { value: 'CUI',             label: 'CUI',             color: 'text-[#502B85] dark:text-[#9572D4]', bg: 'bg-[#502B85]/10 dark:bg-[#502B85]/20 border-[#502B85]/30 hover:bg-[#502B85]/20 dark:hover:bg-[#502B85]/30' },
-  { value: 'CONFIDENTIAL',    label: 'CONFIDENTIAL',    color: 'text-[#0033A0] dark:text-[#5B7FD9]', bg: 'bg-[#0033A0]/10 dark:bg-[#0033A0]/20 border-[#0033A0]/30 hover:bg-[#0033A0]/20 dark:hover:bg-[#0033A0]/30' },
-  { value: 'SECRET',          label: 'SECRET',          color: 'text-[#C8102E] dark:text-[#E74C5C]', bg: 'bg-[#C8102E]/10 dark:bg-[#C8102E]/20 border-[#C8102E]/30 hover:bg-[#C8102E]/20 dark:hover:bg-[#C8102E]/30' },
-  { value: 'TOP SECRET',      label: 'TOP SECRET',      color: 'text-[#B45309] dark:text-[#FFA940]', bg: 'bg-[#FF8C00]/10 dark:bg-[#FF8C00]/20 border-[#FF8C00]/30 hover:bg-[#FF8C00]/20 dark:hover:bg-[#FF8C00]/30' },
-  { value: 'TOP SECRET//SCI', label: 'TOP SECRET//SCI', color: 'text-[#756808] dark:text-[#FCE83A]', bg: 'bg-[#FCE83A]/20 dark:bg-[#FCE83A]/20 border-[#A8920E]/40 hover:bg-[#FCE83A]/40 dark:hover:bg-[#FCE83A]/30' },
+  { value: 'UNCLASSIFIED',         label: 'Unclassified',         color: 'text-[#007A33] dark:text-[#3DBE6B]', bg: 'bg-[#007A33]/10 dark:bg-[#007A33]/20 border-[#007A33]/30 hover:bg-[#007A33]/20 dark:hover:bg-[#007A33]/30' },
+  { value: 'CUI',                  label: 'CUI',                  color: 'text-[#502B85] dark:text-[#9572D4]', bg: 'bg-[#502B85]/10 dark:bg-[#502B85]/20 border-[#502B85]/30 hover:bg-[#502B85]/20 dark:hover:bg-[#502B85]/30' },
+  { value: 'FOR OFFICIAL USE ONLY', label: 'FOR OFFICIAL USE ONLY', color: 'text-[#502B85] dark:text-[#9572D4]', bg: 'bg-[#502B85]/10 dark:bg-[#502B85]/20 border-[#502B85]/30 hover:bg-[#502B85]/20 dark:hover:bg-[#502B85]/30' },
 ];
 
 // Official CUI banner color (#502B85 / dark #9572D4), matching the level/preset

--- a/tests/component/ClassificationSection.test.tsx
+++ b/tests/component/ClassificationSection.test.tsx
@@ -68,6 +68,24 @@ describe('ClassificationSection', () => {
     expect(screen.queryByText('Classified Document Warning')).not.toBeInTheDocument();
   });
 
+  it('offers no classified marking in the custom quick-fill (this browser tool is not accredited)', async () => {
+    const user = userEvent.setup();
+    setLevel('custom');
+    render(<ClassificationSection />);
+
+    await user.click(screen.getByText('Classification')); // expand accordion
+
+    // The unclassified caveats are offered as one-click quick-fill…
+    expect(await screen.findByRole('button', { name: 'FOR OFFICIAL USE ONLY' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Unclassified' })).toBeInTheDocument();
+
+    // …but classified levels must NEVER be a one-click preset here. They are
+    // reachable only through the domain-accreditation-gated level dropdown.
+    for (const name of ['CONFIDENTIAL', 'SECRET', 'TOP SECRET', 'TOP SECRET//SCI']) {
+      expect(screen.queryByRole('button', { name })).not.toBeInTheDocument();
+    }
+  });
+
   it('shows neither classified nor CUI config for an unclassified document', async () => {
     const user = userEvent.setup();
     setLevel('unclassified');


### PR DESCRIPTION
## The problem (safety)
The Classification section's **Custom mode "Quick fill (click to apply)"** offered **CONFIDENTIAL, SECRET, TOP SECRET, and TOP SECRET//SCI** as one-click presets. Clicking one set `customClassification`, which the generator renders as a banner **verbatim**.

This is a real safety hole:
- The custom-mode warning directly above the presets states this is for **non-standard, UNCLASSIFIED markings** and *"Do not enter classified content into this browser-based tool."*
- Classified levels are deliberately **filtered out of the main Classification Level dropdown** on non-accredited domains (the `getDomainClassificationRestriction` gate) — but the quick-fill re-introduced them as one-click actions, bypassing that gate.
- Result: an otherwise-unclassified document could be one-click-stamped **TOP SECRET**.

## Not a defaulting bug
Verified end-to-end that a **new document correctly defaults to Unclassified with no marking**: the store initial state (`classLevel: 'unclassified'`), both generators (`generateClassificationTex` and the flat/DOCX path emit *no* markings for unclassified), and the LaTeX template (`\ClassificationEnabledfalse`, empty `\ClassificationMarking`). A truly fresh session (cleared localStorage + IndexedDB) shows "Unclassified". The TOP SECRET seen in a saved document came from a previously-applied custom preset, not a default.

## Fix
`CLASSIFICATION_PRESETS` now contains only unclassified caveats — **Unclassified, CUI, For Official Use Only**. Classified levels remain selectable **only** through the domain-accreditation-gated Classification Level dropdown, on accredited networks. Added a component regression test asserting the custom quick-fill exposes no CONFIDENTIAL/SECRET/TOP SECRET/TS//SCI button.

## Verification
`tsc -b` + build + eslint + `check-no-cdn` green; **1591/1591** tests pass (incl. the new invariant test). Confirmed live that the code default is Unclassified.

> Note for existing documents: this prevents new classified custom markings. A document already saved with a classified custom marking still shows it until its "Custom Classification Marking" field is cleared or the level is switched back to Unclassified.

Version 1.2.57.