### PR TITLE
fix(a11y): accessible names for copy-to, distribution, and enclosure-cover inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.58] — 2026-07-05
+
+### Accessibility
+
+- The copy-to recipient and action-addressee fields (and their remove buttons),
+  plus an enclosure's cover-page description, now carry proper accessible names
+  so screen-reader users hear what each field is instead of just "edit text".
+
 ## [1.2.57] — 2026-07-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.57",
+  "version": "1.2.58",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/CopyToManager.tsx
+++ b/src/components/editor/CopyToManager.tsx
@@ -46,11 +46,13 @@ export function CopyToManager() {
                   value={ct.text}
                   onChange={(e) => updateCopyTo(index, e.target.value)}
                   placeholder="Recipient…"
+                  aria-label={`Copy-to recipient ${index + 1}`}
                 />
                 <Button
                   variant="ghost"
                   size="icon"
                   onClick={() => removeCopyTo(index)}
+                  aria-label={`Remove copy-to recipient ${index + 1}`}
                   className="text-destructive hover:text-destructive"
                 >
                   <Trash2 className="h-4 w-4" />

--- a/src/components/editor/DistributionManager.tsx
+++ b/src/components/editor/DistributionManager.tsx
@@ -46,11 +46,13 @@ export function DistributionManager() {
                   value={d.text}
                   onChange={(e) => updateDistribution(index, e.target.value)}
                   placeholder="Action addressee…"
+                  aria-label={`Action addressee ${index + 1}`}
                 />
                 <Button
                   variant="ghost"
                   size="icon"
                   onClick={() => removeDistribution(index)}
+                  aria-label={`Remove action addressee ${index + 1}`}
                   className="text-destructive hover:text-destructive"
                 >
                   <Trash2 className="h-4 w-4" />

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -177,6 +177,7 @@ function SortableEnclosure({
               placeholder="Optional description for page…"
               value={enclosure.coverPageDescription || ''}
               onChange={(e) => onUpdateCoverDescription(e.target.value)}
+              aria-label={`Enclosure (${index + 1}) cover page description`}
               className="text-xs min-h-[60px]"
             />
           )}


### PR DESCRIPTION
## Why
Tier 1 #4 (placeholder-only inputs). Triage found most of it already done — References and Enclosures title/URL inputs already carry `aria-label`, and the ZIP/POC-email validation from Tier 1 #3 already exists. The remaining gaps: the **copy-to recipient** and **action-addressee** row inputs were placeholder-only (SRs hear "edit text"), their **icon-only remove buttons** had no accessible name, and the **enclosure cover-page description** textarea was unlabeled.

## What
- `CopyToManager`: recipient `Input` → `aria-label="Copy-to recipient N"`; remove `Button` → `aria-label="Remove copy-to recipient N"`.
- `DistributionManager`: addressee `Input` → `aria-label="Action addressee N"`; remove `Button` → `aria-label="Remove action addressee N"`.
- `EnclosuresManager`: cover-page description `Textarea` → `aria-label="Enclosure (N) cover page description"`.

Pure accessible-name attributes, no behaviour change.

## Verification
`tsc -b` + build + eslint + `check-no-cdn` green; **1591/1591** tests pass.

Version 1.2.58.