### PR TITLE
fix(classification): route advisory banners through the Notice primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.59] — 2026-07-05
+
+### Changed
+
+- The classified-document warning and the custom-classification handling notice
+  now use the shared themed notice component, so they match every other in-app
+  notice and the caution notice draws its amber from the theme (tracking light/
+  dark and every color scheme) instead of a hard-coded shade.
+
 ## [1.2.58] — 2026-07-05
 
 ### Accessibility

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.58",
+  "version": "1.2.59",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/ClassificationSection.tsx
+++ b/src/components/editor/ClassificationSection.tsx
@@ -7,6 +7,7 @@ import {
 import { useDocumentStore } from '@/stores/documentStore';
 import { Shield, AlertTriangle, Info } from 'lucide-react';
 import { HelpTip } from '@/components/ui/help-tip';
+import { Notice } from '@/components/ui/notice';
 import {
   getDomainClassificationRestriction,
   getDomainRestrictionMessage,
@@ -212,7 +213,7 @@ export function ClassificationSection() {
 
             {/* Warning for classified documents */}
             {isClassified && (
-              <div className="flex items-start gap-2 p-3 rounded-md bg-destructive/10 border border-destructive/20">
+              <Notice variant="error" className="flex items-start gap-2">
                 <AlertTriangle aria-hidden="true" className="h-4 w-4 text-destructive mt-0.5 shrink-0" />
                 <div className="text-sm text-destructive">
                   <p className="font-medium"><span className="sr-only">Warning: </span>Classified Document Warning</p>
@@ -221,7 +222,7 @@ export function ClassificationSection() {
                     procedures are followed per applicable security regulations.
                   </p>
                 </div>
-              </div>
+              </Notice>
             )}
 
             {/* Custom mode holds the marking text plus all CUI/Classified
@@ -232,9 +233,9 @@ export function ClassificationSection() {
               <div className="space-y-4 p-3 rounded-md border bg-muted/30">
                 <p className="text-sm font-medium">Custom Classification</p>
 
-                <div className="flex items-start gap-2 p-3 rounded-md bg-amber-50 border border-amber-200 dark:bg-amber-950/30 dark:border-amber-800">
-                  <AlertTriangle aria-hidden="true" className="h-4 w-4 text-amber-700 dark:text-amber-400 mt-0.5 shrink-0" />
-                  <div className="text-sm text-amber-800 dark:text-amber-300">
+                <Notice variant="warning" className="flex items-start gap-2">
+                  <AlertTriangle aria-hidden="true" className="h-4 w-4 text-warning mt-0.5 shrink-0" />
+                  <div className="text-sm text-warning">
                     <p className="font-medium"><span className="sr-only">Warning: </span>Classification handling — non-accredited system</p>
                     <p className="text-xs mt-1">
                       Per DoDM 5200.01 Vol 3 and EO 13526, classified
@@ -255,7 +256,7 @@ export function ClassificationSection() {
                       security regulations.
                     </p>
                   </div>
-                </div>
+                </Notice>
 
                 <div className="space-y-2">
                   <Label htmlFor="customClassification">Custom Classification Marking</Label>


### PR DESCRIPTION
## Why
Tier 2 #7 (Classification polish). Triage found most sub-items already done — decorative icons have `aria-hidden`, the CUI header uses the official `#502B85` token (not `text-purple-600`), the POC-email inputs already validate, and the preset chips are `py-1` (~24px). The one real item: three divergent advisory-banner treatments, one of which still hardcoded raw `amber-50/200`.

## What
Convert the two **boxed** advisories to the shared `Notice` primitive (already used in NISTComplianceModal, UpdatePromptModal, EnclosureErrorModal):
- **Classified Document Warning** → `<Notice variant="error">` (was a one-off `bg-destructive/10` box).
- **Custom-mode handling caution** → `<Notice variant="warning">`, with its icon/text moved to `text-warning` (was raw `amber-50` / `amber-200` / `amber-700` / `amber-800`).

Left intentionally: the **Domain-Restrictions** note keeps its lighter blue left-rule. Notice's `info` variant is `--primary`-tinted, and `--primary` is USMC scarlet — a red tint on a benign "your domain limits classification levels" note would read as danger. No blue token exists to route it through, so it stays a deliberate light-info exception.

## Verification
Live (drove the store into Custom mode): the handling banner is now `[data-slot="notice"]` with background/border computing to the `--warning` token (oklab 0.83 @ 85°, 10%/30%), and **zero `amber-*` classes remain** on the page. `tsc -b` + build + eslint + `check-no-cdn` green; ClassificationSection tests (5) + full suite **1591/1591** pass.

Version 1.2.59.