### PR TITLE
fix(pdf): make the zoom-percent readout a click-to-reset control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.60] — 2026-07-05
+
+### Changed
+
+- The zoom percentage in the PDF viewer toolbar is now a button — click it to
+  reset the zoom to fit-width — instead of a static label.
+
 ## [1.2.59] — 2026-07-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.59",
+  "version": "1.2.60",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/pdf/PdfViewerToolbar.tsx
+++ b/src/components/pdf/PdfViewerToolbar.tsx
@@ -156,9 +156,19 @@ export function PdfViewerToolbar({
       <ToolButton label="Zoom out" onClick={onZoomOut}>
         <ZoomOut className="h-4 w-4" />
       </ToolButton>
-      <span className="tnum hidden min-w-[3rem] text-center text-xs text-muted-foreground @[300px]:block">
-        {zoomPercent}%
-      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={onZoomFitWidth}
+            aria-label={`Zoom ${zoomPercent} percent — reset to fit width`}
+            className="tnum hidden min-w-[3rem] rounded text-center text-xs text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 @[300px]:block"
+          >
+            {zoomPercent}%
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Reset zoom (fit width)</TooltipContent>
+      </Tooltip>
       <ToolButton label="Zoom in" onClick={onZoomIn}>
         <ZoomIn className="h-4 w-4" />
       </ToolButton>


### PR DESCRIPTION
## Why
Tier 2 #8 (PDF viewer toolbar). Triage found nearly all of it already done: the toolbar buttons are `h-8` (32px, not the flagged 28px), the Fit-width/Fit-page toggles already render a `bg-primary/10 text-primary` fill when pressed (the code comment: "a toned fill, not just an icon tint… without relying on color alone"), a Download control exists, and `@container` queries keep the readouts reachable in narrow panels. The one real item: the zoom `%` was a static `<span>` — a dead label.

## What
Turn the zoom-percent readout into a `<button>` that resets zoom to fit-width (via the existing `onZoomFitWidth`), with a hover color shift, the house focus ring, an accessible name (`Zoom N percent — reset to fit width`), and a "Reset zoom (fit width)" tooltip.

**Deferred:** page-render skeletons (blank `bg-white` while a page paints) — that's page-layer work in `PdfPageLayer` and lower value; noted for a follow-up.

## Verification
`tsc -b` + build + eslint + `check-no-cdn` green; **1591/1591** tests pass.

Version 1.2.60.