### PR TITLE
fix(ui): tier-2 leftovers — mobile form grids, casing, welcome shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.61] — 2026-07-05
+
+### Changed
+
+- The two-column rows on the NAVMC 6105 and 11811 forms now stack into one
+  column on phones instead of staying cramped side by side.
+- The document guide's reset button reads "Start over" consistently.
+- The welcome screen's letter preview uses the standard elevation shadow instead
+  of a hard-coded heavy black drop.
+
 ## [1.2.60] — 2026-07-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.60",
+  "version": "1.2.61",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/Form11811Section.tsx
+++ b/src/components/editor/Form11811Section.tsx
@@ -163,7 +163,7 @@ export function Form11811Section() {
             <span className="font-medium">6105 Entry Content</span>
           </AccordionTrigger>
           <AccordionContent className="space-y-4 pt-2">
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <div className="space-y-2">
                 <Label htmlFor="remarksText">Administrative Remarks (Left)</Label>
                 <VariableChipEditor

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -183,7 +183,7 @@ export function Form6105Section() {
             <span className="font-medium">Addressing</span>
           </AccordionTrigger>
           <AccordionContent className="space-y-4 pt-2">
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <div className="space-y-2">
                 <Label htmlFor="from">4. From (Grade, Name, EDIPI, MOS, etc.)</Label>
                 <TextareaWithVariables

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -179,7 +179,7 @@ function DocumentFinder({ onSelectGuide }: { onSelectGuide: (guideId: string) =>
         <div className="pt-4 border-t">
           <Button variant="outline" onClick={handleReset} className="w-full">
             <RotateCcw className="h-4 w-4 mr-2" />
-            Start Over
+            Start over
           </Button>
         </div>
       </div>

--- a/src/components/modals/WelcomeModal.tsx
+++ b/src/components/modals/WelcomeModal.tsx
@@ -103,7 +103,7 @@ export function WelcomeModal() {
         {/* The welcome message, drafted as a naval letter on cream paper. */}
         <div className="flex-1 overflow-y-auto min-h-0 p-4 pb-0">
           <div
-            className="rounded-[3px] px-6 py-6 sm:px-8 shadow-[0_12px_34px_rgba(0,0,0,0.55)]"
+            className="rounded-[3px] px-6 py-6 sm:px-8 shadow-xl"
             style={{ backgroundColor: PAPER_BG, color: INK, fontFamily: SERIF }}
           >
             {/* Letterhead: the wide Marine Coders lockup, engraved in black. */}


### PR DESCRIPTION
## Why
A batch-triage of the remaining Tier-2 sections (Command Palette #9, NAVMC forms #10, Welcome/Tour #11, Editor Sidebar #12) found most sub-items **already done**:
- **#9 Command Palette** — fully stale: pointer-move-gated hover, ↵/↑↓/esc footer, `Kbd active` inversion, navy-remapped shadow, `rounded-lg`, and an iconned `SearchX` empty state all present.
- **#12 Editor Sidebar** — fully stale: collapse/New buttons already have focus rings, sub-labels are `text-2xs muted-foreground`, micro-labels are `--text-2xs`, single left-bar active indicator.

This PR cherry-picks the **three genuinely-real, low-risk** items:

## What
1. **NAVMC forms don't collapse on mobile** — `Form6105Section` and `Form11811Section` had bare `grid grid-cols-2` (no breakpoint), so two-column rows stayed cramped on phones → `grid-cols-1 gap-4 sm:grid-cols-2`.
2. **"Start Over" → "Start over"** in `DocumentGuideModal` (it already used the lowercase form elsewhere in the same file).
3. **WelcomeModal letter-preview shadow** — hard-coded `shadow-[0_12px_34px_rgba(0,0,0,0.55)]` (heavier than its own dialog, off the ladder) → `shadow-xl` (navy ladder).

## Deferred (need a decision, not mechanical) — flagged for you
- `COMMON_FORM_VARS` possibly listing variables that never resolve (data verification).
- Tour running on mobile (product decision).
- MobileRecents pin/delete under the 44px touch target (mobile-layout change).

## Verification
`tsc -b` + build + eslint + `check-no-cdn` green; **1591/1591** tests pass.

Version 1.2.61.