### PR TITLE
fix(letterhead): Blue color swatch renders yellow in the USMC theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.62] — 2026-07-05
+
+### Fixed
+
+- The "Blue" swatch in the letterhead color picker now shows navy blue in every
+  theme. It was borrowing the theme's brand-accent color, which is gold in the
+  USMC theme (and its dark mode) and red in another — so the "Blue" option looked
+  yellow. The swatch now uses the actual navy the letterhead prints (RGB 0,32,91).
+
 ## [1.2.61] — 2026-07-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.61",
+  "version": "1.2.62",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/LetterheadSection.tsx
+++ b/src/components/editor/LetterheadSection.tsx
@@ -168,7 +168,7 @@ export function LetterheadSection() {
                       <SelectContent>
                         <SelectItem value="blue">
                           <span className="flex items-center gap-2">
-                            <span className="h-3 w-3 shrink-0 rounded-full border border-border bg-brand-accent" aria-hidden="true" />
+                            <span className="h-3 w-3 shrink-0 rounded-full border border-border bg-[#00205B]" aria-hidden="true" />
                             Blue
                           </span>
                         </SelectItem>


### PR DESCRIPTION
## Bug
In dark mode (and the USMC theme generally), the letterhead color picker's **"Blue"** option showed a **yellow/gold** swatch dot.

## Cause
The Blue swatch used `bg-brand-accent`. `--brand-accent` is the *per-scheme brand highlight*, not a fixed blue: it's navy in the default/navy schemes but **gold** (`oklch(0.80 0.15 85)` / sRGB `#eab532`) in the USMC scheme and its dark mode, and **red** in another. So the swatch meant to represent "blue letterhead ink" rendered gold.

## Fix
Use the actual navy the letterhead prints — `navyblue = RGB(0,32,91)` = `#00205B` (from `tex/main.tex` / the flat generator) — as a **fixed** color, matching the fixed `bg-black` the Black swatch already uses. The swatch is now honest (matches the PDF output) and theme-independent.

## Verification (live)
Computed swatch background = `rgb(0, 32, 91)` across **default / navy / usmc × light / dark** (previously gold in usmc/dark). `tsc -b` + build + eslint + `check-no-cdn` green; **1591/1591** tests pass.

Version 1.2.62.