### PR TITLE
fix(a11y): accessible names for reference/enclosure remove buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.63] — 2026-07-05
+
+### Accessibility
+
+- The remove buttons on references and enclosures (and the "remove attached PDF"
+  button) now carry accessible names, so screen-reader users hear what each
+  destructive button does instead of just "button".
+
 ## [1.2.62] — 2026-07-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.62",
+  "version": "1.2.63",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -126,6 +126,7 @@ function SortableEnclosure({
                   variant="ghost"
                   size="sm"
                   onClick={onRemoveFile}
+                  aria-label={`Remove attached PDF from enclosure ${index + 1}`}
                   className="h-6 w-6 p-0 shrink-0"
                 >
                   <X className="h-3 w-3" />
@@ -188,6 +189,7 @@ function SortableEnclosure({
           variant="ghost"
           size="icon"
           onClick={onRemove}
+          aria-label={`Remove enclosure ${index + 1}`}
           className="text-destructive hover:text-destructive"
         >
           <Trash2 className="h-4 w-4" />

--- a/src/components/editor/ReferencesManager.tsx
+++ b/src/components/editor/ReferencesManager.tsx
@@ -134,6 +134,7 @@ const SortableReference = memo(function SortableReference({
           variant="ghost"
           size="icon"
           onClick={() => removeReference(index)}
+          aria-label={`Remove reference ${index + 1}`}
           className="text-destructive hover:text-destructive"
         >
           <Trash2 className="h-4 w-4" />


### PR DESCRIPTION
## Why
Audit triage (verified real): the icon-only **Trash2** remove buttons on references and enclosures — and the **X** "remove attached PDF" button — had no `aria-label`, `title`, or text, so screen readers announced each destructive control as a bare "button". (The drag handles and title/URL inputs already have accessible names; these remove buttons were the gap.)

## What
- `ReferencesManager`: remove `Button` → `aria-label="Remove reference N"`.
- `EnclosuresManager`: row remove → `aria-label="Remove enclosure N"`; file-remove X → `aria-label="Remove attached PDF from enclosure N"`.

Pure accessible-name attributes, no behaviour change.

## Verification
`tsc -b` + build + eslint + `check-no-cdn` green; **1591/1591** tests pass.

Version 1.2.63.