### PR TITLE
fix(shortcuts): show mac-native Redo (⌘⇧Z) instead of ⌘Y on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.64] — 2026-07-05
+
+### Fixed
+
+- On macOS, the Redo control now shows its native ⌘⇧Z shortcut instead of ⌘Y
+  (Windows/Linux still show Ctrl+Y). Both gestures already worked; only the
+  displayed hint was wrong on Mac.
+
 ## [1.2.63] — 2026-07-05
 
 ### Accessibility

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.63",
+  "version": "1.2.64",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,7 +4,11 @@ import { GithubIcon } from '@/components/icons/GithubIcon';
 import { Button } from '@/components/ui/button';
 import { Kbd } from '@/components/ui/kbd';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { formatShortcut } from '@/lib/platform';
+import { formatShortcut, isMac } from '@/lib/platform';
+
+// Redo is Ctrl+Y on Windows/Linux but ⌘⇧Z on macOS; the handler accepts both,
+// so display the native gesture per platform.
+const REDO_SHORTCUT = isMac ? 'mod shift Z' : 'mod Y';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -751,7 +755,7 @@ export function Header({
               <Undo2 className="h-4 w-4" aria-hidden="true" />
             </Button>
           </HeaderTip>
-          <HeaderTip label={`Redo (${formatShortcut('mod Y')})`}>
+          <HeaderTip label={`Redo (${formatShortcut(REDO_SHORTCUT)})`}>
             <Button
               variant="ghost"
               size="icon"
@@ -1084,7 +1088,7 @@ export function Header({
                   <div className="text-muted-foreground">Toggle Preview</div>
                   <div className="font-mono text-right">{formatShortcut('mod E')}</div>
                   <div className="text-muted-foreground">Undo / Redo</div>
-                  <div className="font-mono text-right">{formatShortcut('mod Z')} / {formatShortcut('mod Y')}</div>
+                  <div className="font-mono text-right">{formatShortcut('mod Z')} / {formatShortcut(REDO_SHORTCUT)}</div>
                 </div>
               </div>
             </DropdownMenuContent>


### PR DESCRIPTION
## Why
Audit (verified real): the Redo tooltip (Header.tsx:754) and the help panel (Header.tsx:1087) displayed `formatShortcut('mod Y')` → **⌘Y** on macOS, but the mac-native redo gesture is **⌘⇧Z**. `formatShortcut` only maps `mod`→⌘; it doesn't rewrite the key.

Importantly, the keyboard **handler already accepts both**: `App.tsx:1543` fires redo on `e.key === 'y' || (e.key === 'z' && e.shiftKey)`. So ⌘⇧Z already worked on Mac — only the displayed hint was wrong.

## What
Add a `REDO_SHORTCUT = isMac ? 'mod shift Z' : 'mod Y'` constant and use it in both the toolbar tooltip and the help panel. Now:
- macOS: **⌘⇧Z**
- Windows/Linux: **Ctrl+Y** (unchanged; still the standard PC redo)

## Verification
`tsc -b` + build + eslint + `check-no-cdn` green; **1591/1591** tests pass. (No behaviour change — the handler already bound both gestures.)

Version 1.2.64.