### PR TITLE
fix(ui): show the Save-draft keyboard shortcut in the menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.65] — 2026-07-05
+
+### Changed
+
+- The "Save draft" menu item now shows its keyboard shortcut, matching the other
+  shortcut-bearing menu items.
+
 ## [1.2.64] — 2026-07-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.64",
+  "version": "1.2.65",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -830,6 +830,7 @@ export function Header({
               <DropdownMenuItem onClick={handleSaveProgress}>
                 <Save className="h-4 w-4 mr-2" />
                 Save draft
+                <DropdownMenuShortcut>{formatShortcut('mod S')}</DropdownMenuShortcut>
               </DropdownMenuItem>
               <DropdownMenuItem onClick={handleLoadProgress}>
                 <FolderOpen className="h-4 w-4 mr-2" />


### PR DESCRIPTION
Audit (verified real): the **Save draft** dropdown item advertised no keycap, even though the shortcut is wired and shown in the help panel — unlike the Download PDF item which renders a `DropdownMenuShortcut`. Add `<DropdownMenuShortcut>{formatShortcut('mod S')}</DropdownMenuShortcut>` to match. (The help panel already pairs 'Save Draft' with ⌘S correctly — no change there.) tsc-b + build + eslint + check-no-cdn green; 1591/1591 tests pass. Version 1.2.65.