### PR TITLE
fix(ui): unify the mobile 'Generating PDF' copy with desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.66] — 2026-07-05
+
+### Changed
+
+- The "Generating PDF" message now reads the same on mobile as on desktop
+  ("Generating PDF… — This should only take a moment."), with a real ellipsis.
+
 ## [1.2.65] — 2026-07-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.65",
+  "version": "1.2.66",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/modals/MobilePreviewModal.tsx
+++ b/src/components/modals/MobilePreviewModal.tsx
@@ -106,8 +106,8 @@ export function MobilePreviewModal({ pdfUrl, isCompiling, error }: MobilePreview
               <Loader2 className="h-8 w-8 animate-spin text-primary absolute -bottom-1 -right-1 bg-background rounded-full p-1" />
             </div>
             <div className="text-center">
-              <p className="font-medium">Generating PDF...</p>
-              <p className="text-sm text-muted-foreground mt-1">This may take a moment</p>
+              <p className="font-medium">Generating PDF…</p>
+              <p className="text-sm text-muted-foreground mt-1">This should only take a moment.</p>
             </div>
           </div>
         )}


### PR DESCRIPTION
Audit (verified real): the mobile preview modal (`MobilePreviewModal.tsx:109`) showed **'Generating PDF...'** (ASCII dots) / **'This may take a moment'** (no period), while desktop (`PreviewPanel.tsx:176`) shows **'Generating PDF…'** (ellipsis glyph) / **'This should only take a moment.'**. Aligned the mobile copy to the desktop canonical. tsc-b + build + eslint + check-no-cdn green; 1591/1591 tests pass. Version 1.2.66.