### PR TITLE
fix(signature): stop drag-over highlight flicker on the signature drop zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.67] — 2026-07-05
+
+### Fixed
+
+- The signature drag-and-drop zone (in the signature block and in the profile
+  editor) no longer flickers its highlight as you move the file over it. The
+  highlight now clears only when the file actually leaves the zone.
+
 ## [1.2.66] — 2026-07-05
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.66",
+  "version": "1.2.67",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -152,6 +152,10 @@ export function SignatureSection({ config }: SignatureSectionProps) {
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     e.preventDefault();
+    // `dragleave` also fires when the cursor crosses the drop zone's own child
+    // elements (the icon, label, input). Only clear the active tint when the
+    // pointer actually leaves the zone — otherwise the border flickers on/off.
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
     setIsDragging(false);
   }, []);
 

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -304,6 +304,9 @@ export function ProfileModal() {
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     e.preventDefault();
+    // `dragleave` fires when crossing the drop zone's own children too; only
+    // clear the active tint when the pointer truly leaves, to avoid flicker.
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
     setIsDragging(false);
   }, []);
 


### PR DESCRIPTION
## Bug (verified real)
The signature drop zone's active highlight **flickered on/off** while dragging a file over it. `handleDragLeave` called `setIsDragging(false)` unconditionally — but `dragleave` also fires every time the cursor crosses one of the zone's own child elements (the `Upload` icon, the label text, the hidden `<input>`), so the tint snapped off and back on repeatedly.

## Fix
Guard `handleDragLeave` with `if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;` — on `dragleave`, `relatedTarget` is the element being entered, so if it's still inside the drop zone we're just crossing a child and must not clear. The tint now clears only when the pointer truly leaves the zone.

Applied to **both** the `SignatureSection` drop zone (the flagged one) and the identical `ProfileModal` signature drop zone.

## Verification
`tsc -b` + build + eslint + `check-no-cdn` green; **1591/1591** tests pass.

Version 1.2.67.