### PR TITLE
feat(editor): confirm before removing a reference or enclosure that has content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.68] — 2026-07-05
+
+### Added
+
+- Removing a reference or an enclosure that has content — a title, a URL, or an
+  attached PDF — now asks for confirmation first, so a stray click can't quietly
+  delete your work (and, for references, silently re-letter the rest of the
+  list). Blank rows still clear in a single click.
+
 ## [1.2.67] — 2026-07-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.10",
+  "version": "1.2.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.10",
+      "version": "1.2.68",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.67",
+  "version": "1.2.68",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -12,7 +12,7 @@ import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { partitionFiles, rejectedFilesMessage, isPdfFile } from '@/lib/fileFilter';
-import { showAppAlert } from '@/stores/alertStore';
+import { showAppAlert, showAppConfirm } from '@/stores/alertStore';
 import {
   Select,
   SelectContent,
@@ -248,6 +248,39 @@ export function EnclosuresManager() {
     });
   }, [updateEnclosure]);
 
+  // Confirm before dropping an enclosure that holds anything — a title or an
+  // attached PDF (the latter is real uploaded data). A blank row still deletes
+  // in one click.
+  const handleRemoveEnclosure = useCallback(async (index: number, encl: Enclosure) => {
+    const hasContent = (encl.title ?? '').trim() !== '' || !!encl.file;
+    if (hasContent) {
+      const confirmed = await showAppConfirm({
+        title: 'Remove enclosure?',
+        message: encl.file
+          ? `Enclosure (${index + 1}) and its attached PDF “${encl.file.name}” will be removed.`
+          : `Enclosure (${index + 1}) will be removed.`,
+        confirmLabel: 'Remove',
+        destructive: true,
+      });
+      if (!confirmed) return;
+    }
+    removeEnclosure(index);
+  }, [removeEnclosure]);
+
+  // Detaching a PDF discards the uploaded bytes — always confirm.
+  const handleRemoveFile = useCallback(async (index: number, encl: Enclosure) => {
+    if (encl.file) {
+      const confirmed = await showAppConfirm({
+        title: 'Remove attached PDF?',
+        message: `“${encl.file.name}” will be detached from enclosure (${index + 1}).`,
+        confirmLabel: 'Remove',
+        destructive: true,
+      });
+      if (!confirmed) return;
+    }
+    updateEnclosure(index, { file: undefined, fileRef: undefined });
+  }, [updateEnclosure]);
+
   const handleUploadNewEnclosure = useCallback(async (file: File) => {
     // Extract filename without extension for the title
     const title = file.name.replace(/\.pdf$/i, '');
@@ -374,8 +407,8 @@ export function EnclosuresManager() {
                       index={index}
                       onUpdateTitle={(title) => updateEnclosure(index, { title })}
                       onAttachFile={(file) => handleAttachFile(index, file)}
-                      onRemoveFile={() => updateEnclosure(index, { file: undefined, fileRef: undefined })}
-                      onRemove={() => removeEnclosure(index)}
+                      onRemoveFile={() => handleRemoveFile(index, encl)}
+                      onRemove={() => handleRemoveEnclosure(index, encl)}
                       onUpdatePageStyle={(pageStyle) => updateEnclosure(index, { pageStyle })}
                       onUpdateCoverPage={(hasCoverPage) => updateEnclosure(index, { hasCoverPage })}
                       onUpdateCoverDescription={(coverPageDescription) => updateEnclosure(index, { coverPageDescription })}

--- a/src/components/editor/ReferencesManager.tsx
+++ b/src/components/editor/ReferencesManager.tsx
@@ -19,6 +19,7 @@ import {
 import { HelpTip } from '@/components/ui/help-tip';
 import { useDocumentStore } from '@/stores/documentStore';
 import { useUIStore } from '@/stores/uiStore';
+import { showAppConfirm } from '@/stores/alertStore';
 import type { Reference } from '@/types/document';
 import { DOC_TYPE_CONFIG } from '@/types/document';
 import { safeUrl } from '@/lib/url-safety';
@@ -64,6 +65,23 @@ const SortableReference = memo(function SortableReference({
   const trimmedUrl = (reference.url ?? '').trim();
   const urlInvalid = trimmedUrl !== '' && safeUrl(trimmedUrl) === null;
   const urlWarningId = `ref-${index}-url-warning`;
+
+  // Removing a reference re-letters every reference after it — an easy misclick
+  // to make and awkward to undo. Confirm first, but only when the row actually
+  // holds something; discarding a blank row should stay a single click.
+  const handleRemove = async () => {
+    const hasContent = (reference.title ?? '').trim() !== '' || trimmedUrl !== '';
+    if (hasContent) {
+      const confirmed = await showAppConfirm({
+        title: 'Remove reference?',
+        message: `Reference (${reference.letter}) will be removed and the remaining references re-lettered.`,
+        confirmLabel: 'Remove',
+        destructive: true,
+      });
+      if (!confirmed) return;
+    }
+    removeReference(index);
+  };
 
   return (
     <div
@@ -133,7 +151,7 @@ const SortableReference = memo(function SortableReference({
         <Button
           variant="ghost"
           size="icon"
-          onClick={() => removeReference(index)}
+          onClick={handleRemove}
           aria-label={`Remove reference ${index + 1}`}
           className="text-destructive hover:text-destructive"
         >


### PR DESCRIPTION
Removing a reference or enclosure was immediate and unrecoverable. For references it's worse: `removeReference` re-letters every reference after the deleted one, so a misclick can silently reshuffle (a)/(b)/(c)… across the document.

Now a removal is routed through the themed in-app confirm dialog **only when the row holds content**:

- **Reference** — has a title or a URL. Message notes the re-lettering.
- **Enclosure** — has a title or an attached PDF.
- **Attached PDF (X)** — always confirms, since detaching discards uploaded bytes.

Blank rows still delete in a single click — no new friction for the common "added an empty row by mistake" case.

Reuses the existing `showAppConfirm` primitive (Cancel/Remove, destructive styling). No store or data-model changes.

Verified: build 0, lint 0, check-no-cdn OK; live-checked the confirm dialog renders (Cancel/Remove, destructive) and resolves false on cancel.