### PR TITLE
fix(signature): make the signature-style selector a real radio group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.69] — 2026-07-05
+
+### Fixed
+
+- The signature-style selector (Typed Only / Upload Image / Digital Field) is
+  now a proper radio group. It was three independent toggle buttons, so a
+  screen reader announced them as unrelated controls instead of one choice, and
+  keyboard users had to Tab through each. It now announces as a single group,
+  and the arrow keys move the selection between the three options.
+
 ## [1.2.68] — 2026-07-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.68",
+  "version": "1.2.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.68",
+      "version": "1.2.69",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.68",
+  "version": "1.2.69",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -53,6 +53,15 @@ function isStandardOfficeCode(code: string): boolean {
 interface SignatureSectionProps {
   config: DocTypeConfig;
 }
+
+// The three mutually-exclusive signature styles. Rendered as a real radio
+// group (roving focus + arrow keys) rather than independent toggle buttons so
+// a screen reader announces "1 of 3" and keyboard users arrow between them.
+const SIGNATURE_STYLES = [
+  { value: 'none', Icon: Type, label: 'Typed Only' },
+  { value: 'image', Icon: PenLine, label: 'Upload Image' },
+  { value: 'digital', Icon: Shield, label: 'Digital Field' },
+] as const;
 
 export function SignatureSection({ config }: SignatureSectionProps) {
   const { formData, setField, documentMode } = useDocumentStore();
@@ -175,6 +184,31 @@ export function SignatureSection({ config }: SignatureSectionProps) {
   const handleRemoveSignature = useCallback(() => {
     setField('signatureImage', undefined);
   }, [setField]);
+
+  // Signature-style radio group: select a style and drop any uploaded image
+  // when leaving the "image" option (its bytes are meaningless for typed or
+  // digital signatures).
+  const currentSignatureStyle = (formData.signatureType || 'none') as SignatureType;
+  const styleRadioRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const selectSignatureStyle = useCallback((value: SignatureType) => {
+    setField('signatureType', value);
+    if (value !== 'image' && formData.signatureImage) {
+      setField('signatureImage', undefined);
+    }
+  }, [setField, formData.signatureImage]);
+
+  // Roving focus: arrow keys move selection and focus between the styles, wrap
+  // at the ends — the keyboard model a radio group is expected to have.
+  const handleStyleKeyDown = useCallback((e: React.KeyboardEvent, index: number) => {
+    let next: number;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (index + 1) % SIGNATURE_STYLES.length;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (index - 1 + SIGNATURE_STYLES.length) % SIGNATURE_STYLES.length;
+    else return;
+    e.preventDefault();
+    selectSignatureStyle(SIGNATURE_STYLES[next].value);
+    styleRadioRefs.current[next]?.focus();
+  }, [selectSignatureStyle]);
 
   return (
     <>
@@ -446,60 +480,38 @@ export function SignatureSection({ config }: SignatureSectionProps) {
             {/* Signature Type Selection */}
             <div data-tour="signature-style" className="space-y-3">
               <Label>Signature Style</Label>
-              {/* All signature options available */}
-                <div className="grid grid-cols-3 gap-2">
-                    {/* Selected style reads as a tinted ring (border + 10% tint +
-                        primary text), not a solid scarlet fill — a quieter
-                        selection state that keeps Download the one scarlet primary. */}
-                    <button
-                      type="button"
-                      aria-pressed={(formData.signatureType || 'none') === 'none'}
-                      className={`flex flex-col items-center gap-1.5 rounded-md border py-3 px-1.5 text-xs font-medium cursor-pointer transition-colors ${
-                        (formData.signatureType || 'none') === 'none'
-                          ? 'border-primary bg-primary/10 text-primary'
-                          : 'border-border text-foreground hover:bg-muted/40'
-                      }`}
-                      onClick={() => {
-                        setField('signatureType', 'none' as SignatureType);
-                        if (formData.signatureImage) {
-                          setField('signatureImage', undefined);
-                        }
-                      }}
-                    >
-                      <Type className="h-5 w-5" />
-                      <span>Typed Only</span>
-                    </button>
-                    <button
-                      type="button"
-                      aria-pressed={formData.signatureType === 'image'}
-                      className={`flex flex-col items-center gap-1.5 rounded-md border py-3 px-1.5 text-xs font-medium cursor-pointer transition-colors ${
-                        formData.signatureType === 'image'
-                          ? 'border-primary bg-primary/10 text-primary'
-                          : 'border-border text-foreground hover:bg-muted/40'
-                      }`}
-                      onClick={() => setField('signatureType', 'image' as SignatureType)}
-                    >
-                      <PenLine className="h-5 w-5" />
-                      <span>Upload Image</span>
-                    </button>
-                    <button
-                      type="button"
-                      aria-pressed={formData.signatureType === 'digital'}
-                      className={`flex flex-col items-center gap-1.5 rounded-md border py-3 px-1.5 text-xs font-medium cursor-pointer transition-colors ${
-                        formData.signatureType === 'digital'
-                          ? 'border-primary bg-primary/10 text-primary'
-                          : 'border-border text-foreground hover:bg-muted/40'
-                      }`}
-                      onClick={() => {
-                        setField('signatureType', 'digital' as SignatureType);
-                        if (formData.signatureImage) {
-                          setField('signatureImage', undefined);
-                        }
-                      }}
-                    >
-                      <Shield className="h-5 w-5" />
-                      <span>Digital Field</span>
-                    </button>
+              {/* All signature options available. Selected style reads as a
+                  tinted ring (border + 10% tint + primary text), not a solid
+                  scarlet fill — a quieter selection state that keeps Download
+                  the one scarlet primary. */}
+                <div
+                  role="radiogroup"
+                  aria-label="Signature style"
+                  className="grid grid-cols-3 gap-2"
+                >
+                    {SIGNATURE_STYLES.map((style, index) => {
+                      const selected = currentSignatureStyle === style.value;
+                      return (
+                        <button
+                          key={style.value}
+                          ref={(el) => { styleRadioRefs.current[index] = el; }}
+                          type="button"
+                          role="radio"
+                          aria-checked={selected}
+                          tabIndex={selected ? 0 : -1}
+                          className={`flex flex-col items-center gap-1.5 rounded-md border py-3 px-1.5 text-xs font-medium cursor-pointer transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 ${
+                            selected
+                              ? 'border-primary bg-primary/10 text-primary'
+                              : 'border-border text-foreground hover:bg-muted/40'
+                          }`}
+                          onClick={() => selectSignatureStyle(style.value)}
+                          onKeyDown={(e) => handleStyleKeyDown(e, index)}
+                        >
+                          <style.Icon className="h-5 w-5" />
+                          <span>{style.label}</span>
+                        </button>
+                      );
+                    })}
                   </div>
 
                   {/* Description based on selection */}


### PR DESCRIPTION
The signature-style selector (Typed Only / Upload Image / Digital Field) was three separate `<button aria-pressed>` in a grid. A screen reader announced them as three independent toggles rather than one choice out of three, and keyboard users had to Tab through each button (the rank and office-code toggles right above it in the same file already use grouped controls).

The three cards now form a real radio group with no new dependency and identical visuals:

- container `role="radiogroup"` with an accessible name; each card `role="radio"` + `aria-checked`
- roving `tabIndex` — only the selected card is in the tab order
- Arrow keys (←/→/↑/↓) move the selection and focus between the three, wrapping at the ends
- added the standard focus-visible ring the raw buttons never had

Behavior is otherwise unchanged: selecting Typed Only or Digital Field still drops any uploaded signature image.

Verified: build 0, lint 0, check-no-cdn OK; live-checked the group renders `role=radiogroup` and ArrowRight moves selection + `aria-checked` + roving tabIndex + focus to the next option.