### PR TITLE
fix(editor): ease the @ variable menu in instead of snapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.70] — 2026-07-05
+
+### Changed
+
+- The "@" variable-and-cross-reference menu now eases in with a subtle rise
+  instead of snapping into place, matching how the rest of the app's popovers
+  and menus appear.
+
 ## [1.2.69] — 2026-07-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.69",
+  "version": "1.2.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.69",
+      "version": "1.2.70",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.69",
+  "version": "1.2.70",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -501,6 +501,9 @@ const VariableExtension = VariableNode.extend({
                 props: { items: props.items, command: props.command, query: props.query },
                 editor: props.editor,
               });
+              // Ease the popup in instead of snapping — a fresh wrapper element
+              // is created per open, so the entrance plays each time.
+              component.element.classList.add('dd-at-menu');
 
               if (!props.clientRect) return;
 

--- a/src/index.css
+++ b/src/index.css
@@ -633,6 +633,13 @@
   100% { transform: scale(1); }
 }
 
+/* Entrance for the "@" variable-suggestion popup — it previously snapped in
+   with no transition while every other surface eases. Transform-only, so the
+   list stays visible even if the animation clock is throttled. */
+.dd-at-menu {
+  animation: dd-pop-in 130ms ease-out;
+}
+
 /* Respect prefers-reduced-motion — WCAG 2.3.3 */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {


### PR DESCRIPTION
The "@" variable / cross-reference suggestion popup (Tippy, in the body block editor) had no entrance transition — it appeared and disappeared instantly while every other popover and menu in the app eases. 

Now its wrapper gets a `dd-at-menu` class that plays the existing transform-only `dd-pop-in` keyframe (130ms rise). No external Tippy animation CSS is imported — the keyframe lives in our own stylesheet, so the air-gap CDN guard stays clean. A fresh wrapper is created each time the menu opens, so the entrance plays on every open. Transform-only, so the list stays visible even if the animation clock is throttled, and `prefers-reduced-motion` neutralizes it via the existing global rule.

Verified: build 0, lint 0, check-no-cdn OK; live-triggered the @ menu after reload — the popup carries `.dd-at-menu` with `animation-name: dd-pop-in`, `0.13s`, and its listbox renders.