### PR TITLE
fix(pdf): show a loading skeleton on preview pages while they render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.72] — 2026-07-05
+
+### Changed
+
+- PDF preview pages now show a subtle loading shimmer while they render, instead
+  of a blank white rectangle. On a slow render you get feedback that the page is
+  on its way rather than an empty box. (The thumbnail rail already did this.)
+
 ## [1.2.71] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.71",
+  "version": "1.2.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.71",
+      "version": "1.2.72",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.71",
+  "version": "1.2.72",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/pdf/PdfPageLayer.tsx
+++ b/src/components/pdf/PdfPageLayer.tsx
@@ -252,7 +252,15 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
                       devicePixelRatio={dprCap}
                       renderTextLayer={false}
                       renderAnnotationLayer={false}
-                      loading={null}
+                      // Skeleton until the canvas paints — react-pdf swaps this
+                      // out on render, so a slow page shows a shimmer instead of
+                      // a blank white rectangle. Pulse stills under reduced-motion.
+                      loading={
+                        <div
+                          aria-hidden
+                          className="h-full w-full animate-pulse bg-muted/40"
+                        />
+                      }
                       error={null}
                       onRenderSuccess={() => {
                         const pending = pendingRenderRef.current;


### PR DESCRIPTION
A full-size preview page rendered from a blank white rectangle — on a slow render you'd stare at empty white boxes with no sign anything was happening. The thumbnail rail already showed a placeholder; the main page layer passed `loading={null}`.

The main page now passes a subtle pulsing skeleton to react-pdf's `loading` slot. react-pdf renders it until the page canvas paints, then swaps it out — same mechanism the thumbnail rail already uses. `prefers-reduced-motion` stills the pulse via the existing global rule. No change to virtualization or the `onRenderSuccess` ready-tracking.

Verified: build 0, lint 0, check-no-cdn OK. The skeleton is transient (only visible during a page's render window), and no compile ran in the verification session, so this was verified via build + type-check and by mirroring the thumbnail rail's proven `loading` pattern in the same file.