### PR TITLE
fix(design): add a neutral --info token; move the domain-restriction banner onto it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.73] — 2026-07-05
+
+### Changed
+
+- Added a neutral informational color (`--info`) to the theme, defined for light
+  and dark schemes (with an sRGB fallback), and moved the classification "Domain
+  Restrictions" note onto it. It was the last banner still using hardcoded blue
+  palette classes instead of a semantic token.
+
 ## [1.2.72] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.72",
+  "version": "1.2.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.72",
+      "version": "1.2.73",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.72",
+  "version": "1.2.73",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/ClassificationSection.tsx
+++ b/src/components/editor/ClassificationSection.tsx
@@ -179,9 +179,9 @@ export function ClassificationSection() {
             {/* Domain Restriction Info — only when the active domain narrows the
                 level list, so the default panel stays clean like the design. */}
             {isDomainRestricted && (
-              <div className="flex items-start gap-2 border-l-2 border-blue-300 dark:border-blue-800 pl-3">
-                <Info aria-hidden="true" className="h-4 w-4 text-blue-600 dark:text-blue-400 mt-0.5 shrink-0" />
-                <div className="text-sm text-blue-800 dark:text-blue-300">
+              <div className="flex items-start gap-2 border-l-2 border-info/40 pl-3">
+                <Info aria-hidden="true" className="h-4 w-4 text-info mt-0.5 shrink-0" />
+                <div className="text-sm text-info">
                   <p className="font-medium"><span className="sr-only">Important: </span>Domain Restrictions</p>
                   <p className="text-xs mt-1">{restrictionMessage}</p>
                 </div>

--- a/src/index.css
+++ b/src/index.css
@@ -127,6 +127,8 @@
   --color-success-foreground: var(--success-foreground);
   --color-warning: var(--warning);
   --color-warning-foreground: var(--warning-foreground);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -203,6 +205,8 @@
   --success-foreground: oklch(0.99 0 0);
   --warning: oklch(0.50 0.13 65);          /* ~amber-800 — ≥4.5:1 as text on both the light canvas and its own 10% tint */
   --warning-foreground: oklch(0.99 0 0);
+  --info: oklch(0.48 0.19 255);            /* ~blue-700 — neutral informational; ≥4.5:1 as text on the light canvas */
+  --info-foreground: oklch(0.99 0 0);
   --border: oklch(0.88 0.02 250);          /* Navy-tinted border */
   --input: oklch(0.95 0.01 250);
   --ring: oklch(0.43 0.17 25);             /* USMC Red ring */
@@ -431,6 +435,8 @@
   --success-foreground: oklch(0.20 0.04 150);
   --warning: oklch(0.83 0.16 85);          /* ~amber-400 — bright enough as text on deep canvas */
   --warning-foreground: oklch(0.22 0.03 85);
+  --info: oklch(0.72 0.14 255);            /* ~blue-400 — brighter for deep canvas */
+  --info-foreground: oklch(0.20 0.04 255);
   --border: oklch(0.305 0.008 260);        /* Crisper edges for card separation */
   --input: oklch(0.23 0.008 260);
   --ring: oklch(0.55 0.20 25);             /* Bright USMC Red ring */
@@ -479,6 +485,8 @@
     --success-foreground: #ffffff;
     --warning: #92400e;
     --warning-foreground: #ffffff;
+    --info: #1d4ed8;
+    --info-foreground: #ffffff;
     --border: #ced9e5;
     --input: #eaeff5;
     --ring: #970818;
@@ -519,6 +527,8 @@
     --success-foreground: #052e16;
     --warning: #fbbf24;
     --warning-foreground: #1c1917;
+    --info: #60a5fa;
+    --info-foreground: #0a1f3d;
     --border: #2d2f33;
     --input: #1b1d21;
     --ring: #cc272e;


### PR DESCRIPTION
The classification "Domain Restrictions" note was the last banner still painted with hardcoded `blue-300/600/800` palette classes instead of a semantic token. It couldn't just use the shared `Notice` `info` variant, because that variant tints with `--primary` — which in this app is USMC scarlet, so a benign informational note would have read as a warning.

This adds a proper neutral **`--info`** token to the theme:

- `:root` (light): `oklch(0.48 0.19 255)` ≈ blue-700 — ≥4.5:1 as text on the light canvas
- `.dark`: `oklch(0.72 0.14 255)` ≈ blue-400 — bright enough on the deep canvas
- sRGB `@supports` fallback for both (`#1d4ed8` / `#60a5fa`)
- mapped in `@theme inline` so `text-info` / `border-info` work

The domain-restriction banner now uses `text-info` / `border-info/40` instead of the raw blue classes.

Verified: build 0, lint 0, check-no-cdn OK; the token is present in the built CSS for all four scheme×fallback variants, and live-checked the banner's icon and text resolve to the `--info` blue (not scarlet).