### PR TITLE
refactor(forms): prune inert entries from the form autocomplete priority list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.74] — 2026-07-05
+
+### Changed
+
+- Removed dead entries from the NAVMC 6105 / 118(11) form autocomplete's
+  "show these first" list. It named variables (LAST_NAME, EDIPI, RANK, …) that
+  aren't in those forms' example set, so they never had any effect; the list now
+  matches what the forms actually offer. No visible change. (You can still type
+  `@ANYTHING` to create any custom variable.)
+
 ## [1.2.73] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.73",
+  "version": "1.2.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.73",
+      "version": "1.2.74",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.73",
+  "version": "1.2.74",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/Form11811Section.tsx
+++ b/src/components/editor/Form11811Section.tsx
@@ -21,8 +21,10 @@ import { useEditorOutlineStore } from '@/stores/editorOutlineStore';
 import { cn } from '@/lib/utils';
 import { NAVMC_118_11_PLACEHOLDERS } from '@/lib/constants';
 
-// Common variables to show first in autocomplete
-const COMMON_FORM_VARS = ['LAST_NAME', 'FIRST_NAME', 'NAME', 'EDIPI', 'ENTRY_DATE'];
+// Names to sort first in the @ autocomplete. This only reorders entries that
+// exist in `placeholders` (NAVMC_118_11_PLACEHOLDERS = NAME, DATE), so any name
+// not in that set is inert — keep this list to what the form actually offers.
+const COMMON_FORM_VARS = ['NAME', 'DATE'];
 
 // Active-section left-rule for a form AccordionItem, matching the letter
 // sections (FormPanel's SectionShell). activeId only changes at section

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -40,8 +40,10 @@ function sectionRule(active: boolean): string {
   );
 }
 
-// Common variables to show first in autocomplete
-const COMMON_FORM_VARS = ['LAST_NAME', 'FIRST_NAME', 'NAME', 'EDIPI', 'RANK', 'DATE'];
+// Names to sort first in the @ autocomplete. This only reorders entries that
+// exist in `placeholders` (NAVMC_10274_PLACEHOLDERS = NAME, DATE), so any name
+// not in that set is inert — keep this list to what the form actually offers.
+const COMMON_FORM_VARS = ['NAME', 'DATE'];
 
 export function Form6105Section() {
   const { navmc10274, setNavmc10274Field, resetNavmc10274, clearNavmc10274, includeCoverPage, setIncludeCoverPage } = useFormStore();


### PR DESCRIPTION
The NAVMC 6105 and 118(11) form sections each declared a `COMMON_FORM_VARS` "show first" list for the @ autocomplete that named variables not in the form's example placeholder set:

- 6105: `[LAST_NAME, FIRST_NAME, NAME, EDIPI, RANK, DATE]`
- 118(11): `[LAST_NAME, FIRST_NAME, NAME, EDIPI, ENTRY_DATE]`
- both forms' `placeholders` (the example set): `[NAME, DATE]`

`variable-autocomplete.tsx` only uses `commonVariables` to **reorder entries that are already in `placeholders`** (`allMatches.filter(p => commonVariables.includes(p.name))`). So every name except NAME and DATE was inert — it could never match or reorder anything.

Both lists are now `['NAME', 'DATE']`, matching what the forms actually offer, with a comment explaining the constraint. **No visible change** — the removed names never appeared. Users can still type `@ANYTHING` to create custom variables exactly as before.

(If we later want EDIPI / rank / name-parts as first-class autocomplete *examples* on these personnel forms, the right move is to add them to `NAVMC_10274_PLACEHOLDERS` / `NAVMC_118_11_PLACEHOLDERS` — a separate, deliberate change.)

Verified: build 0, lint 0, check-no-cdn OK. Change is provably inert (pruned names were absent from `placeholders`), so no behavior to re-verify live.