### PR TITLE
fix(a11y): name the addressing remove button; fix custom-classification dark contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.75] — 2026-07-05
+
+### Fixed
+
+- The "remove" button on an addressing "Via" line now has an accessible name —
+  it was an icon-only button a screen reader announced as just "button".
+- The "(Custom)" classification label and the "Custom Classification" menu item
+  used a fixed grey with no dark variant, which failed WCAG AA contrast on the
+  dark theme; both now use the theme's secondary-text color, which passes in
+  both light and dark.
+
 ## [1.2.74] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.74",
+  "version": "1.2.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.74",
+      "version": "1.2.75",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.74",
+  "version": "1.2.75",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/AddressingSection.tsx
+++ b/src/components/editor/AddressingSection.tsx
@@ -101,6 +101,7 @@ function SortableViaItem({ id, index, value, onChange, onRemove, onLookup, canRe
         size="icon"
         onClick={onRemove}
         disabled={!canRemove}
+        aria-label={`Remove via routing ${index + 1}`}
         className="shrink-0 text-destructive hover:text-destructive"
       >
         <Trash2 className="h-4 w-4" />

--- a/src/components/editor/ClassificationSection.tsx
+++ b/src/components/editor/ClassificationSection.tsx
@@ -153,11 +153,11 @@ export function ClassificationSection() {
           <div className="flex items-center gap-2">
             <Shield
               aria-hidden="true"
-              className={`h-4 w-4 ${classLevel === 'custom' ? 'text-gray-600' : currentLevel?.color || 'text-foreground'}`}
+              className={`h-4 w-4 ${classLevel === 'custom' ? 'text-muted-foreground' : currentLevel?.color || 'text-foreground'}`}
               style={{ fill: 'currentColor', fillOpacity: 0.2 }}
             />
             Classification
-            <span className={`text-xs font-medium ${classLevel === 'custom' ? 'text-gray-600' : currentLevel?.color}`}>
+            <span className={`text-xs font-medium ${classLevel === 'custom' ? 'text-muted-foreground' : currentLevel?.color}`}>
               ({classLevel === 'custom' ? 'Custom' : currentLevel?.label})
             </span>
             <HelpTip>
@@ -205,7 +205,7 @@ export function ClassificationSection() {
                     </SelectItem>
                   ))}
                   <SelectItem value="custom">
-                    <span className="text-gray-600">Custom Classification</span>
+                    <span className="text-muted-foreground">Custom Classification</span>
                   </SelectItem>
                 </SelectContent>
               </Select>


### PR DESCRIPTION
Two accessibility defects surfaced by a full re-verification of the UX audit against current code:

1. **Addressing "Via" remove button had no accessible name** — it's a `size="icon"` ghost button containing only `<Trash2/>`, with no `aria-label` (unlike the adjacent unit-lookup button, which is wrapped in `IconTip`). A screen reader announced it as just "button." Added `aria-label={`Remove via routing ${index + 1}`}`, matching the reference/enclosure remove buttons.

2. **"Custom" classification label failed WCAG AA in dark mode** — the accordion header label `(Custom)` and the "Custom Classification" select item used `text-gray-600` (#4b5563) with no `dark:` variant, giving ~1.4:1 on the dark card/popover. Swapped both (and the decorative shield icon, for consistency) to `text-muted-foreground`, the theme's secondary-text token, which clears AA in both light and dark.

Verified: build 0, lint 0, check-no-cdn OK. Both are attribute/token changes with no logic change.