### PR TITLE
fix(security): open external GitHub links with noopener,noreferrer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.76] — 2026-07-05
+
+### Fixed
+
+- The "View on GitHub" links (in the About dialog and the header menus) now open
+  with `noopener,noreferrer`, so the new tab can't reach back into the app via
+  `window.opener` (reverse-tabnabbing). The other external links already did this.
+
 ## [1.2.75] — 2026-07-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.75",
+  "version": "1.2.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.75",
+      "version": "1.2.76",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.75",
+  "version": "1.2.76",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1057,7 +1057,7 @@ export function Header({
                 About
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => window.open(GITHUB_REPO_URL, '_blank')}>
+              <DropdownMenuItem onClick={() => window.open(GITHUB_REPO_URL, '_blank', 'noopener,noreferrer')}>
                 <GithubIcon className="h-4 w-4 mr-2" />
                 View on GitHub
               </DropdownMenuItem>
@@ -1224,7 +1224,7 @@ export function Header({
                 <ScrollText className="h-4 w-4 mr-2" />
                 View Logs
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => window.open(GITHUB_REPO_URL, '_blank')}>
+              <DropdownMenuItem onClick={() => window.open(GITHUB_REPO_URL, '_blank', 'noopener,noreferrer')}>
                 <GithubIcon className="h-4 w-4 mr-2" />
                 GitHub
               </DropdownMenuItem>

--- a/src/components/modals/AboutModal.tsx
+++ b/src/components/modals/AboutModal.tsx
@@ -87,7 +87,7 @@ export function AboutModal() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => window.open('https://github.com/marinecoders/dondocs', '_blank')}
+              onClick={() => window.open('https://github.com/marinecoders/dondocs', '_blank', 'noopener,noreferrer')}
             >
               <GithubIcon className="h-4 w-4 mr-2" />
               View on GitHub


### PR DESCRIPTION
The three "View on GitHub" links (`AboutModal.tsx:90` and `Header.tsx` ×2) called `window.open(url, '_blank')` with no window features. Unlike an anchor `target=_blank`, `window.open` does NOT imply `noopener` — so the opened GitHub tab received a live `window.opener` reference back into the app (reverse-tabnabbing vector). All three now pass `'noopener,noreferrer'`, matching the bug-report / feature-request links that already did.

Scope note: the blob/data-PDF `window.open` calls (App.tsx, downloadPdf.ts, MobilePreviewModal) were intentionally left alone — they use the returned window reference (adding `noopener` makes `window.open` return `null` in some browsers and would break the iOS download flow), and they open same-origin blobs, which carry no tabnabbing risk.

Verified: build 0, lint 0, check-no-cdn OK; grep confirms no bare external `window.open(..., '_blank')` without noopener remains.