### PR TITLE
fix(references): derive the library count in the help tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.77] — 2026-07-05
+
+### Fixed
+
+- The References help tip said "Browse 107 common military references," but the
+  library actually has 135. The count is now derived from the dataset, so it
+  can't go stale again.
+
 ## [1.2.76] — 2026-07-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.76",
+  "version": "1.2.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.76",
+      "version": "1.2.77",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.76",
+  "version": "1.2.77",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/ReferencesManager.tsx
+++ b/src/components/editor/ReferencesManager.tsx
@@ -23,6 +23,7 @@ import { showAppConfirm } from '@/stores/alertStore';
 import type { Reference } from '@/types/document';
 import { DOC_TYPE_CONFIG } from '@/types/document';
 import { safeUrl } from '@/lib/url-safety';
+import { ALL_REFERENCES } from '@/data/references';
 
 interface SortableReferenceProps {
   reference: Reference;
@@ -219,7 +220,7 @@ export function ReferencesManager() {
               <ul className="text-xs mt-2 space-y-1 list-disc list-inside">
                 <li><strong>Drag to reorder:</strong> References auto-letter based on position</li>
                 <li><strong>URLs:</strong> Add a link to make the reference clickable in PDF</li>
-                <li><strong>Library:</strong> Browse 107 common military references to insert</li>
+                <li><strong>Library:</strong> Browse {ALL_REFERENCES.length} common military references to insert</li>
               </ul>
             </HelpTip>
           </span>


### PR DESCRIPTION
The References section's help tip read "Browse **107** common military references to insert," but the reference library dataset (`ALL_REFERENCES`) actually holds **135** — the hardcoded number drifted as references were added. Now interpolated from `ALL_REFERENCES.length` so it stays correct automatically.

Verified: build 0, lint 0, check-no-cdn OK; confirmed `ALL_REFERENCES.length === 135` from references.json.