### PR TITLE
fix(dnd): let drag handles claim the touch gesture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.78] — 2026-07-05
+
+### Fixed
+
+- Reordering by drag now works reliably on touch devices. The drag handles on
+  Via routing, references, enclosures, and body paragraphs didn't opt out of the
+  browser's touch-scrolling, so grabbing a handle on a phone could scroll the
+  page instead of starting the drag; they now claim the gesture (`touch-action:
+  none`). Keyboard reordering was unaffected and still works.
+
 ## [1.2.77] — 2026-07-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.77",
+  "version": "1.2.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.77",
+      "version": "1.2.78",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.77",
+  "version": "1.2.78",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/AddressingSection.tsx
+++ b/src/components/editor/AddressingSection.tsx
@@ -71,7 +71,7 @@ function SortableViaItem({ id, index, value, onChange, onRemove, onLookup, canRe
         type="button"
         aria-label={`Drag to reorder via routing ${index + 1}`}
         title="Drag to reorder"
-        className="cursor-grab rounded-sm text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 active:cursor-grabbing"
+        className="cursor-grab touch-none rounded-sm text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 active:cursor-grabbing"
       >
         <GripVertical className="h-4 w-4" />
       </button>

--- a/src/components/editor/BlockParagraphsEditor.tsx
+++ b/src/components/editor/BlockParagraphsEditor.tsx
@@ -200,7 +200,7 @@ const BlockRow = memo(function BlockRow({
         {...listeners}
         aria-label="Drag to reorder"
         title="Drag to reorder"
-        className="absolute -left-5 top-1.5 cursor-grab active:cursor-grabbing text-muted-foreground opacity-0 transition-opacity group-hover:opacity-70 focus-visible:opacity-100"
+        className="absolute -left-5 top-1.5 cursor-grab touch-none active:cursor-grabbing text-muted-foreground opacity-0 transition-opacity group-hover:opacity-70 focus-visible:opacity-100"
       >
         <GripVertical className="h-4 w-4" />
       </button>

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -94,7 +94,7 @@ function SortableEnclosure({
           aria-label={`Drag to reorder enclosure ${index + 1}`}
           {...attributes}
           {...listeners}
-          className="mt-2 cursor-grab rounded-sm text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 active:cursor-grabbing"
+          className="mt-2 cursor-grab touch-none rounded-sm text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 active:cursor-grabbing"
         >
           <GripVertical className="h-4 w-4" />
         </button>

--- a/src/components/editor/ReferencesManager.tsx
+++ b/src/components/editor/ReferencesManager.tsx
@@ -99,7 +99,7 @@ const SortableReference = memo(function SortableReference({
           aria-label={`Drag to reorder reference ${index + 1}`}
           {...attributes}
           {...listeners}
-          className="mt-2 cursor-grab rounded-sm text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 active:cursor-grabbing"
+          className="mt-2 cursor-grab touch-none rounded-sm text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 active:cursor-grabbing"
         >
           <GripVertical className="h-4 w-4" />
         </button>


### PR DESCRIPTION
The reorder drag handles in Via routing (AddressingSection), References, Enclosures, and body paragraphs (BlockParagraphsEditor) used dnd-kit's `PointerSensor` but the handle elements had no `touch-action: none`. On touch devices the browser could claim the gesture for scrolling, so grabbing a handle would scroll the page instead of starting the drag.

Added `touch-none` (`touch-action: none`) to all four handle buttons — the standard dnd-kit fix — so a touch that starts on a handle begins a drag. Desktop pointer drag and keyboard reordering (via the wired `KeyboardSensor`) are unaffected.

Verified: build 0, lint 0, check-no-cdn OK; all four handles confirmed carrying the class.