### PR TITLE
chore(ui): humanize file sizes to KB/MB and unify the 'Copy log' label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.79] — 2026-07-05
+
+### Changed
+
+- File sizes now read in KB or MB as appropriate. A signature image or an
+  attached enclosure PDF over a megabyte showed as, e.g., "2048.0 KB"; it now
+  reads "2 MB". Small files still show KB (or bytes), and a trailing ".0" is
+  dropped. The "Copy log" control and its instructions now read consistently.
+
 ## [1.2.78] — 2026-07-05
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.78",
+  "version": "1.2.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.78",
+      "version": "1.2.79",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.78",
+  "version": "1.2.79",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -29,6 +29,7 @@ import {
 import { HelpTip } from '@/components/ui/help-tip';
 import { useDocumentStore } from '@/stores/documentStore';
 import { persistAttachment } from '@/lib/attachments';
+import { formatFileSize } from '@/lib/utils';
 import type { Enclosure, EnclosurePageStyle } from '@/types/document';
 import { DOC_TYPE_CONFIG } from '@/types/document';
 
@@ -120,7 +121,7 @@ function SortableEnclosure({
                 <FileText className="h-4 w-4 text-primary shrink-0" />
                 <span className="flex-1 min-w-0 truncate">{enclosure.file.name}</span>
                 <span className="text-muted-foreground shrink-0 whitespace-nowrap">
-                  {(enclosure.file.size / 1024).toFixed(1)} KB
+                  {formatFileSize(enclosure.file.size)}
                 </span>
                 <Button
                   variant="ghost"

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -18,6 +18,7 @@ import { loadSignatureAsPngBase64 } from '@/lib/signatureImage';
 import { FILE_LIMITS } from '@/lib/constants';
 import { showAppAlert } from '@/stores/alertStore';
 import { isImageFile, rejectedFilesMessage } from '@/lib/fileFilter';
+import { formatFileSize } from '@/lib/utils';
 import { RequiredMark } from '@/components/ui/required-mark';
 import type { DocTypeConfig, SignatureImage, SignatureType } from '@/types/document';
 import { ALL_SERVICE_RANKS, formatRank } from '@/data/ranks';
@@ -545,7 +546,7 @@ export function SignatureSection({ config }: SignatureSectionProps) {
                       <div className="flex items-center gap-2 text-xs text-muted-foreground">
                         <FileImage className="h-3 w-3" />
                         <span>{formData.signatureImage.name}</span>
-                        <span>({(formData.signatureImage.size / 1024).toFixed(1)} KB)</span>
+                        <span>({formatFileSize(formData.signatureImage.size)})</span>
                       </div>
                     </div>
                   ) : (

--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -793,7 +793,7 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
         return 'Tip: Add variables to the "To" field like "LCpl {{LAST_NAME}}, {{FIRST_NAME}} {{MI}}\\n{{EDIPI}}\\n{{MOS}}"';
       }
       if (formType === 'navmc_118_11') {
-        return 'Tip: Add variables to the remarks like "On {{ENTRY_DATE}}, {{NAME}} failed to meet PFT standards..."';
+        return 'Tip: Add variables to the remarks like "On {{ENTRY_DATE}}, {{NAME}} failed to meet PFT standards…"';
       }
     }
     return 'Tip: Add a variable to your Subject line like "PROMOTION OF {{NAME}} TO {{RANK}}"';

--- a/src/components/modals/CompileErrorModal.tsx
+++ b/src/components/modals/CompileErrorModal.tsx
@@ -135,7 +135,7 @@ export function CompileErrorModal({ open, error, compileLog, onClose }: CompileE
                   ) : (
                     <>
                       <Copy className="h-3 w-3 mr-1" />
-                      Copy logs
+                      Copy log
                     </>
                   )}
                 </Button>
@@ -152,7 +152,7 @@ export function CompileErrorModal({ open, error, compileLog, onClose }: CompileE
           <p className="text-xs text-muted-foreground break-words">
             If this looks like a bug (not just a typo in your document), reporting
             it on GitHub is the fastest way to get it fixed — we triage every
-            report. Use “Copy logs” and paste the log into the issue after
+            report. Use “Copy log” and paste the log into the issue after
             reviewing it — reports go to public GitHub, so don’t include CUI.
           </p>
 

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -44,6 +44,7 @@ import { ALL_SERVICE_RANKS, formatRank } from '@/data/ranks';
 import { canonicalizeUnitAddress } from '@/lib/unitAddress';
 import { loadSignatureAsPngBase64 } from '@/lib/signatureImage';
 import { isImageFile, rejectedFilesMessage } from '@/lib/fileFilter';
+import { formatFileSize } from '@/lib/utils';
 
 // Convert base64 to data URL for display
 function base64ToDataUrl(base64: string, mimeType: string): string {
@@ -655,7 +656,7 @@ export function ProfileModal() {
                       <div className="flex items-center gap-2 text-xs text-muted-foreground">
                         <FileImage className="h-3 w-3" />
                         <span>{formState.signatureImage.name}</span>
-                        <span>({(formState.signatureImage.size / 1024).toFixed(1)} KB)</span>
+                        <span>({formatFileSize(formState.signatureImage.size)})</span>
                       </div>
                     </div>
                   ) : (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,20 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Human-readable byte size: bytes → "812 B" / "24.0 KB" / "2.4 MB".
+ * Keeps one decimal for KB/MB (dropped when it's a whole number) so a
+ * 2 MB upload reads "2 MB", not "2048.0 KB".
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${trimDecimal(kb)} KB`;
+  return `${trimDecimal(kb / 1024)} MB`;
+}
+
+function trimDecimal(n: number): string {
+  // 2.0 → "2", 2.4 → "2.4"
+  return Number.isInteger(n) ? String(n) : n.toFixed(1);
+}

--- a/tests/unit/formatFileSize.test.ts
+++ b/tests/unit/formatFileSize.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { formatFileSize } from '@/lib/utils';
+
+describe('formatFileSize', () => {
+  it('shows raw bytes under 1 KiB', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+    expect(formatFileSize(1)).toBe('1 B');
+    expect(formatFileSize(1023)).toBe('1023 B');
+  });
+
+  it('shows KB from 1 KiB up to 1 MiB, dropping a trailing .0', () => {
+    expect(formatFileSize(1024)).toBe('1 KB');
+    expect(formatFileSize(1536)).toBe('1.5 KB'); // 1.5 KiB
+    expect(formatFileSize(1024 * 1023)).toBe('1023 KB');
+  });
+
+  it('rolls over to MB at 1 MiB', () => {
+    expect(formatFileSize(1024 * 1024)).toBe('1 MB');
+    expect(formatFileSize(Math.round(1024 * 1024 * 2.4))).toBe('2.4 MB');
+  });
+
+  it('keeps one decimal only when it is non-zero', () => {
+    expect(formatFileSize(2048)).toBe('2 KB'); // was "2048.0 KB" before
+    expect(formatFileSize(1024 * 1024 * 3)).toBe('3 MB');
+  });
+});


### PR DESCRIPTION
First of a series of small design-polish PRs from the UX audit backlog.

**File sizes → KB/MB.** Signature-image and enclosure-PDF sizes were always printed in KB with a forced decimal, so a 2 MB file read "2048.0 KB". Added a shared `formatFileSize()` (`src/lib/utils.ts`): bytes → `B`/`KB`/`MB`, one decimal only when non-zero. Wired into `SignatureSection`, `ProfileModal`, and `EnclosuresManager`.

**Copy-log label.** `CompileErrorModal` had a "Copy logs" button + prose while its aria-label said "Copy log"; unified to the singular.

**Stray glyph.** One literal `...` in a BatchModal tip → `…`.

(Deliberately left the broad sentence-case / smart-quote / empty-state-period sweeps alone — too subjective to apply blindly.)

Verified: build 0, lint 0, check-no-cdn OK; added `tests/unit/formatFileSize.test.ts` (4 cases, green).