### PR TITLE
chore(ui): tabular figures on the save-time indicator; tokenize the serif body size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.80] — 2026-07-05
+
+### Changed
+
+- The "Saved · N ago" indicator now uses tabular figures, so its digits don't
+  shift width as the time ticks up.
+- Internal: the block editor's serif reading size moved off a repeated arbitrary
+  value onto one named token. No visible change.
+
 ## [1.2.79] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.79",
+  "version": "1.2.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.79",
+      "version": "1.2.80",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.79",
+  "version": "1.2.80",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/SaveStatus.tsx
+++ b/src/components/SaveStatus.tsx
@@ -65,7 +65,7 @@ export function SaveStatus({ className }: { className?: string }) {
   // this session — never on 'error'/'needs-permission' (BackupNotice's job).
   const backedUp = backupStatus === 'connected' && lastBackupAt != null;
   return (
-    <span className={`inline-flex items-center gap-1 ${base}`}>
+    <span className={`inline-flex items-center gap-1 tnum ${base}`}>
       <Check className="h-3 w-3 text-success" aria-hidden />
       Saved · {savedAgo(lastSavedAt)}
       {backedUp && (

--- a/src/components/editor/BlockParagraphsEditor.tsx
+++ b/src/components/editor/BlockParagraphsEditor.tsx
@@ -210,7 +210,7 @@ const BlockRow = memo(function BlockRow({
           levels 4–7 repeat those patterns but underlined, which is exactly what
           the LaTeX/PDF renders — mirror it here so "(a)" at level 3 and level 7
           aren't indistinguishable in the editor. */}
-      <div className="select-none pt-0.5 pr-2.5 text-right font-serif text-[15px] leading-relaxed text-muted-foreground tnum">
+      <div className="select-none pt-0.5 pr-2.5 text-right font-serif text-serif-body leading-relaxed text-muted-foreground tnum">
         <span className={level >= 4 ? 'underline' : undefined}>{label}</span>
       </div>
 
@@ -224,7 +224,7 @@ const BlockRow = memo(function BlockRow({
               if (!header) setWantsHeader(false);
             }}
             placeholder="Heading"
-            className="mb-1 h-7 border-none bg-transparent px-0 font-serif text-[15px] font-semibold underline shadow-none focus-visible:ring-0"
+            className="mb-1 h-7 border-none bg-transparent px-0 font-serif text-serif-body font-semibold underline shadow-none focus-visible:ring-0"
           />
         )}
         <div className="flex items-baseline gap-1">
@@ -236,7 +236,7 @@ const BlockRow = memo(function BlockRow({
                   aria-label={`Portion marking: ${mark.name}. Change`}
                   title="Set portion marking"
                   className={cn(
-                    'shrink-0 rounded-sm font-serif text-[15px] font-semibold outline-none transition-colors hover:bg-accent/50 focus-visible:ring-[3px] focus-visible:ring-ring/50',
+                    'shrink-0 rounded-sm font-serif text-serif-body font-semibold outline-none transition-colors hover:bg-accent/50 focus-visible:ring-[3px] focus-visible:ring-ring/50',
                     mark.color
                   )}
                 >
@@ -258,7 +258,7 @@ const BlockRow = memo(function BlockRow({
               </DropdownMenuContent>
             </DropdownMenu>
           )}
-          <div className="min-w-0 flex-1 font-serif text-[15px]">
+          <div className="min-w-0 flex-1 font-serif text-serif-body">
             <VariableChipEditor
               blockMode
               autoFocus={autoFocus}

--- a/src/index.css
+++ b/src/index.css
@@ -168,6 +168,10 @@
   --text-2xs--line-height: 1rem;
   --text-2xs--letter-spacing: 0.01em;
 
+  /* Serif reading size for the block-paragraph editor body/gutter — one named
+     token instead of the repeated text-[15px] arbitrary. */
+  --text-serif-body: 0.9375rem;
+
   /* Optical tracking ladder: large display text compresses, body/small relaxes. */
   --text-xs--letter-spacing: 0.01em;
   --text-sm--letter-spacing: 0.005em;


### PR DESCRIPTION
Typography-tokens batch from the audit backlog.

- **Tabular save time:** the passive "Saved · N s/m/h ago" indicator now carries `tnum`, so the digit doesn't jump width as the relative time ticks.
- **Serif-body token:** the block-paragraph editor repeated `text-[15px]` four times; added a `--text-serif-body` (0.9375rem) theme token and swapped them for `text-serif-body`. Purely a naming change — no visual difference.

Skipped from this batch (deliberate, not cleanup): unifying the ~8 uppercase "eyebrow" micro-labels into one style — they use intentionally different sizes/trackings/colors per context (palette group headers vs About section caps vs sidebar labels), so collapsing them would change appearance rather than just de-duplicate. The `text-[9/10/11px]` one-offs were already swept onto `--text-2xs` in earlier work.

Verified: build 0, lint 0, check-no-cdn OK; `text-serif-body` confirmed in the built CSS.