### PR TITLE
chore(ui): put popovers/menus/selects on the popover shadow rung; add navy shadow-2xl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.81] — 2026-07-05
+
+### Changed
+
+- Popovers, dropdown menus, and select lists now use the app's "popover"
+  elevation rung (a slightly stronger navy-tinted shadow), matching the
+  documented shadow ladder — and a submenu no longer casts a heavier shadow than
+  the menu it opens from. Added a top `shadow-2xl` rung on the navy ladder so it
+  never falls back to a raw-black shadow.
+
 ## [1.2.80] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.80",
+  "version": "1.2.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.80",
+      "version": "1.2.81",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.80",
+  "version": "1.2.81",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -40,7 +40,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-lg",
           className
         )}
         {...props}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -28,7 +28,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border p-4 shadow-md outline-none",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 rounded-md border p-4 shadow-lg outline-none",
           className
         )}
         {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -60,7 +60,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-lg",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className

--- a/src/index.css
+++ b/src/index.css
@@ -161,6 +161,9 @@
   --shadow-md: 0 0 0 1px rgb(18 27 46 / 0.03), 0 2px 4px -1px rgb(18 27 46 / 0.08), 0 6px 12px -2px rgb(18 27 46 / 0.08);
   --shadow-lg: 0 0 0 1px rgb(18 27 46 / 0.04), 0 6px 12px -3px rgb(18 27 46 / 0.10), 0 16px 24px -6px rgb(18 27 46 / 0.12);
   --shadow-xl: 0 0 0 1px rgb(18 27 46 / 0.04), 0 12px 20px -6px rgb(18 27 46 / 0.12), 0 28px 40px -10px rgb(18 27 46 / 0.18);
+  /* Top rung, so `shadow-2xl` stays on the navy ladder instead of falling back
+     to Tailwind's default black. */
+  --shadow-2xl: 0 0 0 1px rgb(18 27 46 / 0.05), 0 18px 30px -8px rgb(18 27 46 / 0.16), 0 40px 60px -12px rgb(18 27 46 / 0.24);
 
   /* One step below text-xs for micro-labels (eyebrow captions, doc-type chips,
      timestamps) — replaces the scattered text-[9px]/[10px]/[11px] arbitraries. */


### PR DESCRIPTION
Elevation batch from the audit backlog.

The shadow ladder's own comment maps `popovers → lg`, but the popover, dropdown-menu, and select **content** surfaces were all on `shadow-md` — and the dropdown **submenu** was on `shadow-lg`, i.e. casting a heavier shadow than the menu it opens from (inverted hierarchy). Promoted the three content surfaces to `shadow-lg` so they match the documented rung and the submenu is no longer heavier than its parent.

Also added a `--shadow-2xl` rung to the navy ladder so a future `shadow-2xl` resolves to the tinted shadow instead of Tailwind's default black (nothing uses it yet — preventive, dormant until referenced).

Already-done / left alone (verified): `.shadow-card`/`.shadow-elevated` already resolve to the navy ladder; WelcomeModal already uses the navy `shadow-xl`; Card's dark-mode black shadow is correct (shadows on dark surfaces are black, not navy-tinted).

Verified: build 0, lint 0, check-no-cdn OK.