### PR TITLE
chore(ui): move one-off corner radii onto the theme radius scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.82] — 2026-07-05
+
+### Changed
+
+- Corner radii now come from the theme's radius scale instead of a few one-off
+  pixel values: the keyboard-shortcut chips, the PDF thumbnail frames, the
+  page-number field, and the "@" insert menu (which now matches the app's other
+  popovers). Differences are 1–2px — a consistency cleanup, not a redesign.
+
 ## [1.2.81] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.81",
+  "version": "1.2.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.81",
+      "version": "1.2.82",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.81",
+  "version": "1.2.82",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/pdf/PdfPageLayer.tsx
+++ b/src/components/pdf/PdfPageLayer.tsx
@@ -302,7 +302,7 @@ export const PdfPageLayer = forwardRef<PdfPageLayerHandle, PdfPageLayerProps>(fu
                 >
                   <div
                     className={cn(
-                      'overflow-hidden rounded-[3px] bg-white transition-shadow',
+                      'overflow-hidden rounded-sm bg-white transition-shadow',
                       currentPage === i + 1
                         ? 'ring-2 ring-primary'
                         : 'ring-1 ring-black/10 group-hover:ring-ring/60 group-focus-visible:ring-[3px] group-focus-visible:ring-ring/50 dark:ring-white/10'

--- a/src/components/pdf/PdfViewerToolbar.tsx
+++ b/src/components/pdf/PdfViewerToolbar.tsx
@@ -138,7 +138,7 @@ export function PdfViewerToolbar({
           disabled={pageCount === 0}
           inputMode="numeric"
           aria-label="Page number"
-          className="tnum h-6 w-9 rounded border border-border bg-background text-center text-xs text-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-50"
+          className="tnum h-6 w-9 rounded-md border border-border bg-background text-center text-xs text-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-50"
           onKeyDown={(e) => {
             if (e.key === 'Enter') commitPage(e.currentTarget);
             if (e.key === 'Escape') e.currentTarget.value = String(page);

--- a/src/components/ui/kbd.tsx
+++ b/src/components/ui/kbd.tsx
@@ -18,7 +18,7 @@ export function Kbd({
   return (
     <kbd
       className={cn(
-        'inline-flex h-[18px] min-w-[16px] items-center justify-center rounded-[5px] border px-[5px] font-mono text-2xs font-medium leading-none',
+        'inline-flex h-[18px] min-w-[16px] items-center justify-center rounded-sm border px-[5px] font-mono text-2xs font-medium leading-none',
         active
           ? 'border-current/25 bg-current/15 text-current'
           : 'border-border bg-muted/60 text-muted-foreground',

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -342,7 +342,7 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
     // If no matches and user typed something, offer to create custom variable
     if (items.length === 0 && query.trim()) {
       return (
-        <div className="bg-popover border border-border rounded-lg shadow-md overflow-hidden w-[280px]">
+        <div className="bg-popover border border-border rounded-md shadow-md overflow-hidden w-[280px]">
           <div className="px-3 py-2 border-b border-border bg-muted/50">
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <span className="text-base font-medium text-blue-500">@</span>
@@ -370,7 +370,7 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
 
     if (items.length === 0) {
       return (
-        <div className="bg-popover border border-border rounded-lg shadow-md overflow-hidden w-[280px]">
+        <div className="bg-popover border border-border rounded-md shadow-md overflow-hidden w-[280px]">
           <div className="px-3 py-3 text-sm text-muted-foreground text-center">
             Type a variable name...
           </div>
@@ -379,7 +379,7 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
     }
 
     return (
-      <div className="bg-popover text-popover-foreground border border-border rounded-lg shadow-md overflow-hidden w-[300px]">
+      <div className="bg-popover text-popover-foreground border border-border rounded-md shadow-md overflow-hidden w-[300px]">
         <div className="px-3 pt-2.5 pb-1 text-2xs font-semibold uppercase tracking-wider text-muted-foreground">
           Insert
         </div>


### PR DESCRIPTION
Radius-normalization batch.

Swapped a handful of arbitrary corner radii for the theme's radius tokens:
- Kbd chip `rounded-[5px]` → `rounded-sm` (4px)
- PDF thumbnail frame `rounded-[3px]` → `rounded-sm`
- PDF page-number input `rounded` (4px) → `rounded-md` (matches the Input primitive)
- the "@" insert menu's three states `rounded-lg` → `rounded-md`, so it matches the app's dropdowns/popovers/selects

Left alone: the WelcomeModal letter's `rounded-[3px]` — a deliberate sharp "paper" corner. The focus-ring offset half of this batch was already unified app-wide in earlier work (v1.2.26); nothing to do there.

Verified: build 0, lint 0, check-no-cdn OK.