### PR TITLE
chore(ui): tokenize the editor variable chip onto the info color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.83] — 2026-07-05
+
+### Changed
+
+- The inserted variable chips in the body editor (and the "@" glyphs) now draw
+  from the theme's informational-blue token instead of hardcoded Tailwind blue.
+  The color is essentially the same — it's now a theme token, so it stays in
+  step with the rest of the palette.
+
 ## [1.2.82] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.82",
+  "version": "1.2.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.82",
+      "version": "1.2.83",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.82",
+  "version": "1.2.83",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -242,13 +242,13 @@ const VariableNode = Node.create({
       // XSS sink — e.g. a variable label of `<img src=x onerror=...>` would
       // execute. textContent escapes automatically. Closes GH #16.
       const span = document.createElement('span');
-      span.className = 'inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300 text-sm font-medium';
+      span.className = 'inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md bg-info/10 text-info text-sm font-medium';
       span.contentEditable = 'false';
       span.setAttribute('data-type', 'variable');
       span.setAttribute('data-name', node.attrs.name);
 
       const at = document.createElement('span');
-      at.className = 'text-blue-500 dark:text-blue-400';
+      at.className = 'text-info';
       at.textContent = '@';
       span.appendChild(at);
       span.appendChild(document.createTextNode(node.attrs.label || node.attrs.name));
@@ -345,7 +345,7 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
         <div className="bg-popover border border-border rounded-md shadow-md overflow-hidden w-[280px]">
           <div className="px-3 py-2 border-b border-border bg-muted/50">
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <span className="text-base font-medium text-blue-500">@</span>
+              <span className="text-base font-medium text-info">@</span>
               <span>Create new variable</span>
             </div>
           </div>


### PR DESCRIPTION
Color-tokens batch.

The body editor's inserted variable chip and its "@" glyphs used hardcoded Tailwind `blue-100/700` (+ dark variants). Repointed them at the theme's `--info` token (`bg-info/10 text-info`), whose blue closely matches the old values — so it looks the same but is now a real theme token.

**Deliberately skipped** two items the ledger listed here:
- *Merging the classification / portion-marking palettes into one shared set* — they **intentionally diverge** on TOP SECRET: the classification label text uses the AA-darkened `#B45309` (the banner orange `#FF8C00` fails WCAG AA as text — fixed in an earlier release), while the inline portion mark uses the bright `#FF8C00`. Forcing one palette would either reintroduce the contrast failure or change the mark. Left as-is.
- *Pruning the unused `--chart-*` tokens* — harmless dead tokens from the shadcn base; removing them across every scheme block is churn with no benefit.

Verified: build 0, lint 0, check-no-cdn OK; `text-info`/`bg-info/10` confirmed in the built CSS, no raw `blue-` left in the file.