### PR TITLE
chore(ui): scope transition-all to the properties that actually animate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.84] — 2026-07-05
+
+### Changed
+
+- Scoped the remaining `transition-all` animations to just the properties that
+  actually change (colors on the document-guide cards, width on the progress
+  bar and the tour's step dots, and position/size on the tour spotlight — which
+  no longer tries to interpolate its full-screen dimming overlay). Same motion,
+  less work per frame.
+
 ## [1.2.83] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.83",
+  "version": "1.2.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.83",
+      "version": "1.2.84",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.83",
+  "version": "1.2.84",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/modals/DocumentGuideModal.tsx
+++ b/src/components/modals/DocumentGuideModal.tsx
@@ -123,7 +123,7 @@ function DocumentFinder({ onSelectGuide }: { onSelectGuide: (guideId: string) =>
               <button
                 key={rec.docType}
                 onClick={() => onSelectGuide(rec.docType)}
-                className={`focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 w-full text-left p-4 rounded-lg border transition-all hover:border-primary hover:bg-accent/50 ${
+                className={`focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 w-full text-left p-4 rounded-lg border transition-[color,background-color,border-color] hover:border-primary hover:bg-accent/50 ${
                   index === 0 ? 'border-primary bg-primary/5 ring-2 ring-primary/20' : ''
                 }`}
               >
@@ -208,7 +208,7 @@ function DocumentFinder({ onSelectGuide }: { onSelectGuide: (guideId: string) =>
           <button
             key={option.value}
             onClick={() => handleAnswer(question.id, option.value)}
-            className="focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 w-full text-left p-4 rounded-lg border hover:border-primary hover:bg-accent/50 transition-all group"
+            className="focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 w-full text-left p-4 rounded-lg border hover:border-primary hover:bg-accent/50 transition-[color,background-color,border-color] group"
           >
             <div className="flex items-center gap-3">
               <div className="flex-1 min-w-0">
@@ -246,7 +246,7 @@ function GuideCard({ guide, isExpanded, onToggle }: {
   onToggle: () => void;
 }) {
   return (
-    <div className="border rounded-lg overflow-hidden bg-card transition-all">
+    <div className="border rounded-lg overflow-hidden bg-card transition-[color,background-color,border-color]">
       <button
         onClick={onToggle}
         className="focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 w-full text-left p-4 hover:bg-accent/50 transition-colors"
@@ -979,7 +979,7 @@ export function DocumentGuideModal() {
                 </div>
                 <div className="h-1.5 rounded-full bg-muted overflow-hidden">
                   <div
-                    className="h-full bg-success transition-all duration-300"
+                    className="h-full bg-success transition-[width] duration-300"
                     style={{ width: `${(learnedCount / POWER_FEATURES.length) * 100}%` }}
                   />
                 </div>
@@ -1078,7 +1078,7 @@ export function DocumentGuideModal() {
                             setSelectedCategory(null);
                             setExpandedGuide(null);
                           }}
-                          className="focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 w-full text-left p-6 rounded-lg border-2 hover:border-primary hover:bg-accent/50 transition-all group"
+                          className="focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 w-full text-left p-6 rounded-lg border-2 hover:border-primary hover:bg-accent/50 transition-[color,background-color,border-color] group"
                         >
                           <div className="flex items-center gap-4">
                             {(() => { const GI = GROUP_ICONS[group.id] ?? FileText; return <GI className="h-8 w-8 shrink-0 text-primary" aria-hidden="true" />; })()}

--- a/src/components/tour/TourOverlay.tsx
+++ b/src/components/tour/TourOverlay.tsx
@@ -237,7 +237,7 @@ export function TourOverlay() {
           a hole via its large spread shadow; without one, a plain full dim. */}
       {rect ? (
         <div
-          className="fixed z-[111] pointer-events-none rounded-lg ring-2 ring-primary transition-all duration-200"
+          className="fixed z-[111] pointer-events-none rounded-lg ring-2 ring-primary transition-[top,left,width,height] duration-200"
           style={{
             top: rect.top - PAD,
             left: rect.left - PAD,
@@ -301,8 +301,8 @@ export function TourOverlay() {
                     key={i}
                     className={
                       i === stepIndex
-                        ? 'h-1.5 w-4 shrink-0 rounded-full bg-primary transition-all'
-                        : 'h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30 transition-all'
+                        ? 'h-1.5 w-4 shrink-0 rounded-full bg-primary transition-[width]'
+                        : 'h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30 transition-[width]'
                     }
                   />
                 ))}


### PR DESCRIPTION
Motion batch — the conservative subset (motion is where deliberate design lives, so I only did the safe scoping).

Replaced the 8 remaining `transition-all` usages with property-scoped transitions matching what each element actually animates:
- document-guide option/category cards → `transition-[color,background-color,border-color]` (hover border/bg)
- guide progress bar + tour step dots → `transition-[width]`
- **tour spotlight** → `transition-[top,left,width,height]`, so it animates its geometry when moving between targets without also trying to interpolate the 9999px full-screen dimming shadow (a literal ledger item)

Same visible motion, just no wasted interpolation of unrelated properties. The primitives were already scoped in earlier work. Left the deliberate motion-timing choices (durations, easing curves, modal-open speed, exit animations) alone — those read as intentional, not cleanup.

Verified: build 0, lint 0, check-no-cdn OK; zero `transition-all` left in components.