### PR TITLE
chore(ui): tooltip offset + max width; About title icon size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.85] — 2026-07-05
+
+### Changed
+
+- Tooltips now sit a few pixels off their trigger (instead of touching it) and
+  cap their width, so a long hint wraps into a tidy box rather than stretching.
+- The About dialog's title icon is now the same size as every other dialog
+  title's icon.
+
 ## [1.2.84] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.84",
+  "version": "1.2.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.84",
+      "version": "1.2.85",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.84",
+  "version": "1.2.85",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/modals/AboutModal.tsx
+++ b/src/components/modals/AboutModal.tsx
@@ -24,7 +24,7 @@ export function AboutModal() {
       <DialogContent className="sm:max-w-lg max-h-[85vh]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-3">
-            <FileText className="h-6 w-6 text-primary" />
+            <FileText className="h-5 w-5 text-primary" />
             <span className="text-xl font-bold">Naval Correspondence Generator</span>
             <Badge variant="secondary" title={`Build ${GIT_SHA} · ${formatBuildTime()}`}>
               v{APP_VERSION}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -37,7 +37,7 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
-  sideOffset = 0,
+  sideOffset = 4,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
@@ -47,7 +47,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className
         )}
         {...props}


### PR DESCRIPTION
Kbd/tooltip/icon batch.

- **Tooltip:** default `sideOffset` 0 → 4 (a small gap from the trigger, standard for tooltips) and added `max-w-xs` so a long hint wraps into a box instead of stretching wide. `text-balance` was already there.
- **About dialog title icon:** `h-6 w-6` → `h-5 w-5`, matching every other dialog title's icon (it was the lone outlier).

Deliberately skipped from this batch:
- routing `DropdownMenuShortcut` through the bordered `<Kbd>` chip — menu shortcuts as plain muted text is the standard menu convention (macOS-style); chips would read heavier. The Help-panel grid already uses `<Kbd>`.
- the `h-4 w-4` → `size-4` shorthand sweep — pure source churn with zero rendered difference.

Verified: build 0, lint 0, check-no-cdn OK.