### PR TITLE
chore(ui): hover tooltips on the sidebar collapse/expand/new buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.86] — 2026-07-05
+
+### Changed
+
+- The sidebar's collapse, expand, and New-document buttons now show a hover
+  tooltip (they already had screen-reader names). Tidied a no-op ellipsis style
+  on the Recents timestamps.
+
 ## [1.2.85] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.85",
+  "version": "1.2.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.85",
+      "version": "1.2.86",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.85",
+  "version": "1.2.86",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/layout/EditorSidebar.tsx
+++ b/src/components/layout/EditorSidebar.tsx
@@ -207,7 +207,7 @@ export function EditorSidebar() {
         <button
           type="button"
           onClick={toggleSidebar}
-          aria-label="Expand sidebar"
+          aria-label="Expand sidebar" title="Expand sidebar"
           aria-expanded={false}
           className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
         >
@@ -216,7 +216,7 @@ export function EditorSidebar() {
         <button
           type="button"
           onClick={newDocument}
-          aria-label="New document"
+          aria-label="New document" title="New document"
           className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
         >
           <Plus className="h-4 w-4" />
@@ -242,7 +242,7 @@ export function EditorSidebar() {
           <button
             type="button"
             onClick={toggleSidebar}
-            aria-label="Collapse sidebar"
+            aria-label="Collapse sidebar" title="Collapse sidebar"
             aria-expanded={true}
             className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
           >
@@ -481,7 +481,7 @@ export function EditorSidebar() {
                               >
                                 {m.title}
                               </span>
-                              <span className="block truncate text-2xs text-muted-foreground tnum">
+                              <span className="block whitespace-nowrap text-2xs text-muted-foreground tnum">
                                 {relTime(m.updatedAt)}
                               </span>
                             </span>


### PR DESCRIPTION
Header + editor-sidebar batch. Most of this batch's ledger items turned out already-done, so this is the genuinely-open subset:

- The sidebar's **Expand**, **Collapse**, and **New document** icon buttons had `aria-label` (screen-reader names) but no `title`, so mouse users got no hover hint like the sort/select controls do. Added matching `title`s.
- Swapped a no-op `truncate` on the Recents timestamp for `whitespace-nowrap` — the relative times ("2m ago", "3d ago", …) are always short, so the ellipsis never triggered; keeping just the no-wrap is the honest intent.

Verified already-done / deliberate (left alone): the active Recents row already shows only the 3px bar + `text-primary` (no doubled fill — documented in-code); the Recents-zone controls are already uniform at 28px; the compiling refresh button's disabled fade is the correct disabled cue.

Verified: build 0, lint 0, check-no-cdn OK.