### PR TITLE
chore(ui): editor-panel touch-ups (press feedback, cursor, stray italic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.87] — 2026-07-05
+
+### Changed
+
+- Small editor-panel touch-ups: the signature-style buttons give a subtle press
+  response, the custom-classification preset chips show a pointer cursor on
+  hover, and the letterhead "Street / Box (optional)" hint drops a stray italic
+  so it matches the other "(optional)" hints.
+
 ## [1.2.86] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.86",
+  "version": "1.2.87",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.86",
+      "version": "1.2.87",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.86",
+  "version": "1.2.87",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/ClassificationSection.tsx
+++ b/src/components/editor/ClassificationSection.tsx
@@ -281,7 +281,7 @@ export function ClassificationSection() {
                             key={preset.value}
                             type="button"
                             onClick={() => setField('customClassification', preset.value)}
-                            className={`px-2 py-1 text-xs font-medium rounded-md border transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 ${preset.color} ${preset.bg} ${active ? 'ring-2 ring-offset-1 ring-offset-background ring-current' : ''}`}
+                            className={`px-2 py-1 text-xs font-medium rounded-md border cursor-pointer transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 ${preset.color} ${preset.bg} ${active ? 'ring-2 ring-offset-1 ring-offset-background ring-current' : ''}`}
                             title={`Set marking to "${preset.value}"`}
                           >
                             {preset.label}

--- a/src/components/editor/LetterheadSection.tsx
+++ b/src/components/editor/LetterheadSection.tsx
@@ -272,7 +272,7 @@ export function LetterheadSection() {
                       htmlFor="addressStreet"
                       className="text-xs font-normal text-muted-foreground"
                     >
-                      Street / Box <span className="italic">(optional)</span>
+                      Street / Box <span>(optional)</span>
                     </Label>
                     <Input
                       id="addressStreet"

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -500,7 +500,7 @@ export function SignatureSection({ config }: SignatureSectionProps) {
                           role="radio"
                           aria-checked={selected}
                           tabIndex={selected ? 0 : -1}
-                          className={`flex flex-col items-center gap-1.5 rounded-md border py-3 px-1.5 text-xs font-medium cursor-pointer transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 ${
+                          className={`flex flex-col items-center gap-1.5 rounded-md border py-3 px-1.5 text-xs font-medium cursor-pointer transition-[color,background-color,border-color,transform] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 active:scale-[0.98] ${
                             selected
                               ? 'border-primary bg-primary/10 text-primary'
                               : 'border-border text-foreground hover:bg-muted/40'


### PR DESCRIPTION
Editor form-sections batch — the concrete, safe subset (most items in this batch were already done or are deliberate).

- **Signature-style buttons:** added `active:scale-[0.98]` press feedback (and scoped their transition to include `transform`), matching the press affordance elsewhere.
- **Custom-classification preset chips:** added `cursor-pointer` so hovering a preset shows the pointer.
- **Letterhead "Street / Box (optional)":** dropped a lone `italic` on the "(optional)" hint so it matches the non-italic "(optional)" on the sibling field.

Left alone (already done / deliberate): the shared `<RequiredMark/>` already exists; the classification preset active ring uses `ring-current` on purpose (color-codes to the marking); the Via ordinal badge width was already normalized.

Verified: build 0, lint 0, check-no-cdn OK.