### PR TITLE
chore(ui): steady @-menu width, hover fill on remove buttons, 'Browse Library'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.88] — 2026-07-05
+
+### Changed
+
+- The "@" insert menu no longer changes width as you type (its empty / create /
+  results states are now the same width).
+- The reference and enclosure trash buttons show a faint red hover fill instead
+  of a no-op hover.
+- The References "Library" button reads "Browse Library," parallel to "Add
+  Reference."
+
 ## [1.2.87] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.87",
+  "version": "1.2.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.87",
+      "version": "1.2.88",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.87",
+  "version": "1.2.88",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/EnclosuresManager.tsx
+++ b/src/components/editor/EnclosuresManager.tsx
@@ -191,7 +191,7 @@ function SortableEnclosure({
           size="icon"
           onClick={onRemove}
           aria-label={`Remove enclosure ${index + 1}`}
-          className="text-destructive hover:text-destructive"
+          className="text-destructive hover:bg-destructive/10 hover:text-destructive"
         >
           <Trash2 className="h-4 w-4" />
         </Button>

--- a/src/components/editor/ReferencesManager.tsx
+++ b/src/components/editor/ReferencesManager.tsx
@@ -154,7 +154,7 @@ const SortableReference = memo(function SortableReference({
           size="icon"
           onClick={handleRemove}
           aria-label={`Remove reference ${index + 1}`}
-          className="text-destructive hover:text-destructive"
+          className="text-destructive hover:bg-destructive/10 hover:text-destructive"
         >
           <Trash2 className="h-4 w-4" />
         </Button>
@@ -284,7 +284,7 @@ export function ReferencesManager() {
                   onClick={() => setReferenceLibraryOpen(true)}
                 >
                   <Library className="h-4 w-4 mr-2" />
-                  Library
+                  Browse Library
                 </Button>
               </div>
 

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -342,7 +342,7 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
     // If no matches and user typed something, offer to create custom variable
     if (items.length === 0 && query.trim()) {
       return (
-        <div className="bg-popover border border-border rounded-md shadow-md overflow-hidden w-[280px]">
+        <div className="bg-popover border border-border rounded-md shadow-md overflow-hidden w-[300px]">
           <div className="px-3 py-2 border-b border-border bg-muted/50">
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <span className="text-base font-medium text-info">@</span>
@@ -370,7 +370,7 @@ const SuggestionList = forwardRef<SuggestionListRef, SuggestionListProps>(
 
     if (items.length === 0) {
       return (
-        <div className="bg-popover border border-border rounded-md shadow-md overflow-hidden w-[280px]">
+        <div className="bg-popover border border-border rounded-md shadow-md overflow-hidden w-[300px]">
           <div className="px-3 py-3 text-sm text-muted-foreground text-center">
             Type a variable name...
           </div>


### PR DESCRIPTION
Block-editor + references/enclosures batch.

- **@ insert menu:** its three states (results / empty / create-new) were `w-[280px]` vs `w-[300px]`, so the popup jumped width as you typed. All three now `w-[300px]`.
- **Remove (trash) buttons** on references and enclosures had `hover:text-destructive` on already-destructive text (a no-op). Added `hover:bg-destructive/10` for a real hover affordance.
- **"Library" → "Browse Library"** on the references button, parallel to "Add Reference."

Left alone: the reference letter badge `tnum` (letters aren't digits, so tabular figures do nothing); the NAVMC form-title size / shared-FOUO-string items are more subjective and I didn't want to restructure those panels for a cosmetic tweak.

Verified: build 0, lint 0, check-no-cdn OK.