### PR TITLE
chore(ui): align preview empty/loading hero; widen PDF page field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.89] — 2026-07-05
+
+### Changed
+
+- The preview panel's idle "your document preview will appear here" icon is now
+  the same size as the loading spinner, and its helper text uses the same width,
+  so the empty and loading states line up. The PDF page-number field is a touch
+  wider so three-digit page numbers aren't cramped.
+
 ## [1.2.88] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.88",
+  "version": "1.2.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.88",
+      "version": "1.2.89",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.88",
+  "version": "1.2.89",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/layout/PreviewPanel.tsx
+++ b/src/components/layout/PreviewPanel.tsx
@@ -178,9 +178,9 @@ export function PreviewPanel({ pdfUrl, isCompiling, isWarmingUp = false, preview
                 )
               ) : (
                 <>
-                  <Eye className="h-8 w-8 text-muted-foreground" />
+                  <Eye className="h-10 w-10 text-muted-foreground" />
                   <p className="text-sm font-medium text-foreground">Your document preview will appear here</p>
-                  <p className="max-w-[16rem] text-center text-xs text-muted-foreground">
+                  <p className="max-w-xs text-center text-xs text-muted-foreground">
                     Fill in the Subject and body on the left — the formatted letter renders here as you type.
                   </p>
                 </>

--- a/src/components/pdf/PdfViewerToolbar.tsx
+++ b/src/components/pdf/PdfViewerToolbar.tsx
@@ -138,7 +138,7 @@ export function PdfViewerToolbar({
           disabled={pageCount === 0}
           inputMode="numeric"
           aria-label="Page number"
-          className="tnum h-6 w-9 rounded-md border border-border bg-background text-center text-xs text-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-50"
+          className="tnum h-6 w-10 rounded-md border border-border bg-background text-center text-xs text-foreground outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-50"
           onKeyDown={(e) => {
             if (e.key === 'Enter') commitPage(e.currentTarget);
             if (e.key === 'Escape') e.currentTarget.value = String(page);


### PR DESCRIPTION
Preview + PDF viewer batch — the trivially-safe subset (most of this batch was already done or is a feature-add).

- **Preview panel:** the idle empty-state icon (`Eye`) was `h-8`, but the warming-up / generating spinners are `h-10`; bumped the idle icon to `h-10` and unified the two helper-text max-widths to `max-w-xs`, so the empty and loading states share one hero geometry.
- **PDF toolbar:** page-number input `w-9` → `w-10`, so three-digit page numbers aren't cramped.

Left alone (already done / feature-add / subjective): the fit-width/fit-page toggles already show a `bg-primary/10` pressed fill; the toolbar already has group dividers; the resize divider's "1px hairline at rest" and double-click-to-reset / live-width-readout are design/feature calls, not cleanups.

Verified: build 0, lint 0, check-no-cdn OK.