### PR TITLE
chore(ui): normalize About title; ring the date-picker 'today'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.90] — 2026-07-05
+
+### Changed
+
+- The About dialog's title now uses the same size and weight as every other
+  dialog title. In the date picker, "today" is marked with a ring outline
+  instead of a fill, so it reads distinctly from the solid-filled selected day.
+
 ## [1.2.89] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.89",
+  "version": "1.2.90",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.89",
+      "version": "1.2.90",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.89",
+  "version": "1.2.90",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/modals/AboutModal.tsx
+++ b/src/components/modals/AboutModal.tsx
@@ -25,7 +25,7 @@ export function AboutModal() {
         <DialogHeader>
           <DialogTitle className="flex items-center gap-3">
             <FileText className="h-5 w-5 text-primary" />
-            <span className="text-xl font-bold">Naval Correspondence Generator</span>
+            <span>Naval Correspondence Generator</span>
             <Badge variant="secondary" title={`Build ${GIT_SHA} · ${formatBuildTime()}`}>
               v{APP_VERSION}
             </Badge>

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -48,7 +48,7 @@ function Calendar({
         range_end: "day-range-end rounded-r-md",
         selected:
           "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-        today: "bg-primary/10 text-primary font-semibold",
+        today: "ring-1 ring-inset ring-primary/40 text-primary font-semibold",
         outside:
           "day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30",
         disabled: "text-muted-foreground opacity-50",


### PR DESCRIPTION
Final polish batch (modals / notices / onboarding / primitives) — the clearly-safe subset.

- **About dialog title:** dropped the `text-xl font-bold` override so it inherits `DialogTitle`'s `text-lg font-semibold`, matching every other dialog title.
- **Date picker "today":** was a `bg-primary/10` fill — the same visual language as the solid-filled "selected" day. Changed to a `ring-1 ring-inset ring-primary/40` outline so today and selected read as distinct states (standard calendar convention).

Verified already-done / deliberate (left alone): About already has `max-h-[85vh]`; the ShareModal copy-again button already shows a `Copy` icon at rest; the notice strips were already tokenized onto `--warning` with focus rings; bumping the global `Label` from `text-xs` to `text-sm` would restyle every label app-wide (callers compensate with overrides) — too broad for a polish pass.

Verified: build 0, lint 0, check-no-cdn OK.