### PR TITLE
fix(ui): remove the duplicate full-viewport EGA watermark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.91] — 2026-07-06
+
+### Fixed
+
+- The Marine Corps EGA emblem no longer appears twice. A faint full-viewport
+  watermark sat behind the whole app in addition to the denser one in the editor
+  column; because they were centered on different things, they drifted apart at
+  some zoom levels and read as a doubled emblem (with one bleeding behind the
+  sidebar and header). Removed the full-viewport copy, leaving the single
+  contained editor watermark. The animated background is unchanged.
+
 ## [1.2.90] — 2026-07-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.90",
+  "version": "1.2.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.90",
+      "version": "1.2.91",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.90",
+  "version": "1.2.91",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,6 @@ import { StorageNotice } from '@/components/StorageNotice';
 import { BackupNotice } from '@/components/BackupNotice';
 import { InstallNotice } from '@/components/InstallNotice';
 import { probeStorageHealth } from '@/lib/documentsDb';
-const marineCodersLogo = `${import.meta.env.BASE_URL}attachments/marine-coders-logo.svg`;
 import { useUIStore } from '@/stores/uiStore';
 import { useDocumentStore, getSavedSession, rehydrateEnclosureFiles } from '@/stores/documentStore';
 import { useFormStore, FORMS_PERSIST_KEY } from '@/stores/formStore';
@@ -1822,18 +1821,10 @@ ${texFiles['body.tex'] || '% No body content'}
         and preview toolbar under it — with a 100vh fallback for pre-dvh
         engines. */}
     <div className="flex flex-col h-screen-dvh bg-background relative overflow-hidden">
-      {/* Faint Marine Coders EGA watermark behind the whole app. The animated
-          beams + a denser EGA seal live inside the editor column (FormPanel),
-          so the branded motion stays in the editor and doesn't sweep behind the
-          sidebar, header, and preview. */}
-      <div className="fixed inset-0 z-0 flex items-center justify-center pointer-events-none mt-16">
-        <img
-          src={marineCodersLogo}
-          alt=""
-          className="w-full max-w-[90vw] sm:max-w-[1200px] opacity-[0.04] sm:opacity-[0.035] dark:opacity-[0.055] dark:sm:opacity-[0.05] invert dark:invert-0"
-          aria-hidden="true"
-        />
-      </div>
+      {/* The Marine Coders EGA seal (and the animated beams) live inside the
+          editor column (FormPanel) as a single, contained brand watermark. The
+          previous full-viewport seal here duplicated it behind the sidebar and
+          header at some zoom levels, so it was removed. */}
       {/* Skip link for keyboard navigation - WCAG 2.4.1 */}
       <a
         href="#main-content"


### PR DESCRIPTION
**Bug:** at some browser zoom levels the Marine Corps EGA emblem showed twice — once in the editor (correct) and again bleeding behind the sidebar and header.

**Cause:** two faint EGA watermarks were layered:
- a `fixed inset-0` full-viewport seal in `App.tsx` (centered on the *viewport*), behind the whole app; and
- a denser seal in `FormPanel` (centered on the *editor column*).

Because they're centered on different things, they never line up — the editor column is offset by the sidebar / preview — so they separate into two visibly-offset emblems as the layout scales.

**Fix:** removed the full-viewport copy in `App.tsx` (and its now-unused `marineCodersLogo` const), leaving the single contained editor watermark. The `BackgroundBeams` animation is untouched.

Verified live: after the change the DOM has exactly one faint watermark (the 480px editor one), the full-viewport one is gone, the header brand logo and the beams are intact. build 0, lint 0, check-no-cdn OK.