### PR TITLE
fix(pwa): reliably deliver new builds to open sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.92] — 2026-07-06
+
+### Fixed
+
+- New builds now reach open sessions reliably. The service worker and the HTML
+  entry are the two files that tell a running app a newer version exists, but
+  they had no cache rule, so a CDN- or browser-cached copy could hide new
+  releases — leaving people on stale UI until a manual hard-refresh. They're now
+  served `no-cache, must-revalidate` (hashed assets stay cached forever), and the
+  app also checks for updates the moment its tab is refocused or the network
+  reconnects — not only on the 60-second timer. Together these get a fresh build
+  in front of active users within seconds of them returning to the tab.
+
 ## [1.2.91] — 2026-07-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.91",
+  "version": "1.2.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.91",
+      "version": "1.2.92",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.91",
+  "version": "1.2.92",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/public/_headers
+++ b/public/_headers
@@ -15,6 +15,29 @@
   Content-Type: text/plain
   Cache-Control: no-cache, no-store, must-revalidate
 
+# Update pivots — must always be revalidated, never served stale.
+# The service worker is how every client learns a new build exists: if the edge
+# or browser serves a cached sw.js, registration.update() can't see the new
+# version and users get stuck on the old UI. index.html is the entry that points
+# at the current hashed bundles, so it must be fresh too. `no-cache` = revalidate
+# with the origin (cheap 304 when unchanged), not "never cache".
+/sw.js
+  Cache-Control: no-cache, must-revalidate
+/index.html
+  Cache-Control: no-cache, must-revalidate
+/
+  Cache-Control: no-cache, must-revalidate
+/registerSW.js
+  Cache-Control: no-cache, must-revalidate
+/manifest.webmanifest
+  Cache-Control: no-cache, must-revalidate
+
+# Hashed build assets are content-addressed (their name changes when they
+# change), so they're safe to cache forever — this is a load-time win, not a
+# staleness risk.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
 # Enable CORS for all assets (needed for service worker)
 /*
   Access-Control-Allow-Origin: *

--- a/src/hooks/useServiceWorker.ts
+++ b/src/hooks/useServiceWorker.ts
@@ -17,6 +17,9 @@ export function useServiceWorker() {
   // Periodic update-check interval, cancelled on unmount so dev HMR and tests
   // don't leak a 60s timer calling registration.update() against a dead component.
   const updateIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // The live registration, so the focus/reconnect listeners below can trigger an
+  // immediate update check (not just wait for the next 60s tick).
+  const registrationRef = useRef<ServiceWorkerRegistration | null>(null);
 
   const {
     needRefresh: [needRefresh],
@@ -29,6 +32,7 @@ export function useServiceWorker() {
       // Poll for updates every 60s. Clear any prior interval in case
       // onRegisteredSW fires more than once (e.g. dev re-registration).
       if (registration) {
+        registrationRef.current = registration;
         if (updateIntervalRef.current) {
           clearInterval(updateIntervalRef.current);
         }
@@ -49,6 +53,26 @@ export function useServiceWorker() {
         clearInterval(updateIntervalRef.current);
         updateIntervalRef.current = null;
       }
+    };
+  }, []);
+
+  // Check for a new build the moment a long-lived session comes back to life —
+  // when the tab is refocused or the network reconnects — instead of waiting up
+  // to 60s for the next poll (or the browser's own ~24h check). This is what
+  // gets a fresh build to users who leave the app open for hours/days.
+  useEffect(() => {
+    const checkNow = () => {
+      if (document.visibilityState === 'visible') {
+        registrationRef.current?.update().catch(() => {});
+      }
+    };
+    document.addEventListener('visibilitychange', checkNow);
+    window.addEventListener('focus', checkNow);
+    window.addEventListener('online', checkNow);
+    return () => {
+      document.removeEventListener('visibilitychange', checkNow);
+      window.removeEventListener('focus', checkNow);
+      window.removeEventListener('online', checkNow);
     };
   }, []);
 


### PR DESCRIPTION
**Problem:** active users stay on stale UI after a deploy (e.g. the EGA fix didn't reach them) with no way short of a manual hard-refresh.

**Root causes (two, both real):**

1. **No cache policy on the update pivots.** `public/_headers` set caching for wasm/tex but **nothing for `sw.js` or `index.html`** — the two files that tell a running app a new build exists. A CDN/browser-cached `sw.js` means `registration.update()` fetches the *old* worker and never sees the new release. Added `Cache-Control: no-cache, must-revalidate` for `sw.js`, `index.html`, `/`, `registerSW.js`, and the web manifest. Hashed `/assets/*` are content-addressed, so they're now explicitly `immutable` (a load-time win, no staleness risk).

2. **Update checks only fired on a 60 s timer.** A user who leaves the tab open and returns hours later waited up to a minute (or the browser's own ~24 h check). Added an immediate `registration.update()` on `visibilitychange` (tab refocus), `focus`, and `online` (reconnect). So returning to the tab now surfaces the update prompt within seconds.

Neither change forces a reload — it keeps the existing 'prompt, don't interrupt work' model; it just makes the *prompt* actually appear.

**Honest caveat:** this makes delivery robust **going forward**. The current already-cached cohort picks up this build via the browser's built-in SW update check (≤24 h) or any reload; there's no way to un-cache an already-served `sw.js` faster than that — it's a fundamental SW constraint. Once they're on this build, every future update lands within seconds.

Verified: build 0, lint 0, check-no-cdn OK; `dist/_headers` carries the `sw.js` no-cache rule (Cloudflare Pages reads it from the output root).