### PR TITLE
fix(signature): print a bare "By direction" unless an authority is named

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.93] — 2026-07-06
+
+### Fixed
+
+- The "By direction" signature block now reads "By direction" instead of
+  "By direction of the Commanding Officer". Per SECNAV M-5216.5 Ch 7
+  ¶14b(4)-(5) the bare form is the norm; the "of the <activity head>" long
+  form is reserved for correspondence affecting pay and allowances. Both the
+  PDF and DOCX paths hardcoded the long form with a "the Commanding Officer"
+  fallback, so every by-direction letter carried it. The Authority field is
+  now optional and only adds the long form when a name is entered.
+
 ## [1.2.92] — 2026-07-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.92",
+  "version": "1.2.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.92",
+      "version": "1.2.93",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.92",
+  "version": "1.2.93",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -461,19 +461,24 @@ export function SignatureSection({ config }: SignatureSectionProps) {
                   onCheckedChange={(checked) => setField('byDirection', !!checked)}
                 />
                 <Label htmlFor="byDirection" className="font-normal">
-                  By direction of...
+                  By direction
                 </Label>
               </div>
 
               {formData.byDirection && (
                 <div className="space-y-2 ml-6">
-                  <Label htmlFor="byDirectionAuthority">Authority</Label>
+                  <Label htmlFor="byDirectionAuthority">Authority (optional)</Label>
                   <Input
                     id="byDirectionAuthority"
                     value={formData.byDirectionAuthority || ''}
                     onChange={(e) => setField('byDirectionAuthority', e.target.value)}
-                    placeholder="the Commanding Officer"
+                    placeholder="Leave blank for a plain “By direction”"
                   />
+                  <p className="text-xs text-muted-foreground">
+                    Per SECNAV M-5216.5 Ch 7, the signature block reads “By direction.”
+                    Name an authority only when the correspondence affects pay and
+                    allowances — it then prints “By direction of the Commanding Officer.”
+                  </p>
                 </div>
               )}
             </div>

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -591,6 +591,15 @@ function buildBody(paragraphs: Paragraph[], config: DocTypeConfig): string {
   return bodyParts.join('');
 }
 
+/** "By direction" line per SECNAV M-5216.5 Ch 7 ¶14b(4)-(5): the bare form is
+ *  the norm. The "of the <activity head>" long form is reserved for
+ *  correspondence affecting pay and allowances, so it appears only when an
+ *  authority is actually named — never as a default. */
+function buildByDirectionLine(authority: string | undefined): string {
+  const named = (authority || '').trim();
+  return named ? `By direction of ${escapeTabular(named)}` : 'By direction';
+}
+
 /** Single signature block positioned in right half using tabularX */
 function buildSignature(data: Partial<DocumentData>, config: DocTypeConfig): string {
   const sigStyle = config.signature;
@@ -610,8 +619,7 @@ function buildSignature(data: Partial<DocumentData>, config: DocTypeConfig): str
     if (data.sigTitle) sigRows.push(escapeTabular(data.sigTitle));
   }
   if (data.byDirection) {
-    const authority = data.byDirectionAuthority || 'the Commanding Officer';
-    sigRows.push(`By direction of ${escapeTabular(authority)}`);
+    sigRows.push(buildByDirectionLine(data.byDirectionAuthority));
   }
 
   const rows = sigRows.map(r => ` & ${r} \\\\`).join('\n');
@@ -639,8 +647,7 @@ function buildBusinessSignature(data: Partial<DocumentData>): string {
   if (data.sigRank) sigRows.push(escapeTabular(data.sigRank));
   if (data.sigTitle) sigRows.push(escapeTabular(data.sigTitle));
   if (data.byDirection) {
-    const authority = data.byDirectionAuthority || 'the Commanding Officer';
-    sigRows.push(`By direction of ${escapeTabular(authority)}`);
+    sigRows.push(buildByDirectionLine(data.byDirectionAuthority));
   }
 
   // Use tabularX{XcX} for centering (pandoc ignores \begin{center})

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -336,8 +336,12 @@ export function generateSignatoryTex(store: DocumentStore): string {
 
   let byDirectionTex = '';
   if (data.byDirection) {
-    const authority = data.byDirectionAuthority || 'the Commanding Officer';
-    byDirectionTex = `\\setByDirection{By direction of ${escapeLatex(authority)}}`;
+    // Per SECNAV M-5216.5 Ch 7 ¶14b(4)-(5) the bare "By direction" is the norm;
+    // the "of the <activity head>" long form is reserved for correspondence
+    // affecting pay and allowances, so it only appears when one is named.
+    const authority = (data.byDirectionAuthority || '').trim();
+    const line = authority ? `By direction of ${escapeLatex(authority)}` : 'By direction';
+    byDirectionTex = `\\setByDirection{${line}}`;
   }
 
   // Set signature type and image

--- a/tests/integration/by-direction-render.test.ts
+++ b/tests/integration/by-direction-render.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Rendered-output check for the "By direction" signature block.
+ *
+ * The unit regression (tests/regressions/by-direction-bare-form.test.ts)
+ * asserts the generators emit the right LaTeX *source*. That passes even if a
+ * template never renders the macro — `generator.ts` only calls
+ * `\setByDirection{...}`; the per-doc-type templates are what actually print it
+ * via `\optionalField{\ByDirection}`. This test closes that gap: it compiles a
+ * real PDF and reads the signature block off the page, so dropping the
+ * `\ByDirection` render site is caught rather than shipping a silently missing
+ * signature line.
+ *
+ * Requires pdflatex + pdftotext; skipped (not falsely passed) without them.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { writeFile, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { compileFixture } from '../_helpers/compileLatex';
+
+const toolchain =
+  spawnSync('pdflatex', ['--version'], { encoding: 'utf-8' }).status === 0 &&
+  spawnSync('pdftotext', ['-v'], { encoding: 'utf-8' }).status === 0;
+
+if (!toolchain) {
+  console.warn('[by-direction-render] pdflatex/pdftotext missing — SKIPPING.');
+}
+
+function store(byDirectionAuthority: string) {
+  return {
+    docType: 'naval_letter',
+    formData: {
+      docType: 'naval_letter',
+      fontSize: '12pt',
+      fontFamily: 'times',
+      pageNumbering: 'none',
+      department: 'usmc',
+      unitLine1: '1ST BATTALION, 6TH MARINES',
+      unitLine2: '2D MARINE DIVISION, II MEF',
+      unitAddress: 'PSC BOX 20123, CAMP LEJEUNE, NC 28542-0123',
+      sealType: 'dow',
+      letterheadColor: 'blue',
+      ssic: '1000',
+      serial: '0123',
+      date: '15 Jan 25',
+      from: 'Commanding Officer, 1st Battalion, 6th Marines',
+      to: 'Commanding General, II MEF',
+      subject: 'BY DIRECTION RENDER CHECK',
+      sigFirst: 'John',
+      sigMiddle: 'A',
+      sigLast: 'DOE',
+      sigRank: 'Lieutenant Colonel',
+      sigTitle: 'Commanding Officer',
+      classLevel: 'unclassified',
+      byDirection: true,
+      byDirectionAuthority,
+    },
+    references: [],
+    enclosures: [],
+    paragraphs: [{ text: 'Render check.', level: 0 }],
+    copyTos: [],
+    distributions: [],
+  } as never;
+}
+
+/** Compile the fixture and return the text pdftotext reads off the page. */
+async function renderedText(authority: string): Promise<string> {
+  const result = await compileFixture(store(authority));
+  expect(result.ok, `pdflatex failed; work dir: ${result.workDir}`).toBe(true);
+  const dir = await mkdtemp(join(tmpdir(), 'dondocs-bd-'));
+  const pdfPath = join(dir, 'out.pdf');
+  await writeFile(pdfPath, result.pdfBytes!);
+  const { stdout } = spawnSync('pdftotext', [pdfPath, '-'], { encoding: 'utf-8' });
+  // A blank extraction would make the assertions below vacuous.
+  expect(stdout.trim().length).toBeGreaterThan(0);
+  return stdout;
+}
+
+describe('by-direction signature — rendered PDF', () => {
+  it.skipIf(!toolchain)('prints a bare "By direction" when no authority is named', async () => {
+    const text = await renderedText('');
+    expect(text).toMatch(/By direction/);
+    expect(text).not.toMatch(/By direction of/);
+  });
+
+  it.skipIf(!toolchain)('prints the long form when an authority is named', async () => {
+    expect(await renderedText('the Commanding Officer')).toMatch(
+      /By direction of the Commanding Officer/
+    );
+  });
+});

--- a/tests/regressions/by-direction-bare-form.test.ts
+++ b/tests/regressions/by-direction-bare-form.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Regression: the "By direction" signature block hardcoded a
+ * `|| 'the Commanding Officer'` fallback, so every by-direction letter printed
+ * "By direction of the Commanding Officer" — in both the PDF (generator) and
+ * flat/DOCX (flat-generator) paths. SECNAV M-5216.5 Ch 7 ¶14b(4)-(5) makes the
+ * bare "By direction" the norm and reserves the "of the <activity head>" long
+ * form for correspondence affecting pay and allowances, so the long form must
+ * appear only when an authority is actually named.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateFlatLatex } from '@/services/latex/flat-generator';
+import { generateSignatoryTex } from '@/services/latex/generator';
+
+function store(byDirectionAuthority?: string) {
+  return {
+    docType: 'naval_letter',
+    formData: {
+      from: 'Commanding Officer, 1st Battalion, 6th Marines',
+      to: 'CG, II MEF',
+      subject: 'TEST',
+      sigFirst: 'John',
+      sigLast: 'DOE',
+      sigRank: 'Lieutenant Colonel',
+      byDirection: true,
+      byDirectionAuthority,
+    },
+    references: [],
+    enclosures: [],
+    paragraphs: [{ text: 'body', level: 0 }],
+    copyTos: [],
+    distributions: [],
+  } as never;
+}
+
+describe.each([
+  ['flat-generator (DOCX path)', (a?: string) => generateFlatLatex(store(a))],
+  ['generator (PDF path)', (a?: string) => generateSignatoryTex(store(a))],
+])('by-direction bare form — %s', (_label, render) => {
+  it('emits a bare "By direction" when no authority is named', () => {
+    const tex = render();
+    expect(tex).toContain('By direction');
+    // The long form must not be conjured from a default.
+    expect(tex).not.toContain('By direction of');
+  });
+
+  it('emits the long form only when an authority is named', () => {
+    expect(render('the Commanding Officer')).toContain(
+      'By direction of the Commanding Officer'
+    );
+  });
+
+  it('treats a whitespace-only authority as unset', () => {
+    expect(render('   ')).not.toContain('By direction of');
+  });
+});


### PR DESCRIPTION
Reported by a user in Semper Admin: the by-direction signature block always appends "of the Commanding Officer".

**The reg.** SECNAV M-5216.5 Ch 7 ¶14b(4)-(5) — documented in our own `tex/README.md:445` — makes the bare **"By direction"** the norm. The **"of the <activity head>"** long form is reserved for correspondence that *affects pay and allowances*.

**The bug.** Both generators hardcoded the long form with a fallback:
```js
const authority = data.byDirectionAuthority || 'the Commanding Officer';
sigRows.push(`By direction of ${escapeTabular(authority)}`);
```
So every by-direction letter — PDF and DOCX — printed the long form, defaulting to an activity head the user never named. The UI reinforced it: the checkbox was labelled "By direction of…" with a "the Commanding Officer" placeholder, walking users into the non-compliant form.

**The fix.**
- Long form only when an authority is actually named; blank (or whitespace-only) → bare `By direction`. Extracted `buildByDirectionLine()` in the flat generator since both call sites were identical; `generator.ts` fixed in place (different escaper).
- Relabelled the checkbox to **"By direction"**, made Authority explicitly optional, and added a hint explaining the pay-and-allowances rule so the long form is a deliberate choice.

**Tests.** New `tests/regressions/by-direction-bare-form.test.ts` runs the same three cases against *both* generators (bare / named / whitespace-only). They fail against the old default.

build 0, lint 0, check-no-cdn OK, 1601/1601 tests.