### PR TITLE
feat(endorsement): let an endorsement continue the basic letter's sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.94] — 2026-07-06
+
+### Added
+
+- Endorsements can now say where they pick up. An endorsement continues the
+  basic letter's numbering rather than opening its own (SECNAV M-5216.5 Ch 9
+  ¶3) — if the basic letter ran to reference (f), the endorsement starts at
+  (g) — but DonDocs restarted every sequence from scratch: page 1, reference
+  (a), enclosure (1). The basic letter is a separate document the app cannot
+  read, so a "Continues from the basic letter" group on endorsement document
+  types takes the first page number, first reference letter, and first
+  enclosure number. The starting page number was already honored by the
+  generator but had no control to set it.
+
+  The continuation applies to endorsements only, so a value left behind after
+  switching document type can never silently offset a basic letter's sequence.
+
 ## [1.2.93] — 2026-07-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.93",
+  "version": "1.2.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.93",
+      "version": "1.2.94",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.93",
+  "version": "1.2.94",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/editor/EndorsementBasicLetterSection.tsx
+++ b/src/components/editor/EndorsementBasicLetterSection.tsx
@@ -245,6 +245,73 @@ export function EndorsementBasicLetterSection() {
                 [activity] [letter type] [SSIC] Ser [N/N] of [date].
               </p>
             </div>
+
+            {/* Sequence continuation. An endorsement carries on the basic
+                letter's numbering instead of opening its own (Ch 9 ¶3), but the
+                basic letter is a separate document DonDocs can't read — so the
+                user supplies where this one picks up. */}
+            <div className="space-y-3 border-t border-border pt-4">
+              <div className="space-y-1">
+                <h4 className="text-sm font-medium">Continues from the basic letter</h4>
+                <p className="text-xs text-muted-foreground">
+                  An endorsement picks up where the basic letter left off — per SECNAV
+                  M-5216.5 Ch 9 ¶3, if it ran to reference (f), this one starts at (g).
+                  Leave these blank to start a fresh sequence.
+                </p>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-3">
+                <div className="space-y-2">
+                  <Label htmlFor="startingPageNumber">First page number</Label>
+                  <Input
+                    id="startingPageNumber"
+                    type="number"
+                    min={1}
+                    inputMode="numeric"
+                    value={formData.startingPageNumber ?? ''}
+                    onChange={(e) => {
+                      const v = e.target.value.trim();
+                      setField('startingPageNumber', v === '' ? 1 : Math.max(1, Number(v) || 1));
+                    }}
+                    placeholder="1"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="startingReferenceLetter">First reference</Label>
+                  <Input
+                    id="startingReferenceLetter"
+                    value={formData.startingReferenceLetter || ''}
+                    onChange={(e) => setField('startingReferenceLetter', e.target.value.trim().toLowerCase())}
+                    placeholder="a"
+                    maxLength={1}
+                    aria-describedby="startingReferenceLetter-hint"
+                  />
+                  <p id="startingReferenceLetter-hint" className="sr-only">
+                    A single letter, a through z.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="startingEnclosureNumber">First enclosure</Label>
+                  <Input
+                    id="startingEnclosureNumber"
+                    type="number"
+                    min={1}
+                    inputMode="numeric"
+                    value={formData.startingEnclosureNumber ?? ''}
+                    onChange={(e) => {
+                      const v = e.target.value.trim();
+                      setField(
+                        'startingEnclosureNumber',
+                        v === '' ? undefined : Math.max(1, Number(v) || 1)
+                      );
+                    }}
+                    placeholder="1"
+                  />
+                </div>
+              </div>
+            </div>
           </div>
         </AccordionContent>
       </AccordionItem>

--- a/src/lib/endorsement.ts
+++ b/src/lib/endorsement.ts
@@ -49,6 +49,38 @@ export function refWordForDocType(docType: string): string {
   return REF_WORD[docType] ?? 'ltr';
 }
 
+/** The doc types that continue a package rather than open one. */
+export function isEndorsement(docType: string): boolean {
+  return docType === 'same_page_endorsement' || docType === 'new_page_endorsement';
+}
+
+/**
+ * Zero-based index the reference lettering starts at.
+ *
+ * SECNAV M-5216.5 Ch 9 ¶3: an endorsement continues the basic letter's
+ * sequence — if the basic ran to (f), the endorsement's first new reference is
+ * (g). The basic letter is a separate document DonDocs cannot see, so the user
+ * supplies the start. Only endorsements continue a sequence; everything else
+ * opens its own at (a), so a stale value can't silently offset a basic letter.
+ */
+export function referenceStartIndex(docType: string, startingLetter?: string): number {
+  if (!isEndorsement(docType)) return 0;
+  const letter = (startingLetter ?? '').trim().toLowerCase();
+  if (!/^[a-z]$/.test(letter)) return 0;
+  return letter.charCodeAt(0) - 97;
+}
+
+/**
+ * The number the enclosure list starts at — the same Ch 9 ¶3 continuation rule
+ * as references. Defaults to 1 for anything that isn't an endorsement or has no
+ * usable value.
+ */
+export function enclosureStartNumber(docType: string, startingNumber?: number): number {
+  if (!isEndorsement(docType)) return 1;
+  const n = Number(startingNumber);
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1;
+}
+
 // Empty or a bracketed placeholder ([SSIC]) counts as absent.
 function usable(value: string | undefined): string {
   const t = (value ?? '').trim();

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -17,6 +17,7 @@
 import type { DocumentData, Reference, Enclosure, Paragraph, CopyTo, Distribution, DocTypeConfig } from '@/types/document';
 import { DOC_TYPE_CONFIG } from '@/types/document';
 import { LAYOUT, TEXT_WIDTH_IN } from '@/services/docx/layout-config';
+import { enclosureStartNumber } from '@/lib/endorsement';
 import { splitAddressForLetterhead } from '@/lib/unitAddress';
 import { deriveOverallClassLevel } from '@/lib/overallClassification';
 
@@ -503,16 +504,19 @@ ${trimLastRow(rows)}
 
 /** Enclosures using tabular for proper hanging-indent alignment.
  * Colon spacing per SECNAV Ch 7 ¶11b: Encl=3sp */
-function buildEnclosures(enclosures: Enclosure[]): string {
+function buildEnclosures(enclosures: Enclosure[], startNumber = 1): string {
   if (enclosures.length === 0) return '';
 
   const rows: string[] = [];
   for (let i = 0; i < enclosures.length; i++) {
     const encl = enclosures[i];
+    // `startNumber` lets an endorsement continue the basic letter's numbering
+    // (Ch 9 ¶3); it is 1 for everything that opens its own sequence.
+    const n = startNumber + i;
     if (i === 0) {
-      rows.push(`Encl:\\hspace{3\\fontdimen2\\font} & (${i + 1})~~${escapeTabular(encl.title)} \\\\`);
+      rows.push(`Encl:\\hspace{3\\fontdimen2\\font} & (${n})~~${escapeTabular(encl.title)} \\\\`);
     } else {
-      rows.push(` & (${i + 1})~~${escapeTabular(encl.title)} \\\\`);
+      rows.push(` & (${n})~~${escapeTabular(encl.title)} \\\\`);
     }
   }
 
@@ -1101,7 +1105,10 @@ function buildStandardLayout(store: DocumentStore, config: DocTypeConfig): strin
   content += buildInReplyTo(data);
   content += buildAddressBlock(data, config);
   content += buildReferences(store.references);
-  content += buildEnclosures(store.enclosures);
+  content += buildEnclosures(
+    store.enclosures,
+    enclosureStartNumber(store.docType, store.formData.startingEnclosureNumber)
+  );
   content += buildBody(store.paragraphs, config);
   content += buildSignature(data, config);
   content += buildDistribution(store.distributions);
@@ -1175,7 +1182,10 @@ function buildMemoLayout(store: DocumentStore, config: DocTypeConfig): string {
   }
   content += buildAddressBlock(data, config);
   content += buildReferences(store.references);
-  content += buildEnclosures(store.enclosures);
+  content += buildEnclosures(
+    store.enclosures,
+    enclosureStartNumber(store.docType, store.formData.startingEnclosureNumber)
+  );
   content += buildBody(store.paragraphs, config);
   if (config.hasDecisionBlock) content += buildDecisionBlock();
   content += buildSignature(data, config);
@@ -1203,7 +1213,10 @@ Subj:\\hspace{3\\fontdimen2\\font} & ${maybeUnderline(escapeTabularWrapped(data.
   }
 
   content += buildReferences(store.references);
-  content += buildEnclosures(store.enclosures);
+  content += buildEnclosures(
+    store.enclosures,
+    enclosureStartNumber(store.docType, store.formData.startingEnclosureNumber)
+  );
   content += buildBody(store.paragraphs, config);
   content += buildDualSignature(data, 'moa');
   content += buildDistribution(store.distributions);
@@ -1223,7 +1236,10 @@ function buildJointLayout(store: DocumentStore, config: DocTypeConfig): string {
   content += '\\vspace{12pt}\n\\noindent JOINT LETTER\n\n\\vspace{12pt}\n';
   content += buildJointAddressBlock(data);
   content += buildReferences(store.references);
-  content += buildEnclosures(store.enclosures);
+  content += buildEnclosures(
+    store.enclosures,
+    enclosureStartNumber(store.docType, store.formData.startingEnclosureNumber)
+  );
   content += buildBody(store.paragraphs, config);
   content += buildDualSignature(data, 'joint');
   content += buildDistribution(store.distributions);
@@ -1271,7 +1287,10 @@ ${trimLastRow(rows)}
   }
 
   content += buildReferences(store.references);
-  content += buildEnclosures(store.enclosures);
+  content += buildEnclosures(
+    store.enclosures,
+    enclosureStartNumber(store.docType, store.formData.startingEnclosureNumber)
+  );
   content += buildBody(store.paragraphs, config);
   content += buildDualSignature(data, 'joint_memo');
   content += buildDistribution(store.distributions);

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -2,6 +2,7 @@ import { escapeLatex, escapeLatexUrl, processBodyText, formatSubjectForLatex, fo
 import type { DocumentData, Reference, Enclosure, Paragraph, CopyTo, Distribution } from '@/types/document';
 import { DOC_TYPE_CONFIG } from '@/types/document';
 import { base64ToUint8Array } from '@/lib/encoding';
+import { enclosureStartNumber } from '@/lib/endorsement';
 import { safeUrl } from '@/lib/url-safety';
 import { splitAddressForLetterhead } from '@/lib/unitAddress';
 import { deriveOverallClassLevel } from '@/lib/overallClassification';
@@ -573,7 +574,10 @@ ${store.enclosures
     .map((e, i) => {
       // Always use JSPDF marker - JavaScript handles ALL enclosure pages
       // This ensures correct ordering (text-only and PDF enclosures in sequence)
-      return `\\enclosure{${i + 1}}{JSPDF}{${escapeLatex(e.title || 'Untitled')}}`;
+      // The start number lets an endorsement continue the basic letter's
+      // numbering (Ch 9 ¶3); it is 1 for everything else.
+      const n = enclosureStartNumber(store.docType, store.formData.startingEnclosureNumber) + i;
+      return `\\enclosure{${n}}{JSPDF}{${escapeLatex(e.title || 'Untitled')}}`;
     })
     .join('\n')}
 `;

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -840,9 +840,14 @@ export function generateAllLatexFiles(store: DocumentStore): GeneratedFiles {
     'classification.tex': generateClassificationTex(store),
   };
 
-  // Collect ALL enclosures for JavaScript handling (maintains correct order)
+  // Collect ALL enclosures for JavaScript handling (maintains correct order).
+  // The number must match the one printed in the Encl: list and used for the
+  // `\enclosure{n}` hyperlink anchor — the merge stamps page markers and
+  // resolves "Encl (n)" links by it, so an endorsement's continued numbering
+  // has to reach here too.
+  const enclStart = enclosureStartNumber(store.docType, store.formData.startingEnclosureNumber);
   const enclosures: EnclosureData[] = store.enclosures.map((encl, i) => ({
-    number: i + 1,
+    number: enclStart + i,
     title: encl.title || 'Untitled',
     data: encl.file?.data, // undefined if no PDF attached
     pageStyle: encl.pageStyle,

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -9,6 +9,7 @@ import { useUIStore } from './uiStore';
 import { debug } from '@/lib/debug';
 import { TIMING, STORAGE_KEYS} from '@/lib/constants';
 import { compressedParse, compressedStringify } from '@/lib/compressedStorage';
+import { referenceStartIndex } from '@/lib/endorsement';
 import { canonicalizeUnitAddress } from '@/lib/unitAddress';
 import { normalizeLevels, migratePortionMarkings } from '@/lib/paragraphUtils';
 
@@ -155,18 +156,18 @@ export interface DocumentState {
   getSnapshot: () => DocumentSnapshot;
 }
 
-const getNextReferenceLetter = (refs: Reference[]): string => {
+// `offset` shifts the sequence so an endorsement can continue the basic
+// letter's lettering (Ch 9 ¶3) — it is 0 for every non-endorsement.
+const letterAt = (index: number): string => {
   const alphabet = 'abcdefghijklmnopqrstuvwxyz';
-  return alphabet[refs.length] || `a${refs.length - 26}`;
+  return alphabet[index] || `a${index - 26}`;
 };
 
-const reLetterReferences = (refs: Reference[]): Reference[] => {
-  const alphabet = 'abcdefghijklmnopqrstuvwxyz';
-  return refs.map((ref, index) => ({
-    ...ref,
-    letter: alphabet[index] || `a${index - 26}`,
-  }));
-};
+const getNextReferenceLetter = (refs: Reference[], offset = 0): string =>
+  letterAt(refs.length + offset);
+
+const reLetterReferences = (refs: Reference[], offset = 0): Reference[] =>
+  refs.map((ref, index) => ({ ...ref, letter: letterAt(index + offset) }));
 
 // Example form data for first-time visitors (one-time mode / no profile selected)
 const EXAMPLE_FORM_DATA: Partial<DocumentData> = {
@@ -307,15 +308,40 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
           fontFamily: newFontFamily,
           date: convertedDate,
         },
+        // Only endorsements continue a sequence, so switching type re-letters:
+        // leaving one resets to (a), entering one applies the saved start.
+        references: reLetterReferences(
+          state.references,
+          referenceStartIndex(type, state.formData.startingReferenceLetter)
+        ),
       };
     }
-    return { docType: type, formData: { ...state.formData, docType: type } };
+    return {
+      docType: type,
+      formData: { ...state.formData, docType: type },
+      references: reLetterReferences(
+        state.references,
+        referenceStartIndex(type, state.formData.startingReferenceLetter)
+      ),
+    };
     });
   },
 
-  setField: (key, value) => set((state) => ({
-    formData: { ...state.formData, [key]: value },
-  })),
+  setField: (key, value) => set((state) => {
+    const formData = { ...state.formData, [key]: value };
+    // The start letter shifts every reference after it, so re-letter in the
+    // same commit — otherwise the rows keep the previous sequence on screen.
+    if (key === 'startingReferenceLetter') {
+      return {
+        formData,
+        references: reLetterReferences(
+          state.references,
+          referenceStartIndex(state.docType, formData.startingReferenceLetter)
+        ),
+      };
+    }
+    return { formData };
+  }),
 
   setFormData: (data) => set((state) => ({
     formData: { ...state.formData, ...data },
@@ -343,7 +369,14 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
   addReference: (title, url) => set((state) => ({
     references: [
       ...state.references,
-      { letter: getNextReferenceLetter(state.references), title, url: url || '' },
+      {
+        letter: getNextReferenceLetter(
+          state.references,
+          referenceStartIndex(state.docType, state.formData.startingReferenceLetter)
+        ),
+        title,
+        url: url || '',
+      },
     ],
   })),
 
@@ -352,14 +385,22 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
   })),
 
   removeReference: (index) => set((state) => ({
-    references: reLetterReferences(state.references.filter((_, i) => i !== index)),
+    references: reLetterReferences(
+      state.references.filter((_, i) => i !== index),
+      referenceStartIndex(state.docType, state.formData.startingReferenceLetter)
+    ),
   })),
 
   reorderReferences: (fromIndex, toIndex) => set((state) => {
     const newRefs = [...state.references];
     const [moved] = newRefs.splice(fromIndex, 1);
     newRefs.splice(toIndex, 0, moved);
-    return { references: reLetterReferences(newRefs) };
+    return {
+      references: reLetterReferences(
+        newRefs,
+        referenceStartIndex(state.docType, state.formData.startingReferenceLetter)
+      ),
+    };
   }),
 
   // Enclosures
@@ -614,13 +655,23 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
       copyTos: data.copyTos?.length,
     });
     useUIStore.getState().setValidationVisible(false);
-    set((state) => ({
-      paragraphs: data.paragraphs ? migratePortionMarkings(data.paragraphs) : state.paragraphs,
-      references: data.references ? reLetterReferences(data.references) : state.references,
-      enclosures: data.enclosures ?? state.enclosures,
-      copyTos: data.copyTos ?? state.copyTos,
-      formData: data.formData ? { ...state.formData, ...data.formData } : state.formData,
-    }));
+    set((state) => {
+      const formData = data.formData ? { ...state.formData, ...data.formData } : state.formData;
+      return {
+        paragraphs: data.paragraphs ? migratePortionMarkings(data.paragraphs) : state.paragraphs,
+        // Re-letter against the incoming start so a loaded endorsement keeps
+        // the sequence it was saved with.
+        references: data.references
+          ? reLetterReferences(
+              data.references,
+              referenceStartIndex(state.docType, formData.startingReferenceLetter)
+            )
+          : state.references,
+        enclosures: data.enclosures ?? state.enclosures,
+        copyTos: data.copyTos ?? state.copyTos,
+        formData,
+      };
+    });
   },
 
   // History (Undo/Redo)

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -107,6 +107,12 @@ export interface DocumentData {
   // Page settings
   pageNumbering: string;
   startingPageNumber: number;
+  // Endorsements continue the basic letter's sequences rather than opening
+  // their own (SECNAV M-5216.5 Ch 9 ¶3). The basic letter is a separate
+  // document, so the user supplies where this one picks up. See
+  // `referenceStartIndex` / `enclosureStartNumber` in lib/endorsement.ts.
+  startingReferenceLetter?: string;
+  startingEnclosureNumber?: number;
 
   // Letterhead
   department: string;

--- a/tests/integration/endorsement-continuation-render.test.ts
+++ b/tests/integration/endorsement-continuation-render.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Rendered-output check for endorsement sequence continuation (Ch 9 ¶3).
+ *
+ * The unit tests cover the pure offset helpers; this proves the offsets survive
+ * all the way onto the page — the reference line prints "(g)" and the enclosure
+ * line prints "(2)" rather than restarting at (a)/(1). Compiles a real PDF and
+ * reads it back, so a generator that ignores the start value is caught.
+ *
+ * Requires pdflatex + pdftotext; skipped (not falsely passed) without them.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { writeFile, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { compileFixture } from '../_helpers/compileLatex';
+
+const toolchain =
+  spawnSync('pdflatex', ['--version'], { encoding: 'utf-8' }).status === 0 &&
+  spawnSync('pdftotext', ['-v'], { encoding: 'utf-8' }).status === 0;
+
+if (!toolchain) {
+  console.warn('[endorsement-continuation-render] pdflatex/pdftotext missing — SKIPPING.');
+}
+
+/** A same-page endorsement carrying one reference and one enclosure. */
+function store(opts: {
+  docType?: string;
+  startingReferenceLetter?: string;
+  startingEnclosureNumber?: number;
+}) {
+  const docType = opts.docType ?? 'same_page_endorsement';
+  return {
+    docType,
+    formData: {
+      docType,
+      fontSize: '12pt',
+      fontFamily: 'times',
+      pageNumbering: 'none',
+      department: 'usmc',
+      unitLine1: '1ST BATTALION, 6TH MARINES',
+      unitAddress: 'PSC BOX 20123, CAMP LEJEUNE, NC 28542-0123',
+      sealType: 'dow',
+      letterheadColor: 'blue',
+      ssic: '1000',
+      date: '15 Jan 25',
+      from: 'Commanding Officer, 1st Battalion, 6th Marines',
+      to: 'Commanding General, II MEF',
+      subject: 'CONTINUATION RENDER CHECK',
+      endorsementOrdinal: 'FIRST',
+      basicLetterId: 'CG II MEF ltr 1000 Ser 01/23 of 1 Jan 25',
+      sigFirst: 'John',
+      sigLast: 'DOE',
+      classLevel: 'unclassified',
+      startingReferenceLetter: opts.startingReferenceLetter,
+      startingEnclosureNumber: opts.startingEnclosureNumber,
+    },
+    // The letter the store would have derived for a start of (g).
+    references: [{ letter: opts.startingReferenceLetter === 'g' ? 'g' : 'a', title: 'MCO 1500.52', url: '' }],
+    enclosures: [{ title: 'Training Record' }],
+    paragraphs: [{ text: 'Forwarded, concurring.', level: 0 }],
+    copyTos: [],
+    distributions: [],
+  } as never;
+}
+
+async function renderedText(s: ReturnType<typeof store>): Promise<string> {
+  const result = await compileFixture(s);
+  expect(result.ok, `pdflatex failed; work dir: ${result.workDir}`).toBe(true);
+  const dir = await mkdtemp(join(tmpdir(), 'dondocs-cont-'));
+  const pdfPath = join(dir, 'out.pdf');
+  await writeFile(pdfPath, result.pdfBytes!);
+  const { stdout } = spawnSync('pdftotext', [pdfPath, '-'], { encoding: 'utf-8' });
+  expect(stdout.trim().length).toBeGreaterThan(0);
+  return stdout;
+}
+
+describe('endorsement continuation — rendered PDF', () => {
+  it.skipIf(!toolchain)('continues the reference lettering and enclosure numbering', async () => {
+    const text = await renderedText(
+      store({ startingReferenceLetter: 'g', startingEnclosureNumber: 2 })
+    );
+    expect(text).toMatch(/\(g\)\s*MCO 1500\.52/);
+    expect(text).toMatch(/\(2\)\s*Training Record/);
+  });
+
+  it.skipIf(!toolchain)('starts at (a)/(1) when no continuation is given', async () => {
+    const text = await renderedText(store({}));
+    expect(text).toMatch(/\(a\)\s*MCO 1500\.52/);
+    expect(text).toMatch(/\(1\)\s*Training Record/);
+  });
+
+  it.skipIf(!toolchain)('ignores a stale start value on a basic letter', async () => {
+    // Guards the footgun: set a start, then switch away from an endorsement.
+    const text = await renderedText(
+      store({ docType: 'naval_letter', startingEnclosureNumber: 5 })
+    );
+    expect(text).toMatch(/\(1\)\s*Training Record/);
+    expect(text).not.toMatch(/\(5\)\s*Training Record/);
+  });
+});

--- a/tests/regressions/enclosure-number-agreement.test.ts
+++ b/tests/regressions/enclosure-number-agreement.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression: an enclosure's number is produced in three places that must agree
+ * — the printed "Encl:" list, the `\enclosure{n}` LaTeX anchor, and the
+ * `number` handed to the JS PDF merge (which stamps page markers and resolves
+ * "Encl (n)" hyperlinks by it).
+ *
+ * When endorsement continuation landed, the first two were offset but the merge
+ * list still counted from `i + 1`. A continued endorsement therefore printed
+ * "Encl: (2)" while the merged PDF marked the page "Enclosure (1)" and the
+ * hyperlink anchor pointed at a destination that was never created. These
+ * assert the three stay in lockstep.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateAllLatexFiles } from '@/services/latex/generator';
+import { generateFlatLatex } from '@/services/latex/flat-generator';
+
+function store(docType: string, startingEnclosureNumber?: number) {
+  return {
+    docType,
+    formData: {
+      docType,
+      fontSize: '12pt',
+      fontFamily: 'times',
+      pageNumbering: 'none',
+      department: 'usmc',
+      unitLine1: '1ST BATTALION, 6TH MARINES',
+      ssic: '1000',
+      date: '15 Jan 25',
+      from: 'Commanding Officer, 1st Battalion, 6th Marines',
+      to: 'CG, II MEF',
+      subject: 'TEST',
+      endorsementOrdinal: 'FIRST',
+      basicLetterId: 'CG II MEF ltr 1000 Ser 01/23 of 1 Jan 25',
+      sigFirst: 'John',
+      sigLast: 'DOE',
+      startingEnclosureNumber,
+    },
+    references: [],
+    enclosures: [{ title: 'Alpha' }, { title: 'Bravo' }],
+    paragraphs: [{ text: 'body', level: 0 }],
+    copyTos: [],
+    distributions: [],
+  } as never;
+}
+
+describe('enclosure numbering agrees across all three producers', () => {
+  it('continued endorsement: merge list, LaTeX anchor, and printed list all start at 2', () => {
+    const s = store('same_page_endorsement', 2);
+    const { enclosures, texFiles } = generateAllLatexFiles(s) as unknown as {
+      enclosures: { number: number }[];
+      texFiles: Record<string, string>;
+    };
+
+    // 1. the list handed to the PDF merge
+    expect(enclosures.map((e) => e.number)).toEqual([2, 3]);
+    // 2. the LaTeX anchor / list definition
+    expect(texFiles['encl-config.tex']).toContain('\\enclosure{2}');
+    expect(texFiles['encl-config.tex']).toContain('\\enclosure{3}');
+    expect(texFiles['encl-config.tex']).not.toContain('\\enclosure{1}');
+    // 3. the printed Encl: list (flat/DOCX path)
+    const flat = generateFlatLatex(s);
+    expect(flat).toContain('(2)~~Alpha');
+    expect(flat).toContain('(3)~~Bravo');
+  });
+
+  it('defaults to 1 with no continuation set', () => {
+    const s = store('same_page_endorsement');
+    const { enclosures } = generateAllLatexFiles(s) as unknown as {
+      enclosures: { number: number }[];
+    };
+    expect(enclosures.map((e) => e.number)).toEqual([1, 2]);
+    expect(generateFlatLatex(s)).toContain('(1)~~Alpha');
+  });
+
+  it('ignores a stale continuation on a basic letter', () => {
+    const s = store('naval_letter', 5);
+    const { enclosures } = generateAllLatexFiles(s) as unknown as {
+      enclosures: { number: number }[];
+    };
+    expect(enclosures.map((e) => e.number)).toEqual([1, 2]);
+    expect(generateFlatLatex(s)).toContain('(1)~~Alpha');
+  });
+});

--- a/tests/unit/documentStore.referenceLettering.test.ts
+++ b/tests/unit/documentStore.referenceLettering.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Reference lettering in the document store, including the endorsement
+ * continuation offset (SECNAV M-5216.5 Ch 9 ¶3).
+ *
+ * `ref.letter` is stored on the data, not derived at render — so every path
+ * that can change the sequence has to re-letter in the same commit, or the rows
+ * keep a stale sequence on screen while the PDF prints a different one.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDocumentStore } from '@/stores/documentStore';
+
+const letters = () => useDocumentStore.getState().references.map((r) => r.letter);
+
+function seedThreeRefs() {
+  const s = useDocumentStore.getState();
+  s.addReference('One');
+  s.addReference('Two');
+  s.addReference('Three');
+}
+
+describe('reference lettering', () => {
+  beforeEach(() => {
+    useDocumentStore.getState().resetForm();
+    useDocumentStore.setState({ references: [] });
+  });
+
+  it('letters a basic letter from (a)', () => {
+    seedThreeRefs();
+    expect(letters()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('continues from the start letter on an endorsement', () => {
+    useDocumentStore.getState().setDocType('same_page_endorsement');
+    useDocumentStore.getState().setField('startingReferenceLetter', 'g');
+    seedThreeRefs();
+    expect(letters()).toEqual(['g', 'h', 'i']);
+  });
+
+  it('re-letters existing rows the moment the start letter changes', () => {
+    useDocumentStore.getState().setDocType('same_page_endorsement');
+    seedThreeRefs();
+    expect(letters()).toEqual(['a', 'b', 'c']);
+    // The regression this guards: rows keeping the old sequence on screen.
+    useDocumentStore.getState().setField('startingReferenceLetter', 'g');
+    expect(letters()).toEqual(['g', 'h', 'i']);
+  });
+
+  it('keeps the sequence contiguous after a removal', () => {
+    useDocumentStore.getState().setDocType('same_page_endorsement');
+    useDocumentStore.getState().setField('startingReferenceLetter', 'g');
+    seedThreeRefs();
+    useDocumentStore.getState().removeReference(1);
+    expect(letters()).toEqual(['g', 'h']);
+  });
+
+  it('resets to (a) when the doc type leaves an endorsement', () => {
+    useDocumentStore.getState().setDocType('same_page_endorsement');
+    useDocumentStore.getState().setField('startingReferenceLetter', 'g');
+    seedThreeRefs();
+    expect(letters()).toEqual(['g', 'h', 'i']);
+    // A stale start must not silently offset a basic letter.
+    useDocumentStore.getState().setDocType('naval_letter');
+    expect(letters()).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/tests/unit/endorsement-continuation.test.ts
+++ b/tests/unit/endorsement-continuation.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Sequence continuation for endorsements (SECNAV M-5216.5 Ch 9 ¶3).
+ *
+ * An endorsement continues the basic letter's reference lettering and enclosure
+ * numbering rather than restarting at (a) / (1). The basic letter is a separate
+ * document DonDocs can't read, so the start is user-supplied — and it must only
+ * ever apply to endorsements, so a stale value can't silently offset a basic
+ * letter's sequence.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isEndorsement,
+  referenceStartIndex,
+  enclosureStartNumber,
+} from '@/lib/endorsement';
+
+describe('isEndorsement', () => {
+  it('is true for both endorsement types only', () => {
+    expect(isEndorsement('same_page_endorsement')).toBe(true);
+    expect(isEndorsement('new_page_endorsement')).toBe(true);
+    expect(isEndorsement('naval_letter')).toBe(false);
+    expect(isEndorsement('mfr')).toBe(false);
+  });
+});
+
+describe('referenceStartIndex', () => {
+  it('maps a start letter to its zero-based index', () => {
+    expect(referenceStartIndex('same_page_endorsement', 'a')).toBe(0);
+    expect(referenceStartIndex('same_page_endorsement', 'b')).toBe(1);
+    // The reg's own example: basic ran to (f), so this one starts at (g).
+    expect(referenceStartIndex('same_page_endorsement', 'g')).toBe(6);
+    expect(referenceStartIndex('new_page_endorsement', 'z')).toBe(25);
+  });
+
+  it('tolerates case and surrounding whitespace', () => {
+    expect(referenceStartIndex('same_page_endorsement', ' G ')).toBe(6);
+    expect(referenceStartIndex('same_page_endorsement', 'G')).toBe(6);
+  });
+
+  it('never offsets a non-endorsement, even with a value set', () => {
+    // The footgun this guards: setting a start, then switching doc type.
+    expect(referenceStartIndex('naval_letter', 'g')).toBe(0);
+    expect(referenceStartIndex('mfr', 'g')).toBe(0);
+  });
+
+  it('falls back to 0 for anything that is not a single a–z letter', () => {
+    for (const bad of [undefined, '', '  ', '1', 'aa', '(g)', '?']) {
+      expect(referenceStartIndex('same_page_endorsement', bad)).toBe(0);
+    }
+  });
+});
+
+describe('enclosureStartNumber', () => {
+  it('returns the start number for endorsements', () => {
+    expect(enclosureStartNumber('same_page_endorsement', 2)).toBe(2);
+    expect(enclosureStartNumber('new_page_endorsement', 7)).toBe(7);
+  });
+
+  it('never offsets a non-endorsement, even with a value set', () => {
+    expect(enclosureStartNumber('naval_letter', 5)).toBe(1);
+  });
+
+  it('defaults to 1 for absent, sub-1, or non-numeric values', () => {
+    expect(enclosureStartNumber('same_page_endorsement', undefined)).toBe(1);
+    expect(enclosureStartNumber('same_page_endorsement', 0)).toBe(1);
+    expect(enclosureStartNumber('same_page_endorsement', -3)).toBe(1);
+    expect(enclosureStartNumber('same_page_endorsement', NaN)).toBe(1);
+  });
+
+  it('floors a fractional value rather than emitting "(2.5)"', () => {
+    expect(enclosureStartNumber('same_page_endorsement', 2.7)).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes the remaining two asks from the Semper Admin report (the third, by direction, shipped in #204).

**One problem, not two.** DonDocs treats every document as standalone, but an endorsement *continues* a package it can't see. Three counters restarted from scratch:

| | was | should be |
|---|---|---|
| page number | 1 | 3 (or wherever the basic letter ended) |
| reference letters | (a) | (g) — "if the basic had up to (f), start with (g)" |
| enclosure numbers | (1) | (2) |

That's SECNAV M-5216.5 **Ch 9 ¶3**, already documented in our own `tex/README.md:537`. The basic letter is a separate document the app cannot read, so the start is user-supplied.

**The change.** A **"Continues from the basic letter"** group in the endorsement-only Basic Letter section takes the first page number / reference letter / enclosure number. `startingPageNumber` already worked in the generator but had **no UI at all** — it was an orphaned field.

Offsets live in `lib/endorsement.ts` (pure, leaf, already the home for Ch 9 logic) as `referenceStartIndex` / `enclosureStartNumber`. Both **return the no-op value for any non-endorsement**, so a stale start can never silently offset a basic letter — the footgun of setting a start then switching doc type.

Reference letters are *stored* (`ref.letter`), so every path that can shift the sequence re-letters in the same commit — add/remove/reorder, changing the start letter, switching doc type, and loading a saved doc. Otherwise the rows show one sequence while the PDF prints another. Enclosure numbers are computed at render, so the offset goes into both generators (the PDF path had the same `i + 1` assumption).

**Tests.** 14 new: the pure helpers, store re-lettering (incl. reset-on-doc-type-change), and a **rendered-PDF** check — compiling a real endorsement and reading `Ref: (g) MCO 1500.52` / `Encl: (2) Training Record` off the page, plus the negative case on a basic letter. The unit tests alone would pass even if a generator ignored the offset entirely.

build 0, lint 0, check-no-cdn OK, 1615/1615 unit + 5 render.