### PR TITLE
fix(pwa): self-heal a stale app shell instead of white-screening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.95] — 2026-07-16
+
+### Fixed
+
+- The app now self-heals from a stale app shell instead of white-screening.
+  After a deploy, a cached `index.html` can point at hashed bundles that no
+  longer exist — the service worker's network-first navigation fetch can be
+  satisfied by the browser's HTTP cache and then store that stale shell in its
+  own runtime cache, so every new tab white-screened until a hard refresh. A
+  boot watchdog in the shell now detects that the app never started and, once
+  per session, drops the shell caches, re-fetches the page past the HTTP
+  cache, and reloads. Offline launches are left untouched, and deploying this
+  release automatically abandons any already-poisoned shell cache.
+
 ## [1.2.94] — 2026-07-06
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -62,6 +62,44 @@
         }
       })();
     </script>
+    <!-- Boot watchdog: self-heal a stale app shell instead of white-screening.
+         After a deploy, a cached index.html can reference hashed bundles that
+         no longer exist (the service worker's NetworkFirst navigation fetch can
+         be satisfied by the browser's HTTP cache, and may then store that stale
+         shell in its own runtime cache — the 1.2.94 white-screen incident). The
+         app sets window.__DD_BOOTED__ as its first act; if that hasn't happened
+         shortly after load and we're online, this drops the shell caches,
+         force-revalidates the page in the HTTP cache, and reloads ONCE
+         (session-guarded so it can never loop; offline is left alone — the
+         cached shell is all an air-gapped machine has). -->
+    <script>
+      (function () {
+        try {
+          var KEY = 'dondocs-boot-recovery';
+          setTimeout(function () {
+            try {
+              if (window.__DD_BOOTED__) { sessionStorage.removeItem(KEY); return; }
+              if (!navigator.onLine) return;
+              if (sessionStorage.getItem(KEY)) return; // one shot per tab session
+              sessionStorage.setItem(KEY, '1');
+              var reload = function () { location.reload(); };
+              var dropShellCaches = ('caches' in window)
+                ? caches.keys().then(function (keys) {
+                    return Promise.all(keys
+                      .filter(function (k) { return k.indexOf('dondocs-app-shell') === 0; })
+                      .map(function (k) { return caches.delete(k); }));
+                  }).catch(function () {})
+                : Promise.resolve();
+              // cache:'reload' bypasses the HTTP cache and replaces the stored
+              // entry with a fresh copy, so the reload below can't re-read the
+              // same stale shell.
+              var refreshShell = fetch(location.href, { cache: 'reload' }).catch(function () {});
+              Promise.all([dropShellCaches, refreshShell]).then(reload, reload);
+            } catch (e) { /* never break boot */ }
+          }, 10000);
+        } catch (e) { /* never break boot */ }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.94",
+  "version": "1.2.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.94",
+      "version": "1.2.95",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.94",
+  "version": "1.2.95",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,20 @@ import './index.css'
 import App from './App.tsx'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 
+declare global {
+  interface Window {
+    /** Set the moment the app bundle executes; read by the index.html boot
+     *  watchdog to tell "stale shell, scripts never loaded" apart from a
+     *  healthy boot. */
+    __DD_BOOTED__?: boolean
+  }
+}
+
+// First observable act of the bundle — if the shell's script tags point at
+// bundles a deploy has replaced, this line never runs and the watchdog in
+// index.html self-heals with a one-shot cache-bypassing reload.
+window.__DD_BOOTED__ = true
+
 // Initialize debug utility (registers global DONDOCS object and keyboard shortcut)
 import '@/lib/debug'
 

--- a/tests/regressions/boot-watchdog-stale-shell.test.ts
+++ b/tests/regressions/boot-watchdog-stale-shell.test.ts
@@ -27,7 +27,10 @@ const SHELL_CACHE_PREFIX = 'dondocs-app-shell';
 const GUARD_KEY = 'dondocs-boot-recovery';
 
 function extractWatchdogSource(): string {
-  const scripts = [...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+  // Case-insensitive: this only extracts a known inline script from our own
+  // index.html, but CodeQL (rightly) treats case-sensitive tag regexes as a
+  // sanitizer-bypass smell, and <SCRIPT> is valid HTML anyway.
+  const scripts = [...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/gi)].map((m) => m[1]);
   const src = scripts.find((s) => s.includes(GUARD_KEY));
   if (!src) throw new Error('boot watchdog inline script not found in index.html');
   return src;

--- a/tests/regressions/boot-watchdog-stale-shell.test.ts
+++ b/tests/regressions/boot-watchdog-stale-shell.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression: the v1.2.94 stale-shell white screen.
+ *
+ * After a deploy, the service worker's NetworkFirst navigation fetch could be
+ * satisfied by the browser's HTTP cache, serve an index.html whose hashed
+ * bundles no longer existed, and store that stale shell in its own runtime
+ * cache — every new load white-screened until a manual hard refresh. The fix
+ * is a boot watchdog inlined in index.html that self-heals with a one-shot,
+ * session-guarded recovery.
+ *
+ * These tests execute the ACTUAL inline script extracted from index.html (not
+ * a copy) against injected doubles, so editing or removing the watchdog — or
+ * breaking any of its guards — fails CI at the PR stage. A final test pins the
+ * cross-file couplings the watchdog depends on: main.tsx must set the boot
+ * flag, and the shell-cache prefix it deletes must match the cacheName in
+ * vite.config.ts (rename one without the other and recovery silently stops
+ * cleaning the poisoned cache).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = join(__dirname, '..', '..');
+const indexHtml = readFileSync(join(ROOT, 'index.html'), 'utf-8');
+
+const SHELL_CACHE_PREFIX = 'dondocs-app-shell';
+const GUARD_KEY = 'dondocs-boot-recovery';
+
+function extractWatchdogSource(): string {
+  const scripts = [...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+  const src = scripts.find((s) => s.includes(GUARD_KEY));
+  if (!src) throw new Error('boot watchdog inline script not found in index.html');
+  return src;
+}
+
+interface RunOptions {
+  booted: boolean;
+  online?: boolean;
+  guardAlreadySet?: boolean;
+  cacheKeys?: string[];
+}
+
+/** Run the extracted watchdog against doubles and fire its timer. */
+async function runWatchdog(opts: RunOptions) {
+  const storage = new Map<string, string>();
+  if (opts.guardAlreadySet) storage.set(GUARD_KEY, '1');
+
+  const deleted: string[] = [];
+  const fetchCalls: { url: string; init?: RequestInit }[] = [];
+  let reloads = 0;
+  let timerCb: (() => void) | null = null;
+
+  const cachesStub = {
+    keys: async () => opts.cacheKeys ?? [],
+    delete: async (k: string) => {
+      deleted.push(k);
+      return true;
+    },
+  };
+  const sandbox = {
+    window: { __DD_BOOTED__: opts.booted ? true : undefined, caches: cachesStub },
+    navigator: { onLine: opts.online ?? true },
+    sessionStorage: {
+      getItem: (k: string) => storage.get(k) ?? null,
+      setItem: (k: string, v: string) => void storage.set(k, v),
+      removeItem: (k: string) => void storage.delete(k),
+    },
+    caches: cachesStub,
+    fetch: (url: string, init?: RequestInit) => {
+      fetchCalls.push({ url, init });
+      return Promise.resolve({ ok: true });
+    },
+    location: {
+      href: 'https://dondocs.test/',
+      reload: () => {
+        reloads++;
+      },
+    },
+    setTimeout: (cb: () => void) => {
+      timerCb = cb;
+      return 0;
+    },
+  };
+
+  // Execute the real inline script with our doubles shadowing the globals.
+  new Function(...Object.keys(sandbox), extractWatchdogSource())(...Object.values(sandbox));
+
+  const fireTimer = async () => {
+    timerCb?.();
+    // let the recovery's promise chain settle
+    await new Promise((r) => globalThis.setTimeout(r, 0));
+    await new Promise((r) => globalThis.setTimeout(r, 0));
+  };
+  await fireTimer();
+
+  return { deleted, fetchCalls, reloads: () => reloads, storage, fireTimer };
+}
+
+describe('boot watchdog — stale shell recovery (v1.2.94 incident)', () => {
+  it('stale shell: drops only app-shell caches, refetches past the HTTP cache, reloads once', async () => {
+    const r = await runWatchdog({
+      booted: false,
+      cacheKeys: [
+        `${SHELL_CACHE_PREFIX}-deadbeef`,
+        `${SHELL_CACHE_PREFIX}-cafef00d`,
+        'engine-core-cache-v1', // must survive — offline engine assets
+        'pandoc-wasm-cache-v2', // must survive — air-gap DOCX engine
+      ],
+    });
+    expect(r.deleted).toEqual([`${SHELL_CACHE_PREFIX}-deadbeef`, `${SHELL_CACHE_PREFIX}-cafef00d`]);
+    // cache:'reload' bypasses the stale HTTP entry AND replaces it with the
+    // fresh response — 'no-store' would leave the poison in place.
+    expect(r.fetchCalls).toEqual([
+      { url: 'https://dondocs.test/', init: { cache: 'reload' } },
+    ]);
+    expect(r.reloads()).toBe(1);
+    expect(r.storage.get(GUARD_KEY)).toBe('1');
+  });
+
+  it('never loops: a second firing with the guard set does nothing', async () => {
+    const r = await runWatchdog({
+      booted: false,
+      guardAlreadySet: true,
+      cacheKeys: [`${SHELL_CACHE_PREFIX}-deadbeef`],
+    });
+    expect(r.deleted).toEqual([]);
+    expect(r.fetchCalls).toEqual([]);
+    expect(r.reloads()).toBe(0);
+  });
+
+  it('healthy boot: no recovery, and the one-shot guard is cleared for next time', async () => {
+    const r = await runWatchdog({
+      booted: true,
+      guardAlreadySet: true, // left over from a prior recovered session
+      cacheKeys: [`${SHELL_CACHE_PREFIX}-deadbeef`],
+    });
+    expect(r.deleted).toEqual([]);
+    expect(r.reloads()).toBe(0);
+    expect(r.storage.has(GUARD_KEY)).toBe(false);
+  });
+
+  it('offline: stands down entirely — the cached shell is all an air-gapped machine has', async () => {
+    const r = await runWatchdog({
+      booted: false,
+      online: false,
+      cacheKeys: [`${SHELL_CACHE_PREFIX}-deadbeef`],
+    });
+    expect(r.deleted).toEqual([]);
+    expect(r.fetchCalls).toEqual([]);
+    expect(r.reloads()).toBe(0);
+    // and it must NOT burn the one-shot guard while offline, or a machine that
+    // comes back online later has no recovery left
+    expect(r.storage.has(GUARD_KEY)).toBe(false);
+  });
+});
+
+describe('boot watchdog — cross-file couplings', () => {
+  it('main.tsx sets the boot flag the watchdog waits for', () => {
+    const main = readFileSync(join(ROOT, 'src', 'main.tsx'), 'utf-8');
+    expect(main).toMatch(/window\.__DD_BOOTED__\s*=\s*true/);
+    expect(extractWatchdogSource()).toContain('__DD_BOOTED__');
+  });
+
+  it('the cache prefix the watchdog deletes matches the shell cacheName in vite.config.ts', () => {
+    const viteConfig = readFileSync(join(ROOT, 'vite.config.ts'), 'utf-8');
+    // vite.config.ts names the runtime cache `dondocs-app-shell-<build>`; the
+    // watchdog deletes by prefix. Renaming one without the other makes
+    // recovery silently stop cleaning the poisoned cache.
+    expect(viteConfig).toMatch(new RegExp(`cacheName:\\s*\`${SHELL_CACHE_PREFIX}-`));
+    expect(extractWatchdogSource()).toContain(`'${SHELL_CACHE_PREFIX}'`);
+  });
+});


### PR DESCRIPTION
**Incident (v1.2.94):** clicking "Update Now" white-screened the app, and every new page load white-screened again; only a hard refresh (Shift+reload) worked — because Shift+reload bypasses the service worker.

**Root cause — a two-layer cache poisoning:**
1. The browser's HTTP disk cache held a stale `index.html` (cached before the #202 no-cache headers; note the edge still serves `sw.js` with `max-age=14400`, so pre-#202 HTML had a 4h TTL).
2. On update, the new SW activated and purged the old precache — the old hashed chunks were now gone both locally and from the server.
3. The SW's `NetworkFirst` navigation fetch was **satisfied by the HTTP cache without touching the network** (Workbox ignores `fetchOptions` for navigate-mode requests, so this can't be configured away), treated the stale HTML as a network success, and **stored it in its own per-build app-shell cache**.
4. From then on, the poisoned shell cache (served whenever the network lost the 3s `networkTimeoutSeconds` race) and/or the stale HTTP entry kept producing dead-chunk HTML → white screen on every new load, for up to the shell cache's 7-day retention.

**Fix: a boot watchdog in `index.html`.** The app bundle sets `window.__DD_BOOTED__` as its first act. An inline script checks 10s after load: if the flag never appeared and we're **online**, it (once per tab session, sessionStorage-guarded)
- deletes all `dondocs-app-shell-*` caches (the poisoned copy),
- `fetch(location.href, { cache: 'reload' })` — replaces the stale HTTP-cache entry with a fresh one, and
- reloads.

Offline is deliberately left alone — the cached shell is all an air-gapped machine has, so the watchdog stands down rather than fight the air-gap promise. A genuinely broken build reloads exactly once and stops (no loop).

**Why merely deploying this heals currently-affected users:** the shell cache is named per build, so the new SW abandons the poisoned cache on activation; users stuck today recover on their next SW update check (60s poll / tab focus) with no action.

**Verified live** (real browser, not just unit tests):
- Healthy boot: `__DD_BOOTED__ = true`, guard cleared, navigation type stays `navigate` after 12s — no misfire.
- Recovery: seeded a fake poisoned `dondocs-app-shell-deadbeef` cache, forced the not-booted condition → cache deleted, fresh HTML fetched past the HTTP cache (200), single reload, second run blocked by the guard.
- Watchdog present in built `dist/index.html`; flag in the main bundle.

**Known follow-up (host-side, not this repo):** the edge serves `sw.js` with `max-age=14400` despite `public/_headers` requesting `no-cache` — harmless for updates (browsers bypass the HTTP cache for SW update checks by spec) but worth chasing in the Cloudflare config.

build 0, lint 0, check-no-cdn OK, 1618/1618 tests.