### PR TITLE
fix(ssic): search the full code list, and name the groups after their codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.96] — 2026-07-16
+
+### Fixed
+
+- The SSIC lookup now searches all 2,240 codes instead of 129. The full
+  SECNAV M-5210.2 code list already shipped in the app but nothing imported it,
+  so the lookup only ever rendered a small hand-maintained subset — searching a
+  real code such as 11013 or 3120 returned nothing at all.
+- Corrected three SSIC major-group names. The hand-maintained list omitted
+  General Material (10000), which shifted every group above it down by one:
+  Facilities and Activities was filed under 10000, Civilian Personnel under
+  11000, and an invented "Science and Technology" filled 12000. Groups are now
+  named to match the codes actually filed under them, and the four groups that
+  had no category at all (13000 Aeronautical, plus Ships, Combat Service
+  Support, and Civil Affairs) are reachable.
+- Searching now expands the groups that contain matches, rather than leaving
+  hits hidden behind collapsed headings.
+
 ## [1.2.95] — 2026-07-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-react",
-  "version": "1.2.95",
+  "version": "1.2.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-react",
-      "version": "1.2.95",
+      "version": "1.2.96",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-react",
   "private": true,
-  "version": "1.2.95",
+  "version": "1.2.96",
   "type": "module",
   "scripts": {
     "predev": "node scripts/vendor-assets.mjs --allow-offline && node scripts/generate-icons.mjs",

--- a/src/components/modals/SSICLookupModal.tsx
+++ b/src/components/modals/SSICLookupModal.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo } from 'react';
-import { Search, X, BookOpen } from 'lucide-react';
+import { useState, useMemo, useEffect } from 'react';
+import { Search, X, BookOpen, Loader2 } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -16,7 +16,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/accordion';
-import { SSIC_CATEGORIES, type SSICCode } from '@/data/ssicCodes';
+import { loadSsicCategories, type SSICCategory, type SSICCode } from '@/data/ssicCodes';
 
 interface SSICLookupModalProps {
   open: boolean;
@@ -24,23 +24,65 @@ interface SSICLookupModalProps {
   onSelect: (code: string) => void;
 }
 
+// The full set is 2,240 codes; a broad search ("1") matches hundreds. Cap what
+// renders so the list stays responsive, and tell the user when there's more.
+const MAX_SEARCH_RESULTS = 100;
+
 export function SSICLookupModal({ open, onOpenChange, onSelect }: SSICLookupModalProps) {
   const [search, setSearch] = useState('');
+  const [categories, setCategories] = useState<SSICCategory[]>([]);
 
-  const filteredCategories = useMemo(() => {
-    if (!search.trim()) return SSIC_CATEGORIES;
+  // ssic.json is dynamically imported to keep it out of the main bundle, so
+  // pull it in when the modal opens. The loader caches, so reopening is free.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void loadSsicCategories().then((loaded) => {
+      if (!cancelled) setCategories(loaded);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const { filteredCategories, totalMatches } = useMemo(() => {
+    if (!search.trim()) {
+      return { filteredCategories: categories, totalMatches: 0 };
+    }
 
     const searchLower = search.toLowerCase();
-    return SSIC_CATEGORIES.map((category) => ({
-      ...category,
-      codes: category.codes.filter(
-        (code) =>
-          code.code.includes(search) ||
-          code.title.toLowerCase().includes(searchLower) ||
-          code.description?.toLowerCase().includes(searchLower)
-      ),
-    })).filter((category) => category.codes.length > 0);
-  }, [search]);
+    const matched = categories
+      .map((category) => ({
+        ...category,
+        codes: category.codes.filter(
+          (code) =>
+            code.code.includes(search) ||
+            code.title.toLowerCase().includes(searchLower) ||
+            code.description?.toLowerCase().includes(searchLower)
+        ),
+      }))
+      .filter((category) => category.codes.length > 0);
+
+    const total = matched.reduce((acc, c) => acc + c.codes.length, 0);
+
+    // Trim across categories in order, so the cap never hides a whole group's
+    // worth of results behind an earlier group.
+    let remaining = MAX_SEARCH_RESULTS;
+    const capped = matched.flatMap((category) => {
+      if (remaining <= 0) return [];
+      const codes = category.codes.slice(0, remaining);
+      remaining -= codes.length;
+      return [{ ...category, codes }];
+    });
+
+    return { filteredCategories: capped, totalMatches: total };
+  }, [search, categories]);
+
+  // Searching must reveal its own hits — an accordion collapsed over a match is
+  // indistinguishable from no match at all. Remounting on the matched set (the
+  // `key` below) re-applies defaultValue, so groups auto-open while searching
+  // while the accordion stays uncontrolled for ordinary browsing.
+  const matchedRanges = search.trim() ? filteredCategories.map((c) => c.range).join('|') : '';
 
   const handleSelect = (code: SSICCode) => {
     onSelect(code.code);
@@ -48,7 +90,8 @@ export function SSICLookupModal({ open, onOpenChange, onSelect }: SSICLookupModa
     setSearch('');
   };
 
-  const totalResults = filteredCategories.reduce((acc, cat) => acc + cat.codes.length, 0);
+  const shown = filteredCategories.reduce((acc, cat) => acc + cat.codes.length, 0);
+  const loading = categories.length === 0;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -83,11 +126,24 @@ export function SSICLookupModal({ open, onOpenChange, onSelect }: SSICLookupModa
         </div>
 
         <p className="text-sm text-muted-foreground">
-          {search ? `${totalResults} results found` : 'Browse or search SSIC codes'}
+          {!search && 'Browse or search SSIC codes'}
+          {search && totalMatches > shown && `Showing ${shown} of ${totalMatches} results — refine your search`}
+          {search && totalMatches <= shown && `${totalMatches} result${totalMatches === 1 ? '' : 's'} found`}
         </p>
 
         <ScrollArea className="h-[400px] pr-4">
-          <Accordion type="multiple" className="w-full" defaultValue={search ? filteredCategories.map((c) => c.range) : []}>
+          {loading && (
+            <div className="flex items-center justify-center gap-2 py-8 text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span className="text-sm">Loading SSIC codes…</span>
+            </div>
+          )}
+          <Accordion
+            key={matchedRanges || 'browse'}
+            type="multiple"
+            className="w-full"
+            defaultValue={matchedRanges ? matchedRanges.split('|') : []}
+          >
             {filteredCategories.map((category) => (
               <AccordionItem key={category.range} value={category.range}>
                 <AccordionTrigger className="hover:no-underline">

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -29,10 +29,12 @@ export {
 } from './ranks';
 
 // SSIC Codes
+//
+// `loadSsicCategories()` async-loads the 172 KB ssic.json on first call; the
+// result is cached, so callers can await it freely.
 export {
-  SSIC_CATEGORIES,
-  ALL_SSIC_CODES,
-  SSIC_BY_CODE,
+  loadSsicCategories,
+  loadAllSsicCodes,
   type SSICCode,
   type SSICCategory,
 } from './ssicCodes';

--- a/src/data/ssicCodes.ts
+++ b/src/data/ssicCodes.ts
@@ -1,5 +1,12 @@
-// SSIC (Standard Subject Identification Code) Reference Data
-// Based on SECNAV M-5210.2 (Department of the Navy Standard Subject Identification Codes)
+// SSIC (Standard Subject Identification Code) reference data.
+//
+// Codes come from `ssic.json` (SECNAV M-5210.2, August 2018 — 2,240 codes).
+// That file is the source of truth for code + title; this module only groups
+// them and layers on the hand-written descriptions.
+//
+// Loaded through a cached dynamic import() so the 172 KB payload stays out of
+// the main bundle — the same treatment units.json gets. Callers await
+// `loadSsicCategories()`; the SSIC lookup modal does so when it opens.
 
 export interface SSICCode {
   code: string;
@@ -13,214 +20,114 @@ export interface SSICCategory {
   codes: SSICCode[];
 }
 
-export const SSIC_CATEGORIES: SSICCategory[] = [
-  {
-    range: '1000-1999',
-    name: 'Military Personnel',
-    codes: [
-      { code: '1000', title: 'General Military Personnel Matters', description: 'General matters relating to military personnel' },
-      { code: '1001', title: 'Military Personnel Policy' },
-      { code: '1040', title: 'Promotions and Advancements' },
-      { code: '1050', title: 'Officer Procurement and Training' },
-      { code: '1070', title: 'Classification and Assignment' },
-      { code: '1080', title: 'Military Awards and Decorations' },
-      { code: '1100', title: 'Manpower Management' },
-      { code: '1133', title: 'Billet Structure' },
-      { code: '1200', title: 'Military Compensation' },
-      { code: '1300', title: 'Recruiting' },
-      { code: '1306', title: 'Enlisted Assignments' },
-      { code: '1320', title: 'Officer Assignments' },
-      { code: '1400', title: 'Separations and Retirements' },
-      { code: '1500', title: 'Education and Training', description: 'Military education and professional development' },
-      { code: '1510', title: 'Professional Military Education' },
-      { code: '1520', title: 'Unit Training' },
-      { code: '1540', title: 'Schools and Courses' },
-      { code: '1550', title: 'Training Exercises' },
-      { code: '1600', title: 'Morale, Welfare, and Recreation' },
-      { code: '1610', title: 'Leave and Liberty' },
-      { code: '1620', title: 'Morale Programs' },
-      { code: '1640', title: 'Recreation Programs' },
-      { code: '1650', title: 'Religious Programs' },
-      { code: '1700', title: 'Discipline' },
-      { code: '1740', title: 'Correctional Programs' },
-      { code: '1752', title: 'Alcohol and Drug Abuse Prevention' },
-      { code: '1754', title: 'Sexual Assault Prevention' },
-    ],
-  },
-  {
-    range: '2000-2999',
-    name: 'Telecommunications',
-    codes: [
-      { code: '2000', title: 'General Telecommunications Matters' },
-      { code: '2010', title: 'Communications Policy' },
-      { code: '2070', title: 'Frequency Management' },
-      { code: '2300', title: 'Telephone Systems' },
-      { code: '2400', title: 'Radio Systems' },
-    ],
-  },
-  {
-    range: '3000-3999',
-    name: 'Operations and Readiness',
-    codes: [
-      { code: '3000', title: 'General Operations and Readiness', description: 'Operational planning and readiness matters' },
-      { code: '3040', title: 'Combat Readiness' },
-      { code: '3050', title: 'Joint Operations' },
-      { code: '3070', title: 'Exercises and Training Operations' },
-      { code: '3100', title: 'Plans and Policy' },
-      { code: '3120', title: 'Operations Plans' },
-      { code: '3140', title: 'Contingency Plans' },
-      { code: '3300', title: 'Deployment' },
-      { code: '3400', title: 'Intelligence Operations' },
-      { code: '3500', title: 'Force Protection' },
-      { code: '3502', title: 'Antiterrorism' },
-      { code: '3504', title: 'Physical Security' },
-    ],
-  },
-  {
-    range: '4000-4999',
-    name: 'Logistics',
-    codes: [
-      { code: '4000', title: 'General Logistics Matters', description: 'Supply, maintenance, and logistics support' },
-      { code: '4100', title: 'Supply Management' },
-      { code: '4200', title: 'Transportation' },
-      { code: '4300', title: 'Food Service' },
-      { code: '4400', title: 'Maintenance Management' },
-      { code: '4500', title: 'Facilities Management' },
-      { code: '4600', title: 'Contracting' },
-      { code: '4700', title: 'Property Management' },
-      { code: '4790', title: 'Equipment Disposition' },
-    ],
-  },
-  {
-    range: '5000-5999',
-    name: 'General Administration and Management',
-    codes: [
-      { code: '5000', title: 'General Admin and Management', description: 'Administrative policy and procedures' },
-      { code: '5040', title: 'Management Programs' },
-      { code: '5050', title: 'Managerial Economics' },
-      { code: '5100', title: 'Organization and Functions' },
-      { code: '5200', title: 'Information Management' },
-      { code: '5210', title: 'Records Management', description: 'Filing systems, records retention and disposition' },
-      { code: '5211', title: 'NAVMC Forms' },
-      { code: '5212', title: 'Directives and Publications' },
-      { code: '5214', title: 'Reports Management' },
-      { code: '5215', title: 'Forms Management' },
-      { code: '5216', title: 'Correspondence', description: 'Official correspondence and memoranda' },
-      { code: '5220', title: 'Information Security' },
-      { code: '5230', title: 'Privacy Act' },
-      { code: '5239', title: 'Cybersecurity' },
-      { code: '5300', title: 'History and Museums' },
-      { code: '5310', title: 'Historical Records' },
-      { code: '5400', title: 'Public Affairs' },
-      { code: '5430', title: 'Public Relations' },
-      { code: '5450', title: 'Community Relations' },
-      { code: '5500', title: 'Inspections' },
-      { code: '5510', title: 'Command Inspections' },
-      { code: '5520', title: 'Inspector General' },
-      { code: '5530', title: 'Investigations' },
-      { code: '5580', title: 'Law Enforcement' },
-      { code: '5600', title: 'Legal Services' },
-      { code: '5700', title: 'Visual Information' },
-      { code: '5720', title: 'Photography' },
-      { code: '5800', title: 'Equal Opportunity' },
-      { code: '5900', title: 'Printing and Publications' },
-    ],
-  },
-  {
-    range: '6000-6999',
-    name: 'Medicine and Dentistry',
-    codes: [
-      { code: '6000', title: 'General Medical and Dental', description: 'Medical and dental services' },
-      { code: '6100', title: 'Medical Readiness' },
-      { code: '6110', title: 'Physical Examinations' },
-      { code: '6150', title: 'Medical Records' },
-      { code: '6200', title: 'Environmental Health' },
-      { code: '6210', title: 'Preventive Medicine' },
-      { code: '6220', title: 'Occupational Health' },
-      { code: '6260', title: 'Radiation Health' },
-      { code: '6300', title: 'Mental Health' },
-      { code: '6320', title: 'Combat Stress' },
-    ],
-  },
-  {
-    range: '7000-7999',
-    name: 'Financial Management',
-    codes: [
-      { code: '7000', title: 'General Financial Management', description: 'Budgeting, accounting, and fiscal matters' },
-      { code: '7010', title: 'Fiscal Policy' },
-      { code: '7100', title: 'Budget Administration' },
-      { code: '7110', title: 'Budget Preparation' },
-      { code: '7120', title: 'Budget Execution' },
-      { code: '7200', title: 'Accounting' },
-      { code: '7220', title: 'Fund Administration' },
-      { code: '7300', title: 'Disbursing' },
-      { code: '7400', title: 'Travel' },
-      { code: '7500', title: 'Cost Analysis' },
-      { code: '7510', title: 'Economic Analysis' },
-    ],
-  },
-  {
-    range: '8000-8999',
-    name: 'Ordnance Material',
-    codes: [
-      { code: '8000', title: 'General Ordnance', description: 'Weapons and ammunition' },
-      { code: '8010', title: 'Ordnance Policy' },
-      { code: '8020', title: 'Weapons Systems' },
-      { code: '8300', title: 'Ammunition' },
-      { code: '8350', title: 'Explosives Safety' },
-    ],
-  },
-  {
-    range: '9000-9999',
-    name: 'Ships, Aircraft, and Weapons Systems',
-    codes: [
-      { code: '9000', title: 'General Ships and Aircraft', description: 'Vessels and aviation systems' },
-      { code: '9080', title: 'Boats and Craft' },
-      { code: '9300', title: 'Aviation' },
-      { code: '9301', title: 'Aviation Policy' },
-      { code: '9400', title: 'Ground Equipment' },
-      { code: '9600', title: 'Electronic Equipment' },
-    ],
-  },
-  {
-    range: '10000-10999',
-    name: 'Facilities and Activities',
-    codes: [
-      { code: '10000', title: 'General Facilities', description: 'Real property and facilities' },
-      { code: '10100', title: 'Facilities Planning' },
-      { code: '10110', title: 'Master Planning' },
-      { code: '10500', title: 'Environmental Compliance' },
-      { code: '10520', title: 'Pollution Prevention' },
-    ],
-  },
-  {
-    range: '11000-11999',
-    name: 'Civilian Personnel',
-    codes: [
-      { code: '11000', title: 'General Civilian Personnel', description: 'Civilian workforce management' },
-      { code: '11100', title: 'Employment' },
-      { code: '11200', title: 'Classification and Position Management' },
-      { code: '11300', title: 'Compensation' },
-      { code: '11400', title: 'Labor Relations' },
-      { code: '11500', title: 'Employee Development' },
-    ],
-  },
-  {
-    range: '12000-12999',
-    name: 'Science and Technology',
-    codes: [
-      { code: '12000', title: 'General S&T', description: 'Research and development' },
-      { code: '12100', title: 'Research Policy' },
-      { code: '12300', title: 'Test and Evaluation' },
-      { code: '12600', title: 'Technology Transfer' },
-    ],
-  },
+/**
+ * SSIC major groups, keyed by the thousands digit of the code.
+ *
+ * Groups 1000–13000 are the SECNAV M-5210.2 subject groups. Each name was
+ * cross-checked against the codes actually filed under it in ssic.json — 10000
+ * holds "Provisions and Rations" / "Clothing and Uniforms" (General Material)
+ * while 11000 holds "Shore Station Development" / "Real Estate" (Facilities
+ * and Activities).
+ *
+ * 14000–16000 are NOT M-5210.2 subject groups. Those 20 codes exist in the
+ * source data and name themselves in their own group code ("SHIPS (GENERAL)",
+ * "COMBAT SERVICE SUPPORT (GENERAL)", "CIVIL AFFAIRS (GENERAL)"), so they're
+ * surfaced under those titles rather than dropped or filed under a guess.
+ */
+const SSIC_GROUPS: { thousand: number; name: string }[] = [
+  { thousand: 1, name: 'Military Personnel' },
+  { thousand: 2, name: 'Telecommunications' },
+  { thousand: 3, name: 'Operations and Readiness' },
+  { thousand: 4, name: 'Logistics' },
+  { thousand: 5, name: 'General Administration and Management' },
+  { thousand: 6, name: 'Medicine and Dentistry' },
+  { thousand: 7, name: 'Financial Management' },
+  { thousand: 8, name: 'Ordnance Material' },
+  { thousand: 9, name: 'Ships Design and Material' },
+  { thousand: 10, name: 'General Material' },
+  { thousand: 11, name: 'Facilities and Activities' },
+  { thousand: 12, name: 'Civilian Personnel' },
+  { thousand: 13, name: 'Aeronautical and Astronautical Material' },
+  { thousand: 14, name: 'Ships' },
+  { thousand: 15, name: 'Combat Service Support' },
+  { thousand: 16, name: 'Civil Affairs' },
 ];
 
-// Flatten all codes for easy searching
-export const ALL_SSIC_CODES: SSICCode[] = SSIC_CATEGORIES.flatMap((cat) => cat.codes);
+/**
+ * Plain-language descriptions for the codes reached for most often.
+ * Supplementary only — the title from ssic.json is the authoritative text.
+ */
+const CODE_DESCRIPTIONS: Record<string, string> = {
+  '1000': 'General matters relating to military personnel',
+  '1500': 'Military education and professional development',
+  '3000': 'Operational planning and readiness matters',
+  '4000': 'Supply, maintenance, and logistics support',
+  '5000': 'Administrative policy and procedures',
+  '5210': 'Filing systems, records retention and disposition',
+  '5216': 'Official correspondence and memoranda',
+  '6000': 'Medical and dental services',
+  '7000': 'Budgeting, accounting, and fiscal matters',
+  '8000': 'Weapons and ammunition',
+  '9000': 'Vessels and aviation systems',
+};
 
-// Quick lookup by code
-export const SSIC_BY_CODE: Record<string, SSICCode> = Object.fromEntries(
-  ALL_SSIC_CODES.map((code) => [code.code, code])
-);
+/**
+ * Codes carried over from the previous hand-maintained list that ssic.json
+ * doesn't contain, so widening the dataset can't silently drop a code someone
+ * already relies on.
+ */
+const EXTRA_CODES: SSICCode[] = [{ code: '9301', title: 'Aviation Policy' }];
+
+interface RawSsic {
+  codes: { code: string; title: string }[];
+}
+
+function groupFor(code: string): number | null {
+  const n = parseInt(code, 10);
+  if (!Number.isFinite(n)) return null;
+  const thousand = Math.floor(n / 1000);
+  return SSIC_GROUPS.some((g) => g.thousand === thousand) ? thousand : null;
+}
+
+function buildCategories(raw: RawSsic): SSICCategory[] {
+  // De-dupe by code so an EXTRA_CODES entry can't double up if a later
+  // ssic.json adds it.
+  const byCode = new Map<string, SSICCode>();
+  for (const entry of [...raw.codes, ...EXTRA_CODES]) {
+    if (byCode.has(entry.code)) continue;
+    const description = CODE_DESCRIPTIONS[entry.code];
+    byCode.set(entry.code, description ? { ...entry, description } : { ...entry });
+  }
+
+  const buckets = new Map<number, SSICCode[]>();
+  for (const entry of byCode.values()) {
+    const thousand = groupFor(entry.code);
+    if (thousand === null) continue;
+    const bucket = buckets.get(thousand);
+    if (bucket) bucket.push(entry);
+    else buckets.set(thousand, [entry]);
+  }
+
+  return SSIC_GROUPS.flatMap(({ thousand, name }) => {
+    const codes = buckets.get(thousand);
+    if (!codes || codes.length === 0) return [];
+    codes.sort((a, b) => a.code.localeCompare(b.code, undefined, { numeric: true }));
+    return [{ range: `${thousand * 1000}-${thousand * 1000 + 999}`, name, codes }];
+  });
+}
+
+let cached: Promise<SSICCategory[]> | null = null;
+
+/** SSIC groups with their codes. Caches the parsed result after the first call. */
+export function loadSsicCategories(): Promise<SSICCategory[]> {
+  cached ??= import('./ssic.json').then((mod) =>
+    buildCategories((mod.default ?? mod) as unknown as RawSsic)
+  );
+  return cached;
+}
+
+/** Flat list of every code, for searching the whole set. */
+export async function loadAllSsicCodes(): Promise<SSICCode[]> {
+  const categories = await loadSsicCategories();
+  return categories.flatMap((c) => c.codes);
+}

--- a/tests/unit/ssicCodes.test.ts
+++ b/tests/unit/ssicCodes.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The SSIC lookup rendered a hand-maintained 129-code subset while the full
+ * 2,240-code M-5210.2 set sat in `ssic.json` imported by nothing — a search for
+ * a real code like 11013 returned nothing. That subset also mislabeled its
+ * major groups: it omitted General Material (10000), so every group above it
+ * was shifted down one (Facilities filed as 10000, Civilian Personnel as
+ * 11000) and an invented "Science and Technology" filled 12000.
+ *
+ * These tests pin both halves: the whole dataset is reachable, and each group
+ * name matches the codes actually filed under it.
+ */
+import { describe, it, expect } from 'vitest';
+import { loadSsicCategories, loadAllSsicCodes } from '@/data/ssicCodes';
+
+describe('SSIC dataset', () => {
+  it('exposes the full M-5210.2 set, not the old 129-code subset', async () => {
+    const codes = await loadAllSsicCodes();
+    expect(codes.length).toBeGreaterThan(2000);
+  });
+
+  it('finds codes that the old subset never carried', async () => {
+    const codes = await loadAllSsicCodes();
+    const byCode = new Map(codes.map((c) => [c.code, c]));
+    // 11013 (Shore Station Construction) and 3120 were unreachable before.
+    expect(byCode.get('11013')).toBeDefined();
+    expect(byCode.get('3120')).toBeDefined();
+  });
+
+  it('keeps 9301, which lives only in the old curated list', async () => {
+    const codes = await loadAllSsicCodes();
+    expect(codes.find((c) => c.code === '9301')?.title).toBe('Aviation Policy');
+  });
+
+  it('keeps the hand-written descriptions on common codes', async () => {
+    const codes = await loadAllSsicCodes();
+    const byCode = new Map(codes.map((c) => [c.code, c]));
+    expect(byCode.get('5216')?.description).toBe('Official correspondence and memoranda');
+    expect(byCode.get('1000')?.description).toBeTruthy();
+  });
+
+  it('emits no duplicate codes', async () => {
+    const codes = await loadAllSsicCodes();
+    expect(new Set(codes.map((c) => c.code)).size).toBe(codes.length);
+  });
+});
+
+describe('SSIC major groups', () => {
+  it('files every code under the group matching its thousands digit', async () => {
+    const categories = await loadSsicCategories();
+    for (const category of categories) {
+      const [start] = category.range.split('-').map(Number);
+      for (const { code } of category.codes) {
+        expect(Math.floor(parseInt(code, 10) / 1000) * 1000).toBe(start);
+      }
+    }
+  });
+
+  // The regression itself: these three were shifted, and 13000 was missing.
+  it.each([
+    ['10000-10999', 'General Material', '10120'], // Clothing and Uniforms
+    ['11000-11999', 'Facilities and Activities', '11011'], // Real Estate
+    ['12000-12999', 'Civilian Personnel', '12300'], // Employment
+    ['13000-13999', 'Aeronautical and Astronautical Material', '13010'], // Aircraft Characteristics
+  ])('names %s "%s" and files %s under it', async (range, name, sampleCode) => {
+    const categories = await loadSsicCategories();
+    const category = categories.find((c) => c.range === range);
+    expect(category?.name).toBe(name);
+    expect(category?.codes.some((c) => c.code === sampleCode)).toBe(true);
+  });
+
+  it('no longer advertises groups that are not in M-5210.2', async () => {
+    const categories = await loadSsicCategories();
+    const names = categories.map((c) => c.name);
+    expect(names).not.toContain('Science and Technology');
+  });
+
+  it('sorts codes numerically within a group', async () => {
+    const categories = await loadSsicCategories();
+    const group = categories.find((c) => c.range === '1000-1999')!;
+    const nums = group.codes.map((c) => parseInt(c.code, 10));
+    expect(nums).toEqual([...nums].sort((a, b) => a - b));
+  });
+});


### PR DESCRIPTION
Two bugs in the SSIC lookup, found while checking why a valid code couldn't be found.

## 1. The lookup only searched 129 of 2,240 codes

`src/data/ssic.json` — the full SECNAV M-5210.2 list (2,240 codes) — **was imported by nothing**. The modal rendered a separate hand-maintained 129-code subset from `ssicCodes.ts`, so searching a real code returned nothing:

| Code | Before | After |
|---|---|---|
| `11013` Shore Station Construction | no results | found |
| `3120` Operating Procedures, Tasks, and Employment | no results | found |
| `13010` Aircraft Characteristics | no results | found |

## 2. Three major-group names were wrong, and four groups were missing

The hand-maintained list **omitted General Material (10000)**, which shifted everything above it down one — and an invented "Science and Technology" (not an M-5210.2 group) filled the gap at 12000. Each corrected name was cross-checked against the codes actually filed under it:

| Range | Was | Now | Evidence in the data |
|---|---|---|---|
| 10000s | Facilities and Activities | **General Material** | Provisions and Rations, Clothing and Uniforms |
| 11000s | Civilian Personnel | **Facilities and Activities** | Shore Station Development, Real Estate |
| 12000s | Science and Technology | **Civilian Personnel** | Employment, OPM Issuance System |
| 13000s | *(no category — 138 codes unreachable)* | **Aeronautical and Astronautical Material** | Aircraft Characteristics, Aerodynamics |

The old descriptions corroborate the shift: 10000 read "Real property and facilities" and 11000 "Civilian workforce management" — the correct text for the *next* group up.

## Also

- **Searching now expands its own matches.** The accordion's `defaultValue` never re-applied, so a hit could sit invisible behind a collapsed heading — indistinguishable from no match.
- **Results cap at 100** with `Showing 100 of 1167 results — refine your search`, so a broad query can't render a thousand rows.
- **`ssic.json` loads via a cached dynamic `import()`** (the treatment units.json already gets) — it splits into its own 108 KB chunk instead of landing in the main bundle.

## Nothing dropped

- `9301 Aviation Policy` exists only in the old curated list, not in ssic.json — carried over explicitly, so widening the dataset can't silently delete a code someone uses.
- The 11 hand-written descriptions on common codes (5216, 5210, 1000…) are preserved as an overlay. The three that described the *shifted* groups were dropped, as they no longer match their code.
- Codes de-duped by code; sorted numerically within each group.

## Flagged, not silently decided

**14000/15000/16000 are not M-5210.2 subject groups** (SSIC runs 1000–13000). Those 20 codes are in the source data and name themselves in their own group code ("SHIPS (GENERAL)", "COMBAT SERVICE SUPPORT (GENERAL)", "CIVIL AFFAIRS (GENERAL)"), so they're surfaced under those titles rather than dropped or filed under a guess. Worth an S1 read on whether they belong in an SSIC picker at all.

Similarly, **12000 holds 3 INTELLIGENCE-titled codes** (12000, 121xx) that don't fit Civilian Personnel — an anomaly in the source data, left as-is rather than "corrected".

## Verified

Driven in a real browser, not just unit tests: opened the lookup, typed `11013` → **"1 result found"**, auto-expanded, showing *Shore Station Construction* under *Facilities and Activities*. Broad search `1` → **"Showing 100 of 1167"** with exactly 100 rows rendered. Clearing returns to 16 collapsed groups.

12 new tests pin both bugs (full set reachable; each group named for the codes under it; 9301 and descriptions preserved; no duplicates). build 0, lint 0, check-no-cdn OK, 1636/1636.