### PR TITLE
docs: correct the counts the README advertises

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,9 @@ jobs:
         # Lint is now a gate: the baseline is clean (0 errors). The
         # `eslint-plugin-security` follow-up is still open. Bundle-size
         # and `npm audit` gates already exist (see the `build` and
-        # `audit` jobs below). CodeQL runs separately via the
-        # auto-generated `codeql.yml` workflow.
+        # `audit` jobs below). CodeQL is not in this repo at all — it runs
+        # from GitHub's default setup (Settings > Code security), weekly and
+        # on every PR, so there's no workflow file here to read.
     steps:
       - uses: actions/checkout@v7
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ DonDocs uses a WebAssembly LaTeX compiler to produce publication-quality PDFs th
 - **Clause Library** - Save and insert reusable body paragraphs, seeded with common SECNAV boilerplate
 - **Endorsement Inheritance** - Base an endorsement on a saved letter: composes the basic-letter reference line and carries the subject, references, and enclosures forward
 - **Clear Fields** - Reset all content while preserving letterhead for quick new document creation
-- **Reference Library** - 107 searchable military references with one-click insert
-- **Unit Directory** - 3,139 units searchable by name, abbreviation, MCC, or location; insert directly into letterhead or To/Via lines
+- **Reference Library** - 135 searchable military references with one-click insert
+- **Unit Directory** - 3,140 units searchable by name, abbreviation, MCC, or location; insert directly into letterhead or To/Via lines
 - **Office Codes** - 74 standard military position codes for signature blocks
 - **SSIC Lookup** - 2,240 codes searchable by number or description
 - **Batch Generation** - Generate multiple documents with 28 built-in placeholders and Insert Variable button
@@ -89,7 +89,7 @@ DonDocs uses a WebAssembly LaTeX compiler to produce publication-quality PDFs th
   - Dates of Birth
   - Phone numbers
   - Personal email addresses
-  - 95+ medical/PHI keywords
+  - 40 medical/PHI keywords
 - **Digital Signature Fields** - CAC/PIV compatible signature boxes in PDF
 - **Classification Markings** - Unclassified through TOP SECRET//SCI
 - **CUI Handling** - 10 categories with distribution statements (A-F)
@@ -502,7 +502,7 @@ There are two types of templates:
 **Format Templates** (LaTeX) - Define document layouts:
 - `public/lib/latex-templates.js` contains all LaTeX templates as a JavaScript object
 - `tex/main.tex` - Main document structure, package imports, base commands
-- `tex/templates/*.tex` - Document format templates (17 types: naval_letter, mfr, etc.)
+- `tex/templates/*.tex` - Document format templates (20 types: naval_letter, mfr, etc.)
 - Each format defines:
   - `\printDateAndTitle` - How date/SSIC block is formatted
   - `\printAddressBlock` - How From/To/Via/Subject appears


### PR DESCRIPTION
Four numbers in the README didn't match the code. Each was checked against the data rather than adjusted by eye.

| Claim | Was | Is |
|---|---|---|
| Reference library | 107 | **135** |
| Unit directory | 3,139 | **3,140** |
| Medical/PHI keywords | 95+ | **40** |
| `tex/templates/*.tex` | 17 types | **20** |

**The PHI line is the one that mattered.** The other three undersell the tool; that one oversells a security feature. `MEDICAL_KEYWORDS` in `src/services/pii/detector.ts` holds 40 entries — telling someone the pre-export scan checks "95+" is exactly the sort of thing that costs you trust in the scanner at the moment someone is deciding whether to rely on it. The number now matches the list. Growing the list is a separate job: the detector uses precision gates rather than confidence scores, so keywords can't be added carelessly without generating false positives.

**Verified as already accurate, left alone:** SSIC "2,240 codes searchable" (true as of #207), office codes (74), document types (20, in three places), and 8 paragraph levels (`MAX_DEPTH` 7, zero-indexed).

## Also

`test.yml` claimed *"CodeQL runs separately via the auto-generated `codeql.yml` workflow."* No such file exists — CodeQL runs from GitHub's default setup, configured in repo settings, weekly and on every PR. The comment now says that, so the next person doesn't go looking for a workflow that was never there.

Docs and a comment only — no version bump, no behavior change. lint 0.