### PR TITLE
feat(templates): add the appointee's acknowledgement endorsement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.98] — 2026-07-16
+
+### Added
+
+- An "Appointment Acknowledgement (Endorsement)" template — the appointee's
+  half of an appointment, endorsing back to the appointing officer that they
+  have read the references and assume the duties. It pairs with the existing
+  "Appointment to Collateral Duty" letter, which had no acknowledgement to go
+  with it. The duty title and unit are placeholders and no program's orders are
+  baked in, so the same template serves any collateral duty.
+- This is the first template that isn't a naval letter; loading it switches the
+  document type to a same-page endorsement.
+
 ## [1.2.97] — 2026-07-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dondocs",
-  "version": "1.2.97",
+  "version": "1.2.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dondocs",
-      "version": "1.2.97",
+      "version": "1.2.98",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.97",
+  "version": "1.2.98",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/src/data/templates/administrative/appointment-acknowledgement.ts
+++ b/src/data/templates/administrative/appointment-acknowledgement.ts
@@ -1,0 +1,25 @@
+import type { LetterTemplate } from '../types';
+
+/**
+ * The appointee's half of an appointment: a first endorsement back to the
+ * appointing officer acknowledging the duty.
+ *
+ * Wording follows the acknowledgement endorsements published with real
+ * appointment letters (e.g. MCCS Hawaii's SMP representative letter and
+ * enclosure (2) to MCAS Miramar StaO 1710.4B) — read-and-understand the
+ * references, then assume the duties. The duty title and references are left
+ * as placeholders: the appointment letter is the same shape whatever the
+ * collateral duty is, and only the governing references change with it.
+ */
+export const appointmentAcknowledgement: LetterTemplate = {
+  id: 'appointment-acknowledgement',
+  name: 'Appointment Acknowledgement (Endorsement)',
+  category: 'Administrative',
+  description: "Acknowledge an appointment back to the appointing officer — the appointee's endorsement",
+  docType: 'same_page_endorsement',
+  subject: 'APPOINTMENT TO COLLATERAL DUTY',
+  paragraphs: [
+    { text: 'I have read and understand the references listed above and all orders pertaining to my appointment.', level: 0 },
+    { text: 'I hereby assume the duties and responsibilities as the [DUTY TITLE] for [UNIT NAME].', level: 0 },
+  ],
+};

--- a/src/data/templates/administrative/index.ts
+++ b/src/data/templates/administrative/index.ts
@@ -1,3 +1,4 @@
 export { appointmentCollateralDuty } from './appointment-collateral-duty';
+export { appointmentAcknowledgement } from './appointment-acknowledgement';
 export { appointmentBoardMember } from './appointment-board-member';
 export { appointmentSafetyOfficer } from './appointment-safety-officer';

--- a/src/data/templates/index.ts
+++ b/src/data/templates/index.ts
@@ -18,6 +18,7 @@ import { commandInterest } from './leadership';
 // Administrative
 import {
   appointmentCollateralDuty,
+  appointmentAcknowledgement,
   appointmentBoardMember,
   appointmentSafetyOfficer,
 } from './administrative';
@@ -42,6 +43,7 @@ export const LETTER_TEMPLATES: LetterTemplate[] = [
   commandInterest,
   // Administrative
   appointmentCollateralDuty,
+  appointmentAcknowledgement,
   appointmentBoardMember,
   appointmentSafetyOfficer,
   // Investigations

--- a/tests/unit/appointmentAcknowledgement.test.ts
+++ b/tests/unit/appointmentAcknowledgement.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The acknowledgement template is the first template with a docType other than
+ * `naval_letter`, so it exercises a path the other 11 never have: the loader
+ * must switch the document type, and the endorsement generator must render the
+ * template's paragraphs. These tests pin both, plus the placeholder contract
+ * (the duty title and references vary per appointment; the letter shape does
+ * not, so nothing about a specific duty may be baked in).
+ */
+import { describe, it, expect } from 'vitest';
+import { LETTER_TEMPLATES } from '@/data/templates';
+import { generateFlatLatex } from '@/services/latex/flat-generator';
+import { DOC_TYPE_CONFIG, DOC_TYPE_LABELS } from '@/types/document';
+
+const ack = LETTER_TEMPLATES.find((t) => t.id === 'appointment-acknowledgement')!;
+
+describe('appointment acknowledgement template', () => {
+  it('is registered', () => {
+    expect(ack).toBeDefined();
+  });
+
+  it('is an endorsement, not a naval letter — it is the appointee half', () => {
+    expect(ack.docType).toBe('same_page_endorsement');
+    // Guard the loader contract: TemplateLoaderModal calls setDocType(t.docType),
+    // so an unknown docType would silently produce a broken document.
+    expect(DOC_TYPE_CONFIG[ack.docType]).toBeDefined();
+    expect(DOC_TYPE_LABELS[ack.docType]).toBeDefined();
+  });
+
+  it('carries the read-and-understand / assume-the-duties wording', () => {
+    const text = ack.paragraphs.map((p) => p.text).join(' ');
+    expect(text).toMatch(/read and understand/i);
+    expect(text).toMatch(/assume the duties and responsibilities/i);
+  });
+
+  it('leaves duty and unit as placeholders — the refs change per appointment', () => {
+    const text = ack.paragraphs.map((p) => p.text).join(' ');
+    expect(text).toContain('[DUTY TITLE]');
+    expect(text).toContain('[UNIT NAME]');
+    // No specific program's orders may be baked in: the same letter serves MSG,
+    // SMP, safety, or any other collateral duty, and each cites its own.
+    expect(text).not.toMatch(/MCO\s+\d/);
+    expect(text).not.toMatch(/\bSMP\b|Single Marine Program/i);
+  });
+
+  it('renders through the endorsement generator', () => {
+    const tex = generateFlatLatex({
+      docType: ack.docType,
+      formData: {
+        docType: ack.docType,
+        from: 'Sergeant J. A. DOE, USMC',
+        to: 'Commanding Officer, 1st Battalion, 6th Marines',
+        subject: ack.subject,
+        basicLetterId: 'CO 1stBn 6thMar ltr 5216 Ser 0123 of 15 Jan 25',
+        endorsementOrdinal: 'FIRST',
+        sigFirst: 'John',
+        sigLast: 'DOE',
+      },
+      references: [],
+      enclosures: [],
+      paragraphs: ack.paragraphs,
+      copyTos: [],
+      distributions: [],
+    } as never);
+
+    expect(tex).toContain('FIRST ENDORSEMENT');
+    expect(tex).toMatch(/read and understand/i);
+    expect(tex).toMatch(/assume the duties/i);
+  });
+});


### PR DESCRIPTION
Toward #203. An appointment has two halves — the appointing officer's letter and the appointee's endorsement back. We shipped only the first.

## What's added

`Appointment Acknowledgement (Endorsement)` — `same_page_endorsement`, two paragraphs:

1. I have read and understand the references listed above and all orders pertaining to my appointment.
2. I hereby assume the duties and responsibilities as the [DUTY TITLE] for [UNIT NAME].

The wording follows acknowledgement endorsements published with real appointment letters — MCCS Hawaii's SMP representative letter and enclosure (2) to MCAS Miramar StaO 1710.4B. Two different installations, two different programs, same skeleton, so this is the standard shape rather than one command's habit.

**Nothing duty-specific is baked in.** The duty title and unit are placeholders and no program's orders appear, because the appointment letter is the same whatever the collateral duty is — only the governing references change. A test asserts no `MCO <n>` and no program name can creep in, so this can't quietly become an SMP-only template.

**First template that isn't a naval letter.** The other 11 are all `naval_letter`, so `TemplateLoaderModal`'s `setDocType(t.docType)` path has never been exercised by a template. Tests pin that the docType resolves in both `DOC_TYPE_CONFIG` and `DOC_TYPE_LABELS` — an unknown one would silently produce a broken document.

## Verified

Compiled the template to a real PDF and read the page back:

```
FIRST ENDORSEMENT on CO 1stBn 6thMar ltr 5216 Ser 0123 of 15 Jan 25
From: Sergeant J. A. DOE, USMC
To:   Commanding Officer, 1st Battalion, 6th Marines
I have read and understand the references listed above and all orders pertaining to my appointment.
I hereby assume the duties and responsibilities as the [DUTY TITLE] for [UNIT NAME].
                                        J. A. DOE
```

5 new tests. build 0, lint 0, check-no-cdn OK, 1641/1641.

## What this does not do — #203 stays open

#203 asks for **one page** holding the appointment and the acknowledgement with a rule between them. This does not deliver that, and shouldn't be read as closing it.

A same-page endorsement currently renders **only the endorsement portion** — `letterhead: false`, `ssic: false`, `skipSubject: true`, and the page starts at the rule. Verified by rendering one: no letterhead, no basic letter above it. The design follows the paper workflow in Ch 9 Fig 9-1, where the endorsement is typed onto the printed basic letter's signature page — which doesn't survive being a PDF generator.

So this gives both halves as **two documents**. Emitting both portions in one document is a generator change, tracked separately.