### PR TITLE
feat(endorsement): carry the appointee's acknowledgement on the letter's page

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,12 @@ name: test
 on:
   push:
     branches: [main]
+  # No base-branch filter: a stacked PR targets the branch below it, not main,
+  # and `branches: [main]` silently skipped every job for those — leaving the
+  # Cloudflare deploy previews as the only checks, which look green but test
+  # nothing. Run on every PR regardless of base; the concurrency group below
+  # still cancels superseded runs.
   pull_request:
-    branches: [main]
 
 # Cancel in-progress runs when a new commit lands on the same PR / branch.
 # Each push gets a fresh, definitive result.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -237,11 +237,16 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-      - name: install xelatex + pandoc
+      - name: install xelatex + pandoc + poppler
         # texlive-xetex pulls in the engine + ulem + hyperref + the
         # font packages (txfonts, txfontsb) we use. tabularx + enumitem
         # come from texlive-latex-extra. pandoc ships standalone (3.x
         # in current Ubuntu). ~120MB total install.
+        #
+        # poppler-utils supplies pdftotext + pdfinfo. The render tests
+        # (by-direction-render, appended-endorsement-render) read text and
+        # page counts off a compiled PDF and skip themselves when those
+        # binaries are absent — so without this they passed by not running.
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -249,7 +254,8 @@ jobs:
             texlive-latex-base \
             texlive-latex-extra \
             texlive-fonts-recommended \
-            pandoc
+            pandoc \
+            poppler-utils
 
       - run: npm ci
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
 
 ### Fixed
 
+- The acknowledgement carries its own date line. Ch 9 ¶2.1a starts the
+  endorsement line "on the second line below the date line", and the relief a
+  same-page endorsement gets is limited to the SSIC, subject, and the basic
+  letter's identification symbols — not the date, which Fig 9-1 shows. The date
+  and serial are optional and blank by default, printing the line for the
+  appointee to hand-date at signature.
 - The rendered-PDF tests (`by-direction-render`) were skipping in CI rather than
   running: the compile-matrix job installs texlive and pandoc but never
   installed poppler-utils, and the tests skip themselves when `pdftotext` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
 - An appointment letter can now carry the appointee's acknowledgement on the
   same sheet: you sign the top, a rule divides the page, and the appointee
   endorses back below it. Tick "Add an acknowledgement endorsement" in the
-  Signature section of a naval letter, standard letter, or memorandum. The
+  Signature section of a naval letter or standard letter. The
   From/To lines invert the letter automatically, so the common case needs no
   typing beyond the acknowledgement text and the appointee's name.
 - Previously the endorsement could only be produced as its own separate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.99] — 2026-07-16
+
+### Added
+
+- An appointment letter can now carry the appointee's acknowledgement on the
+  same sheet: you sign the top, a rule divides the page, and the appointee
+  endorses back below it. Tick "Add an acknowledgement endorsement" in the
+  Signature section of a naval letter, standard letter, or memorandum. The
+  From/To lines invert the letter automatically, so the common case needs no
+  typing beyond the acknowledgement text and the appointee's name.
+- Previously the endorsement could only be produced as its own separate
+  document, which is not what an appointment letter looks like in practice
+  (SECNAV M-5216.5 Ch 9, Fig 9-1).
+
+### Fixed
+
+- The rendered-PDF tests (`by-direction-render`) were skipping in CI rather than
+  running: the compile-matrix job installs texlive and pandoc but never
+  installed poppler-utils, and the tests skip themselves when `pdftotext` is
+  absent. CI now installs poppler-utils, and the suites fail rather than skip
+  when the toolchain is missing, so a skip can no longer be mistaken for a pass.
+
 ## [1.2.98] — 2026-07-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dondocs",
-  "version": "1.2.98",
+  "version": "1.2.99",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dondocs",
-      "version": "1.2.98",
+      "version": "1.2.99",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.98",
+  "version": "1.2.99",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/public/lib/latex-templates.js
+++ b/public/lib/latex-templates.js
@@ -798,17 +798,34 @@ const LATEX_TEMPLATES = {
 \\newcommand{\\AckTo}{}
 \\newcommand{\\AckBody}{}
 \\newcommand{\\AckSignature}{}
-\\newcommand{\\setAppendedEndorsement}[4]{%
+\\newcommand{\\AckSerial}{}
+\\newcommand{\\AckDate}{}
+\\newcommand{\\setAppendedEndorsement}[6]{%
     \\renewcommand{\\AckFrom}{#1}%
     \\renewcommand{\\AckTo}{#2}%
     \\renewcommand{\\AckBody}{#3}%
     \\renewcommand{\\AckSignature}{#4}%
+    \\renewcommand{\\AckSerial}{#5}%
+    \\renewcommand{\\AckDate}{#6}%
 }
 
 \\newcommand{\\printAppendedEndorsement}{%
     \\ifdefempty{\\AckFrom}{}{%
         \\vspace{24pt}%
         \\noindent\\rule{\\textwidth}{0.4pt}\\par
+        \\vspace{12pt}%
+        % Ch 9 para 2.1a starts the endorsement line "on the second line below the
+        % date line". A same-page endorsement may omit the SSIC, subject and the
+        % basic letter's ID symbols — the date line is not on that list, and
+        % Fig 9-1 shows it. The serial is optional: an appointee endorsing back
+        % is not assigning one. Both stay blank for hand-dating at signature.
+        \\hfill
+        \\begin{tabular}[t]{@{}l@{}}
+            \\ifdefempty{\\AckSerial}{}{%
+                \\AckSerial\\\\
+            }%
+            \\AckDate
+        \\end{tabular}\\par
         \\vspace{12pt}%
         \\noindent FIRST ENDORSEMENT\\par
         \\vspace{12pt}%

--- a/public/lib/latex-templates.js
+++ b/public/lib/latex-templates.js
@@ -781,6 +781,51 @@ const LATEX_TEMPLATES = {
 \\newcommand{\\ByDirection}{}
 \\newcommand{\\setByDirection}[1]{\\renewcommand{\\ByDirection}{#1}}
 
+%=============================================================================
+% APPENDED ACKNOWLEDGEMENT ENDORSEMENT
+%=============================================================================
+% An appointment letter commonly carries the appointee's acknowledgement on the
+% same page: the appointing officer signs above the rule, the appointee signs
+% below it, and the whole thing is one sheet (SECNAV M-5216.5 Ch 9 — a
+% same-page endorsement may omit the SSIC, subject, and basic-letter ID because
+% it sits on the basic letter's own page, which is exactly the case here).
+%
+% Unlike a standalone same-page endorsement, both halves are authored at once,
+% so the endorsement carries its own From/To/body/signer rather than reusing
+% the letter's. Empty From = nothing renders, so every doc type can call
+% \\printAppendedEndorsement unconditionally.
+\\newcommand{\\AckFrom}{}
+\\newcommand{\\AckTo}{}
+\\newcommand{\\AckBody}{}
+\\newcommand{\\AckSignature}{}
+\\newcommand{\\setAppendedEndorsement}[4]{%
+    \\renewcommand{\\AckFrom}{#1}%
+    \\renewcommand{\\AckTo}{#2}%
+    \\renewcommand{\\AckBody}{#3}%
+    \\renewcommand{\\AckSignature}{#4}%
+}
+
+\\newcommand{\\printAppendedEndorsement}{%
+    \\ifdefempty{\\AckFrom}{}{%
+        \\vspace{24pt}%
+        \\noindent\\rule{\\textwidth}{0.4pt}\\par
+        \\vspace{12pt}%
+        \\noindent FIRST ENDORSEMENT\\par
+        \\vspace{12pt}%
+        % Colon spacing matches the basic letter's From/To block (Ch 7 para 11b).
+        \\noindent
+        \\begin{tabular}[t]{@{}l@{}p{5.75in}@{}}
+            From:\\hspace{2\\fontdimen2\\font} & \\AckFrom\\tabularnewline
+            To:\\hspace{6\\fontdimen2\\font} & \\AckTo
+        \\end{tabular}\\par
+        \\vspace{12pt}%
+        \\AckBody
+        % 4 lines below the last paragraph, matching the basic signature block.
+        \\vspace{48pt}%
+        \\noindent\\hspace*{3.25in}\\AckSignature\\par
+    }%
+}
+
 % setSignatureImage: If non-empty, redefine SignatureImage so \\ifx check works
 \\newcommand{\\setSignatureImage}[1]{%
     \\def\\temp{#1}%
@@ -1422,6 +1467,16 @@ const LATEX_TEMPLATES = {
 %=============================================================================
 
 \\printSignature
+
+
+%=============================================================================
+% APPENDED ACKNOWLEDGEMENT - The appointee's endorsement on the same page
+%=============================================================================
+% Renders nothing unless \\setAppendedEndorsement has been called. Sits between
+% the signature and Distribution/Copy to, matching Ch 9 Figure 9-1 where the
+% "Copy to:" block is the last thing on the sheet, below the endorsement.
+
+\\printAppendedEndorsement
 
 
 %=============================================================================

--- a/public/lib/latex-templates.js
+++ b/public/lib/latex-templates.js
@@ -812,6 +812,14 @@ const LATEX_TEMPLATES = {
 \\newcommand{\\printAppendedEndorsement}{%
     \\ifdefempty{\\AckFrom}{}{%
         \\vspace{24pt}%
+        % Ch 9 para 1 allows a same-page endorsement only when the whole of it
+        % fits on the signature page -- "If not, use a new-page endorsement." A
+        % minipage cannot be broken, so an endorsement that does not fit moves
+        % whole rather than stranding the appointee's signature on the next
+        % page. It cannot make an over-long endorsement conform (that needs a
+        % new-page endorsement, which is its own doc type), but it does keep the
+        % signature with the block it belongs to.
+        \\noindent\\begin{minipage}{\\textwidth}%
         \\noindent\\rule{\\textwidth}{0.4pt}\\par
         \\vspace{12pt}%
         % Ch 9 para 2.1a starts the endorsement line "on the second line below the
@@ -840,6 +848,7 @@ const LATEX_TEMPLATES = {
         % 4 lines below the last paragraph, matching the basic signature block.
         \\vspace{48pt}%
         \\noindent\\hspace*{3.25in}\\AckSignature\\par
+        \\end{minipage}%
     }%
 }
 

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -548,6 +548,31 @@ export function SignatureSection({ config }: SignatureSectionProps) {
                       </div>
                     </div>
 
+                    {/* Ch 9 ¶2.1a puts a date line above the endorsement line, and
+                        the same-page omission list does not cover it (Fig 9-1).
+                        Left blank it prints an empty line for the appointee to
+                        hand-date, which is how an appointment is usually signed. */}
+                    <div className="grid grid-cols-2 gap-2">
+                      <div className="space-y-2">
+                        <Label htmlFor="endorsementDate">Date (optional)</Label>
+                        <Input
+                          id="endorsementDate"
+                          value={formData.endorsementDate || ''}
+                          onChange={(e) => setField('endorsementDate', e.target.value)}
+                          placeholder="Blank to sign by hand"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="endorsementSerial">Serial (optional)</Label>
+                        <Input
+                          id="endorsementSerial"
+                          value={formData.endorsementSerial || ''}
+                          onChange={(e) => setField('endorsementSerial', e.target.value)}
+                          placeholder="Ser 1710/024"
+                        />
+                      </div>
+                    </div>
+
                     {/* Addressees invert the letter unless overridden, so the common
                         case needs no typing at all. */}
                     <div className="space-y-2">

--- a/src/components/editor/SignatureSection.tsx
+++ b/src/components/editor/SignatureSection.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
+import { canAppendEndorsement } from '@/lib/appendedEndorsement';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
 import { IconTip } from '@/components/ui/icon-tip';
@@ -66,6 +68,7 @@ const SIGNATURE_STYLES = [
 
 export function SignatureSection({ config }: SignatureSectionProps) {
   const { formData, setField, documentMode } = useDocumentStore();
+  const docType = useDocumentStore((s) => s.docType);
   const validationVisible = useUIStore((s) => s.validationVisible);
   const isDualSignature = config.signature === 'dual';
   const hasDualDigitalSignature = isDualSignature && formData.signatureType === 'digital';
@@ -482,6 +485,97 @@ export function SignatureSection({ config }: SignatureSectionProps) {
                 </div>
               )}
             </div>
+
+            {/* Appointment acknowledgement — the appointee's half, same sheet */}
+            {canAppendEndorsement(docType) && (
+              <div className="space-y-3">
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id="appendEndorsement"
+                    checked={formData.appendEndorsement || false}
+                    onCheckedChange={(checked) => setField('appendEndorsement', !!checked)}
+                  />
+                  <Label htmlFor="appendEndorsement" className="font-normal">
+                    Add an acknowledgement endorsement
+                  </Label>
+                  <HelpTip>
+                    <p className="font-medium mb-1">Acknowledgement Endorsement</p>
+                    <p className="text-xs">
+                      Puts the recipient&apos;s acknowledgement on this same page, below a
+                      dividing rule — you sign the top, they sign the bottom, one sheet.
+                      Standard for appointment letters.
+                    </p>
+                  </HelpTip>
+                </div>
+
+                {formData.appendEndorsement && (
+                  <div className="space-y-3 ml-6">
+                    <div className="space-y-2">
+                      <Label htmlFor="endorsementBody">Acknowledgement</Label>
+                      <Textarea
+                        id="endorsementBody"
+                        value={formData.endorsementBody || ''}
+                        onChange={(e) => setField('endorsementBody', e.target.value)}
+                        placeholder={'I have read and understand the references listed above.\nI hereby assume the duties and responsibilities as the [DUTY TITLE].'}
+                        className="min-h-[76px] text-sm"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        One paragraph per line; they&apos;re numbered automatically.
+                      </p>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label>Signed by</Label>
+                      <div className="grid grid-cols-3 gap-2">
+                        <Input
+                          value={formData.endorsementSigFirst || ''}
+                          onChange={(e) => setField('endorsementSigFirst', e.target.value)}
+                          placeholder="First"
+                          aria-label="Acknowledgement signer first name"
+                        />
+                        <Input
+                          value={formData.endorsementSigMiddle || ''}
+                          onChange={(e) => setField('endorsementSigMiddle', e.target.value)}
+                          placeholder="M.I."
+                          aria-label="Acknowledgement signer middle initial"
+                        />
+                        <Input
+                          value={formData.endorsementSigLast || ''}
+                          onChange={(e) => setField('endorsementSigLast', e.target.value)}
+                          placeholder="Last"
+                          aria-label="Acknowledgement signer last name"
+                        />
+                      </div>
+                    </div>
+
+                    {/* Addressees invert the letter unless overridden, so the common
+                        case needs no typing at all. */}
+                    <div className="space-y-2">
+                      <Label htmlFor="endorsementFrom">From (optional)</Label>
+                      <Input
+                        id="endorsementFrom"
+                        value={formData.endorsementFrom || ''}
+                        onChange={(e) => setField('endorsementFrom', e.target.value)}
+                        placeholder={formData.to || "The letter's To line"}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="endorsementTo">To (optional)</Label>
+                      <Input
+                        id="endorsementTo"
+                        value={formData.endorsementTo || ''}
+                        onChange={(e) => setField('endorsementTo', e.target.value)}
+                        placeholder={formData.from || "The letter's From line"}
+                      />
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Left blank, the endorsement answers back: From the letter&apos;s
+                      addressee, To its originator.
+                    </p>
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* Signature Type Selection */}
             <div data-tour="signature-style" className="space-y-3">

--- a/src/lib/appendedEndorsement.ts
+++ b/src/lib/appendedEndorsement.ts
@@ -30,6 +30,8 @@ export interface AppendedEndorsementData {
   endorsementSigFirst?: string;
   endorsementSigMiddle?: string;
   endorsementSigLast?: string;
+  endorsementSerial?: string;
+  endorsementDate?: string;
   /** Fall back to inverting the letter's own addressees. */
   from?: string;
   to?: string;
@@ -40,6 +42,10 @@ export interface AppendedEndorsement {
   to: string;
   /** One entry per non-blank line; the generators number them 1., 2., … */
   paragraphs: string[];
+  /** Optional — an appointee endorsing back is not assigning a serial. */
+  serial: string;
+  /** Blank by default: the appointee hand-dates this when they sign. */
+  date: string;
 }
 
 export function canAppendEndorsement(docType: string): boolean {
@@ -72,7 +78,13 @@ export function resolveAppendedEndorsement(
   // block under a rule would just be a stray paragraph.
   if (!from || !to) return null;
 
-  return { from, to, paragraphs };
+  return {
+    from,
+    to,
+    paragraphs,
+    serial: (data.endorsementSerial || '').trim(),
+    date: (data.endorsementDate || '').trim(),
+  };
 }
 
 /**

--- a/src/lib/appendedEndorsement.ts
+++ b/src/lib/appendedEndorsement.ts
@@ -1,0 +1,90 @@
+/**
+ * The appointee's acknowledgement, carried on the appointment letter's own page.
+ *
+ * An appointment is two halves written at once: the appointing officer signs,
+ * a rule divides the sheet, and the appointee endorses back below it. That is a
+ * same-page endorsement in the sense of SECNAV M-5216.5 Ch 9 — it may omit the
+ * SSIC, subject, and basic-letter ID precisely because it sits on the basic
+ * letter's page — but unlike the standalone `same_page_endorsement` doc type it
+ * is authored together with the letter, so it carries its own addressees, body,
+ * and signer.
+ *
+ * Pure and leaf (no store, no LaTeX escaping) so the PDF and DOCX generators
+ * can share one definition of what "has an acknowledgement" and what goes in it,
+ * and can't drift into rendering different documents from the same input.
+ */
+
+/** Doc types that may carry an appended acknowledgement. */
+const ELIGIBLE = new Set([
+  'naval_letter',
+  'standard_letter',
+  'letterhead_memorandum',
+  'plain_paper_memorandum',
+]);
+
+export interface AppendedEndorsementData {
+  appendEndorsement?: boolean;
+  endorsementFrom?: string;
+  endorsementTo?: string;
+  endorsementBody?: string;
+  endorsementSigFirst?: string;
+  endorsementSigMiddle?: string;
+  endorsementSigLast?: string;
+  /** Fall back to inverting the letter's own addressees. */
+  from?: string;
+  to?: string;
+}
+
+export interface AppendedEndorsement {
+  from: string;
+  to: string;
+  /** One entry per non-blank line; the generators number them 1., 2., … */
+  paragraphs: string[];
+}
+
+export function canAppendEndorsement(docType: string): boolean {
+  return ELIGIBLE.has(docType);
+}
+
+/**
+ * The acknowledgement to render, or null when there's nothing to show.
+ *
+ * The addressees invert the letter by default — the appointee is the letter's
+ * "To" and answers back to its "From" — because that's true of every
+ * appointment and re-typing both is just an opportunity to get them backwards.
+ * An explicit value always wins.
+ */
+export function resolveAppendedEndorsement(
+  docType: string,
+  data: AppendedEndorsementData
+): AppendedEndorsement | null {
+  if (!data.appendEndorsement || !canAppendEndorsement(docType)) return null;
+
+  const from = (data.endorsementFrom || '').trim() || (data.to || '').trim();
+  const to = (data.endorsementTo || '').trim() || (data.from || '').trim();
+
+  const paragraphs = (data.endorsementBody || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  // Without addressees there is no endorsement to render — an unaddressed
+  // block under a rule would just be a stray paragraph.
+  if (!from || !to) return null;
+
+  return { from, to, paragraphs };
+}
+
+/**
+ * The signer's name in the abbreviated form endorsements use (Ch 9): initials
+ * and surname, no rank or title.
+ */
+export function appendedEndorsementSigner(data: AppendedEndorsementData): string {
+  const initials = [data.endorsementSigFirst, data.endorsementSigMiddle]
+    .map((part) => (part || '').trim().charAt(0).toUpperCase())
+    .filter(Boolean)
+    .map((initial) => `${initial}.`)
+    .join(' ');
+  const last = (data.endorsementSigLast || '').trim().toUpperCase();
+  return [initials, last].filter(Boolean).join(' ');
+}

--- a/src/lib/appendedEndorsement.ts
+++ b/src/lib/appendedEndorsement.ts
@@ -98,8 +98,13 @@ export function resolveAppendedEndorsement(
  * and surname, no rank or title.
  */
 export function appendedEndorsementSigner(data: AppendedEndorsementData): string {
-  const initials = [data.endorsementSigFirst, data.endorsementSigMiddle]
-    .map((part) => (part || '').trim().charAt(0).toUpperCase())
+  // First and middle are positional: a middle initial without a first must not
+  // slide into the first slot and print "A. DOE" for someone who left first
+  // blank. Drop the middle when there is no first — same as the letter's own
+  // signature, which never shows a middle without a first.
+  const first = (data.endorsementSigFirst || '').trim().charAt(0).toUpperCase();
+  const middle = first ? (data.endorsementSigMiddle || '').trim().charAt(0).toUpperCase() : '';
+  const initials = [first, middle]
     .filter(Boolean)
     .map((initial) => `${initial}.`)
     .join(' ');

--- a/src/lib/appendedEndorsement.ts
+++ b/src/lib/appendedEndorsement.ts
@@ -14,13 +14,19 @@
  * and can't drift into rendering different documents from the same input.
  */
 
-/** Doc types that may carry an appended acknowledgement. */
-const ELIGIBLE = new Set([
-  'naval_letter',
-  'standard_letter',
-  'letterhead_memorandum',
-  'plain_paper_memorandum',
-]);
+/**
+ * Doc types that may carry an appended acknowledgement — letters only.
+ *
+ * Ch 9 ¶1 opens "When a *letter* is transmitted via your activity, use an
+ * endorsement", and the memorandum chapters (10-12) never mention endorsements
+ * at all, so there is no cite for endorsing a memorandum and Compliant mode may
+ * not invent one. The memo types were listed here on judgement rather than a
+ * cite, and the DOCX path then proved the point: `buildAppendedEndorsement` is
+ * reachable only from `buildStandardLayout`, while memos route through
+ * `buildMemoLayout`, so a memo rendered the acknowledgement in the PDF and
+ * dropped it from the Word file.
+ */
+const ELIGIBLE = new Set(['naval_letter', 'standard_letter']);
 
 export interface AppendedEndorsementData {
   appendEndorsement?: boolean;

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -615,9 +615,20 @@ function buildAppendedEndorsement(store: DocumentStore): string {
 
   const signer = appendedEndorsementSigner(store.formData);
 
+  // Ch 9 para 2.1a: the endorsement line sits below the date line, which the
+  // same-page omission list does not cover (Fig 9-1 shows it). Serial is
+  // optional; both stay blank when the appointee hand-dates at signature.
+  const serialRow = ack.serial ? `${escapeTabular(ack.serial)} \\\\\n` : '';
+
   return `\\vspace{24pt}
 \\noindent
 \\rule{\\textwidth}{0.4pt}
+
+\\vspace{12pt}
+\\hfill
+\\begin{tabular}{@{}l@{}}
+${serialRow}${escapeTabular(ack.date)}
+\\end{tabular}
 
 \\vspace{12pt}
 \\noindent FIRST ENDORSEMENT

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -609,8 +609,11 @@ function buildAppendedEndorsement(store: DocumentStore): string {
   const ack = resolveAppendedEndorsement(store.docType, store.formData);
   if (!ack) return '';
 
+  // \mbox{} protects the label from pandoc's list-marker detection, exactly as
+  // the main body does — without it pandoc consumed the digit and the DOCX
+  // rendered a bare "." where the PDF showed "1.".
   const body = ack.paragraphs
-    .map((text, i) => `\\noindent ${i + 1}.\\hspace{2\\fontdimen2\\font}${escapeFlat(text)}\n\n`)
+    .map((text, i) => `\\noindent \\mbox{${i + 1}.}~~${escapeFlat(text)}\n\n`)
     .join('');
 
   const signer = appendedEndorsementSigner(store.formData);

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -621,17 +621,28 @@ function buildAppendedEndorsement(store: DocumentStore): string {
   // Ch 9 para 2.1a: the endorsement line sits below the date line, which the
   // same-page omission list does not cover (Fig 9-1 shows it). Serial is
   // optional; both stay blank when the appointee hand-dates at signature.
-  const serialRow = ack.serial ? `${escapeTabular(ack.serial)} \\\\\n` : '';
+  //
+  // tabularx{Xr} for the date and tabularx{X@{}l} for the signer, not \hfill
+  // and \hspace*{3.25in}: dondocs.lua understands only \dondocsindent and drops
+  // all other raw LaTeX, so both commands vanished — the DOCX left-aligned the
+  // date and signed the appointee at the margin while the officer signed at
+  // 3.25in. These are the idioms the letter's own date and signature use, and
+  // the ones this file's header prescribes ("tabularX{Xr} for right-aligned
+  // content"). The 0.5pt rule matches the DOCX endorsement divider below.
+  const dateRows = [ack.serial, ack.date]
+    .filter(Boolean)
+    .map((row) => ` & ${escapeTabular(row)} \\\\`)
+    .join('\n');
 
   return `\\vspace{24pt}
 \\noindent
-\\rule{\\textwidth}{0.4pt}
+\\rule{\\textwidth}{0.5pt}
 
 \\vspace{12pt}
-\\hfill
-\\begin{tabular}{@{}l@{}}
-${serialRow}${escapeTabular(ack.date)}
-\\end{tabular}
+\\noindent
+\\begin{tabularx}{\\textwidth}{@{}Xr@{}}
+${dateRows}
+\\end{tabularx}
 
 \\vspace{12pt}
 \\noindent FIRST ENDORSEMENT
@@ -645,7 +656,10 @@ To:\\hspace{6\\fontdimen2\\font} & ${escapeTabular(ack.to)} \\\\
 
 \\vspace{12pt}
 ${body}\\vspace{48pt}
-\\noindent\\hspace*{3.25in}${escapeFlat(signer)}
+\\noindent
+\\begin{tabularx}{\\textwidth}{@{}X@{}l@{}}
+ & ${escapeTabular(signer)} \\\\
+\\end{tabularx}
 
 `;
 }

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -18,6 +18,10 @@ import type { DocumentData, Reference, Enclosure, Paragraph, CopyTo, Distributio
 import { DOC_TYPE_CONFIG } from '@/types/document';
 import { LAYOUT, TEXT_WIDTH_IN } from '@/services/docx/layout-config';
 import { enclosureStartNumber } from '@/lib/endorsement';
+import {
+  resolveAppendedEndorsement,
+  appendedEndorsementSigner,
+} from '@/lib/appendedEndorsement';
 import { splitAddressForLetterhead } from '@/lib/unitAddress';
 import { deriveOverallClassLevel } from '@/lib/overallClassification';
 
@@ -595,6 +599,43 @@ function buildBody(paragraphs: Paragraph[], config: DocTypeConfig): string {
   return bodyParts.join('');
 }
 
+/**
+ * The appointee's acknowledgement below the letter's signature: a rule across
+ * the page, the endorsement line, its own From/To, the body, and the signer.
+ * Mirrors `\printAppendedEndorsement` in tex/main.tex — the two must produce
+ * the same page, so a change here needs the same change there.
+ */
+function buildAppendedEndorsement(store: DocumentStore): string {
+  const ack = resolveAppendedEndorsement(store.docType, store.formData);
+  if (!ack) return '';
+
+  const body = ack.paragraphs
+    .map((text, i) => `\\noindent ${i + 1}.\\hspace{2\\fontdimen2\\font}${escapeFlat(text)}\n\n`)
+    .join('');
+
+  const signer = appendedEndorsementSigner(store.formData);
+
+  return `\\vspace{24pt}
+\\noindent
+\\rule{\\textwidth}{0.4pt}
+
+\\vspace{12pt}
+\\noindent FIRST ENDORSEMENT
+
+\\vspace{12pt}
+\\noindent
+\\begin{tabular}{@{}l@{}p{5.75in}@{}}
+From:\\hspace{2\\fontdimen2\\font} & ${escapeTabular(ack.from)} \\\\
+To:\\hspace{6\\fontdimen2\\font} & ${escapeTabular(ack.to)} \\\\
+\\end{tabular}
+
+\\vspace{12pt}
+${body}\\vspace{48pt}
+\\noindent\\hspace*{3.25in}${escapeFlat(signer)}
+
+`;
+}
+
 /** "By direction" line per SECNAV M-5216.5 Ch 7 ¶14b(4)-(5): the bare form is
  *  the norm. The "of the <activity head>" long form is reserved for
  *  correspondence affecting pay and allowances, so it appears only when an
@@ -1111,6 +1152,9 @@ function buildStandardLayout(store: DocumentStore, config: DocTypeConfig): strin
   );
   content += buildBody(store.paragraphs, config);
   content += buildSignature(data, config);
+  // Between the signature and Distribution/Copy to — Ch 9 Figure 9-1 puts the
+  // "Copy to:" block last on the sheet, below the endorsement.
+  content += buildAppendedEndorsement(store);
   content += buildDistribution(store.distributions);
   content += buildCopyTo(store.copyTos);
 

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -362,7 +362,9 @@ export function generateSignatoryTex(store: DocumentStore): string {
     {${escapeLatex(ack.from)}}
     {${escapeLatex(ack.to)}}
     {${body}}
-    {${escapeLatex(appendedEndorsementSigner(data))}}`;
+    {${escapeLatex(appendedEndorsementSigner(data))}}
+    {${escapeLatex(ack.serial)}}
+    {${escapeLatex(ack.date)}}`;
   }
 
   // Set signature type and image

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -355,8 +355,12 @@ export function generateSignatoryTex(store: DocumentStore): string {
   let appendedEndorsementTex = '';
   const ack = resolveAppendedEndorsement(store.docType, data);
   if (ack) {
+    // Label spacing matches generateBodyTex's `${label}  ${text}` exactly. The
+    // acknowledgement sits on the same sheet as the letter it answers, so its
+    // "1." must align with the letter's "1."; \hspace here put the text 2.3pt
+    // further right than the body above it.
     const body = ack.paragraphs
-      .map((text, i) => `\\noindent ${i + 1}.\\hspace{2\\fontdimen2\\font}${escapeLatex(text)}\\par\\vspace{12pt}`)
+      .map((text, i) => `\\noindent ${i + 1}.  ${escapeLatex(text)}\\par\\vspace{12pt}`)
       .join('');
     appendedEndorsementTex = `\\setAppendedEndorsement
     {${escapeLatex(ack.from)}}

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -6,6 +6,10 @@ import { enclosureStartNumber } from '@/lib/endorsement';
 import { safeUrl } from '@/lib/url-safety';
 import { splitAddressForLetterhead } from '@/lib/unitAddress';
 import { deriveOverallClassLevel } from '@/lib/overallClassification';
+import {
+  resolveAppendedEndorsement,
+  appendedEndorsementSigner,
+} from '@/lib/appendedEndorsement';
 
 interface DocumentStore {
   docType: string;
@@ -345,6 +349,22 @@ export function generateSignatoryTex(store: DocumentStore): string {
     byDirectionTex = `\\setByDirection{${line}}`;
   }
 
+  // The appointee's acknowledgement, if this letter carries one. Body is
+  // pre-numbered here because \setAppendedEndorsement takes it as one argument;
+  // main.tex's \printAppendedEndorsement renders nothing when From is empty.
+  let appendedEndorsementTex = '';
+  const ack = resolveAppendedEndorsement(store.docType, data);
+  if (ack) {
+    const body = ack.paragraphs
+      .map((text, i) => `\\noindent ${i + 1}.\\hspace{2\\fontdimen2\\font}${escapeLatex(text)}\\par\\vspace{12pt}`)
+      .join('');
+    appendedEndorsementTex = `\\setAppendedEndorsement
+    {${escapeLatex(ack.from)}}
+    {${escapeLatex(ack.to)}}
+    {${body}}
+    {${escapeLatex(appendedEndorsementSigner(data))}}`;
+  }
+
   // Set signature type and image
   // signatureType: 'none' = just typed name, 'image' = uploaded signature, 'digital' = empty field for CAC signing
   const signatureType = data.signatureType || 'none';
@@ -376,6 +396,8 @@ export function generateSignatoryTex(store: DocumentStore): string {
 \\setSignatoryAbbrev{${escapeLatex(abbrevName)}}
 
 ${byDirectionTex}
+
+${appendedEndorsementTex}
 
 ${signatureConfigTex}
 `;

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -157,6 +157,21 @@ export interface DocumentData {
   signatureImage?: SignatureImage;
   signatureType?: SignatureType;
 
+  // Acknowledgement endorsement — an appointment letter usually carries the
+  // appointee's acknowledgement on its own sheet: the appointing officer signs,
+  // a rule divides the page, the appointee endorses back below it. Both halves
+  // are written at once, so the endorsement keeps its own addressees, body, and
+  // signer rather than reusing the letter's. Addressees default to inverting
+  // the letter. See src/lib/appendedEndorsement.ts.
+  appendEndorsement?: boolean;
+  endorsementFrom?: string;
+  endorsementTo?: string;
+  /** One paragraph per line; numbered like any endorsement body. */
+  endorsementBody?: string;
+  endorsementSigFirst?: string;
+  endorsementSigMiddle?: string;
+  endorsementSigLast?: string;
+
   // Classification
   classLevel: string;
   customClassification: string;

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -171,6 +171,9 @@ export interface DocumentData {
   endorsementSigFirst?: string;
   endorsementSigMiddle?: string;
   endorsementSigLast?: string;
+  /** Distinct from the letter's own serial/date: the appointee signs later. */
+  endorsementSerial?: string;
+  endorsementDate?: string;
 
   // Classification
   classLevel: string;

--- a/tests/_helpers/pdfToolchain.ts
+++ b/tests/_helpers/pdfToolchain.ts
@@ -1,0 +1,42 @@
+/**
+ * Toolchain probe for the rendered-PDF tests.
+ *
+ * These tests compile a real PDF and read it back with pdftotext/pdfinfo. A
+ * contributor without poppler installed should get a skip, not a failure — but
+ * in CI a skip is indistinguishable from a pass, which is how
+ * `by-direction-render` sat there not running at all: the compile-matrix job
+ * installed texlive and pandoc but never poppler-utils.
+ *
+ * So: skip locally, hard-fail in CI. Pair `hasPdfToolchain` with
+ * `describeToolchainRequirement()` inside the suite that depends on it.
+ */
+import { spawnSync } from 'node:child_process';
+import { it, expect } from 'vitest';
+
+function has(bin: string, versionFlag: string): boolean {
+  try {
+    return spawnSync(bin, [versionFlag], { encoding: 'utf-8' }).status === 0;
+  } catch {
+    return false;
+  }
+}
+
+export const hasPdfToolchain =
+  has('pdflatex', '--version') && has('pdftotext', '-v') && has('pdfinfo', '-v');
+
+/**
+ * Registers a test that fails in CI when the toolchain is missing, so the
+ * suite's `skipIf` can never turn a dropped dependency into a green run.
+ */
+export function describeToolchainRequirement(suite: string): void {
+  it(`${suite}: pdflatex + pdftotext + pdfinfo are installed (required in CI)`, () => {
+    if (process.env.CI) {
+      expect(
+        hasPdfToolchain,
+        'CI must install texlive + poppler-utils; without them these render tests skip and prove nothing.'
+      ).toBe(true);
+    } else if (!hasPdfToolchain) {
+      console.warn(`[${suite}] pdflatex/pdftotext/pdfinfo missing — render tests SKIPPED locally.`);
+    }
+  });
+}

--- a/tests/integration/appended-endorsement-differential.test.ts
+++ b/tests/integration/appended-endorsement-differential.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Differential PDF ⇿ DOCX check for the appended acknowledgement (#203).
+ *
+ * `tests/unit/appendedEndorsement.test.ts` asserts both generators emit the
+ * acknowledgement, but it compares LaTeX *source* — it cannot see whether the
+ * DOCX pipeline actually carries it through pandoc onto a Word page. The two
+ * paths build the block independently (`\printAppendedEndorsement` in
+ * main.tex vs `buildAppendedEndorsement` in flat-generator.ts) and escape it
+ * with different escapers, which is exactly how PR #67's underline-subject bug
+ * survived a green compile matrix.
+ *
+ * A PDF and a DOCX that disagree about a signed appointment is the worst
+ * outcome this feature can produce: the officer signs one rendering and the
+ * appointee acknowledges on another.
+ */
+import { describe, it, expect } from 'vitest';
+import { PDFParse } from 'pdf-parse';
+import mammoth from 'mammoth';
+import { compileFixture } from '../_helpers/compileLatex';
+import { compileDocxFixture } from '../_helpers/compileDocx';
+import { hasPdfToolchain, describeToolchainRequirement } from '../_helpers/pdfToolchain';
+
+const toolchain = hasPdfToolchain;
+
+const store = {
+  docType: 'naval_letter',
+  formData: {
+    docType: 'naval_letter',
+    fontSize: '12pt',
+    fontFamily: 'times',
+    pageNumbering: 'none',
+    department: 'usmc',
+    unitLine1: '1ST BATTALION, 6TH MARINES',
+    unitLine2: '2D MARINE DIVISION, II MEF',
+    unitAddress: 'PSC BOX 20123, CAMP LEJEUNE, NC 28542-0123',
+    sealType: 'dow',
+    letterheadColor: 'blue',
+    ssic: '5216',
+    serial: '0123',
+    date: '15 Jan 25',
+    from: 'Commanding Officer, 1st Battalion, 6th Marines',
+    to: 'Sergeant J. A. DOE, USMC',
+    subject: 'APPOINTMENT AS MARINE SECURITY GUARD REPRESENTATIVE',
+    sigFirst: 'Robert',
+    sigMiddle: 'L',
+    sigLast: 'SMITH',
+    classLevel: 'unclassified',
+    appendEndorsement: true,
+    endorsementBody:
+      'I have read and understand the references listed above.\nI hereby assume the duties and responsibilities as the MSG Representative.',
+    endorsementSigFirst: 'John',
+    endorsementSigMiddle: 'A',
+    endorsementSigLast: 'DOE',
+    endorsementSerial: 'Ser 1710/024',
+    endorsementDate: '3 Feb 25',
+  },
+  references: [],
+  enclosures: [],
+  paragraphs: [
+    { text: 'Per the references, you are hereby appointed as the MSG Representative.', level: 0 },
+  ],
+  copyTos: [],
+  distributions: [],
+} as never;
+
+async function extractPdfText(pdfBytes: Uint8Array): Promise<string> {
+  const parser = new PDFParse({ data: new Uint8Array(pdfBytes) });
+  try {
+    return (await parser.getText()).text ?? '';
+  } finally {
+    await parser.destroy();
+  }
+}
+
+async function extractDocxText(docxBytes: Uint8Array): Promise<string> {
+  return (await mammoth.extractRawText({ buffer: Buffer.from(docxBytes) })).value;
+}
+
+describe('appended acknowledgement — PDF ⇿ DOCX', () => {
+  describeToolchainRequirement('appended-endorsement-differential');
+
+  it.skipIf(!toolchain)('carries the acknowledgement into both outputs', async () => {
+    const [pdfResult, docxResult] = await Promise.all([
+      compileFixture(store),
+      compileDocxFixture(store),
+    ]);
+    expect(pdfResult.ok, `xelatex failed; work dir: ${pdfResult.workDir}`).toBe(true);
+    expect(docxResult.ok, `pandoc failed: ${docxResult.stderr ?? ''}`).toBe(true);
+
+    const pdfText = await extractPdfText(pdfResult.pdfBytes!);
+    const docxText = await extractDocxText(docxResult.docxBytes!);
+
+    // Blank extraction on either side would make every assertion below vacuous.
+    expect(pdfText.trim().length).toBeGreaterThan(0);
+    expect(docxText.trim().length).toBeGreaterThan(0);
+
+    // Normalise whitespace: pdftotext and mammoth wrap differently, and the
+    // question here is whether the content survives, not how it is laid out.
+    const norm = (s: string) => s.replace(/\s+/g, ' ');
+    const pdf = norm(pdfText);
+    const docx = norm(docxText);
+
+    for (const [label, needle] of [
+      ['endorsement line', 'FIRST ENDORSEMENT'],
+      ['appointee as sender', 'Sergeant J. A. DOE, USMC'],
+      ['officer as addressee', 'Commanding Officer, 1st Battalion, 6th Marines'],
+      ['first paragraph', 'I have read and understand the references listed above.'],
+      ['second paragraph', 'I hereby assume the duties and responsibilities as the MSG Representative.'],
+      ['endorsement date', '3 Feb 25'],
+      ['endorsement serial', 'Ser 1710/024'],
+    ] as const) {
+      expect(pdf, `PDF is missing the ${label}`).toContain(needle);
+      expect(docx, `DOCX is missing the ${label}`).toContain(needle);
+    }
+
+    // Both halves are signed in both outputs.
+    expect(pdf).toContain('R. L. SMITH');
+    expect(docx).toContain('R. L. SMITH');
+    expect(pdf).toContain('J. A. DOE');
+    expect(docx).toContain('J. A. DOE');
+
+    // The body is numbered in both — the DOCX path protects labels from
+    // pandoc's list-marker detection with \mbox, so this is a real risk.
+    expect(pdf).toMatch(/1\.\s*I have read and understand/);
+    expect(docx).toMatch(/1\.\s*I have read and understand/);
+    expect(pdf).toMatch(/2\.\s*I hereby assume/);
+    expect(docx).toMatch(/2\.\s*I hereby assume/);
+  }, 120000);
+});

--- a/tests/integration/appended-endorsement-differential.test.ts
+++ b/tests/integration/appended-endorsement-differential.test.ts
@@ -19,13 +19,23 @@ import mammoth from 'mammoth';
 import { compileFixture } from '../_helpers/compileLatex';
 import { compileDocxFixture } from '../_helpers/compileDocx';
 import { hasPdfToolchain, describeToolchainRequirement } from '../_helpers/pdfToolchain';
+import { canAppendEndorsement } from '@/lib/appendedEndorsement';
+import { DOC_TYPE_CONFIG } from '@/types/document';
 
 const toolchain = hasPdfToolchain;
 
-const store = {
-  docType: 'naval_letter',
+/**
+ * Driven off `canAppendEndorsement` rather than a hand-listed fixture, because
+ * the bug this guards against was exactly a doc type the resolver admitted and
+ * the DOCX layout never built. Anything added to ELIGIBLE is tested here or the
+ * suite is empty for it.
+ */
+const ELIGIBLE_DOC_TYPES = Object.keys(DOC_TYPE_CONFIG).filter(canAppendEndorsement);
+
+const makeStore = (docType: string) => ({
+  docType,
   formData: {
-    docType: 'naval_letter',
+    docType,
     fontSize: '12pt',
     fontFamily: 'times',
     pageNumbering: 'none',
@@ -61,7 +71,7 @@ const store = {
   ],
   copyTos: [],
   distributions: [],
-} as never;
+} as never);
 
 async function extractPdfText(pdfBytes: Uint8Array): Promise<string> {
   const parser = new PDFParse({ data: new Uint8Array(pdfBytes) });
@@ -79,7 +89,13 @@ async function extractDocxText(docxBytes: Uint8Array): Promise<string> {
 describe('appended acknowledgement — PDF ⇿ DOCX', () => {
   describeToolchainRequirement('appended-endorsement-differential');
 
-  it.skipIf(!toolchain)('carries the acknowledgement into both outputs', async () => {
+  it('covers every doc type the resolver admits', () => {
+    expect(ELIGIBLE_DOC_TYPES.length).toBeGreaterThan(0);
+    expect(ELIGIBLE_DOC_TYPES).toEqual(['naval_letter', 'standard_letter']);
+  });
+
+  it.skipIf(!toolchain).each(ELIGIBLE_DOC_TYPES)('%s carries the acknowledgement into both outputs', async (docType) => {
+    const store = makeStore(docType);
     const [pdfResult, docxResult] = await Promise.all([
       compileFixture(store),
       compileDocxFixture(store),

--- a/tests/integration/appended-endorsement-escaping.test.ts
+++ b/tests/integration/appended-endorsement-escaping.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The acknowledgement is free text a Marine types, and it goes straight into
+ * LaTeX. Every field is routed through an escaper, but nothing proved that the
+ * result compiles — and an unescaped `&` or `%` is not a cosmetic bug, it is a
+ * failed export at the moment someone is trying to sign an appointment.
+ *
+ * `%` is the sharpest: unescaped it comments out the rest of the line, so the
+ * text silently vanishes rather than erroring. The assertions below therefore
+ * check the characters survive *onto the page*, not merely that pdflatex
+ * exited 0.
+ *
+ * Both generators are covered because they use different escapers for the same
+ * data (escapeLatex vs escapeFlat/escapeTabular), which is exactly the shape of
+ * a drift bug.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { writeFile, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { compileFixture } from '../_helpers/compileLatex';
+import { hasPdfToolchain, describeToolchainRequirement } from '../_helpers/pdfToolchain';
+import { generateFlatLatex } from '@/services/latex/flat-generator';
+
+const toolchain = hasPdfToolchain;
+
+// Every LaTeX special character, in the fields a user actually types.
+const NASTY_BODY =
+  'Funds & equipment are 100% my responsibility under section #4.\n' +
+  'Cost is $50 per item; see C:\\orders\\file and the ~approved^ list {final}.';
+const NASTY_FROM = 'Sergeant J. A. DOE, USMC (S-3 & S-4)';
+const NASTY_DUTY = 'MSG Rep. #1 — 100% Duty';
+
+function store() {
+  return {
+    docType: 'naval_letter',
+    formData: {
+      docType: 'naval_letter',
+      fontSize: '12pt',
+      fontFamily: 'times',
+      pageNumbering: 'none',
+      department: 'usmc',
+      unitLine1: '1ST BATTALION, 6TH MARINES',
+      unitLine2: '2D MARINE DIVISION, II MEF',
+      unitAddress: 'PSC BOX 20123, CAMP LEJEUNE, NC 28542-0123',
+      sealType: 'dow',
+      letterheadColor: 'blue',
+      ssic: '5216',
+      serial: '0123',
+      date: '15 Jan 25',
+      from: 'Commanding Officer, 1st Battalion, 6th Marines',
+      to: NASTY_FROM,
+      subject: 'APPOINTMENT',
+      sigFirst: 'Robert',
+      sigMiddle: 'L',
+      sigLast: 'SMITH',
+      classLevel: 'unclassified',
+      appendEndorsement: true,
+      endorsementBody: NASTY_BODY,
+      endorsementSigFirst: 'John',
+      endorsementSigMiddle: 'A',
+      endorsementSigLast: 'DOE',
+      endorsementSerial: 'Ser 1710/024 & 025',
+      endorsementDate: '3 Feb 25',
+    },
+    references: [],
+    enclosures: [],
+    paragraphs: [{ text: `You are appointed as ${NASTY_DUTY}.`, level: 0 }],
+    copyTos: [],
+    distributions: [],
+  } as never;
+}
+
+describe('appended acknowledgement — LaTeX metacharacters', () => {
+  describeToolchainRequirement('appended-endorsement-escaping');
+
+  it.skipIf(!toolchain)('compiles and prints the characters literally', async () => {
+    const result = await compileFixture(store());
+    expect(result.ok, `pdflatex failed on metacharacters; work dir: ${result.workDir}`).toBe(true);
+
+    const dir = await mkdtemp(join(tmpdir(), 'dondocs-esc-'));
+    const pdfPath = join(dir, 'out.pdf');
+    await writeFile(pdfPath, result.pdfBytes!);
+    const { stdout } = spawnSync('pdftotext', [pdfPath, '-'], { encoding: 'utf-8' });
+    expect(stdout.trim().length).toBeGreaterThan(0);
+
+    // An unescaped % would comment the rest of the line away silently, so the
+    // text after it is the real assertion.
+    expect(stdout).toMatch(/Funds & equipment are 100% my responsibility under section #4\./);
+    expect(stdout).toMatch(/\$50 per item/);
+    expect(stdout).toMatch(/C:\\orders\\file/);
+    expect(stdout).toMatch(/\{final\}/);
+    expect(stdout).toMatch(/Ser 1710\/024 & 025/);
+    expect(stdout).toMatch(/Sergeant J\. A\. DOE, USMC \(S-3 & S-4\)/);
+  });
+
+  it.skipIf(!toolchain)('does not leak a raw control sequence into the tex', () => {
+    const tex = generateFlatLatex(store());
+    const ack = tex.slice(tex.indexOf('FIRST ENDORSEMENT'));
+    // The escaper must have neutralised these; a bare & or % inside the
+    // endorsement body would be a live LaTeX token.
+    expect(ack).not.toMatch(/[^\\]&\s*equipment/);
+    expect(ack).not.toMatch(/[^\\]%\s*my responsibility/);
+    expect(ack).toMatch(/100\\%/);
+    expect(ack).toMatch(/\\&/);
+  });
+});

--- a/tests/integration/appended-endorsement-render.test.ts
+++ b/tests/integration/appended-endorsement-render.test.ts
@@ -149,6 +149,41 @@ describe('appended acknowledgement — rendered PDF', () => {
     expect(text).toMatch(/FIRST ENDORSEMENT/);
   });
 
+  // The acknowledgement sits on the same sheet as the letter it answers, so a
+  // reader sees both numbered lists at once and any difference in the gap after
+  // "1." reads as sloppy. This is invisible to text assertions: pdftotext
+  // reports "1. Zulu" either way. \hspace{2\fontdimen2\font} here put the
+  // acknowledgement's text 2.3pt right of the letter's, so compare x-positions.
+  it.skipIf(!toolchain)("aligns its paragraphs with the letter's above it", async () => {
+    const result = await compileFixture({
+      ...(store({
+        ...acknowledgement,
+        endorsementBody: 'Zulu acknowledgement one.\nZulu acknowledgement two.',
+      }) as unknown as Record<string, unknown>),
+      paragraphs: [
+        { text: 'Zulu letter body one.', level: 0 },
+        { text: 'Zulu letter body two.', level: 0 },
+      ],
+    } as never);
+    expect(result.ok, `pdflatex failed; work dir: ${result.workDir}`).toBe(true);
+
+    const dir = await mkdtemp(join(tmpdir(), 'dondocs-ack-align-'));
+    const pdfPath = join(dir, 'out.pdf');
+    await writeFile(pdfPath, result.pdfBytes!);
+    const { stdout } = spawnSync('pdftotext', ['-bbox', pdfPath, '-'], { encoding: 'utf-8' });
+
+    const words = [...stdout.matchAll(/<word xMin="([\d.]+)"[^>]*>([^<]+)<\/word>/g)]
+      .map((m) => ({ x: Number(m[1]), word: m[2] }));
+    const labelXs = [...new Set(words.filter((w) => /^[12]\.$/.test(w.word)).map((w) => w.x))];
+    const textXs = [...new Set(words.filter((w) => w.word === 'Zulu').map((w) => w.x))];
+
+    // Four numbered paragraphs: two in the letter, two in the acknowledgement.
+    expect(words.filter((w) => w.word === 'Zulu')).toHaveLength(4);
+    // Every label starts at the margin, and every body text starts at one x.
+    expect(labelXs).toHaveLength(1);
+    expect(textXs).toHaveLength(1);
+  });
+
   // A letter long enough to push the acknowledgement past the page break used
   // to tear it in half — endorsement line on one page, the appointee's
   // signature stranded on the next. Ch 9 para 1 permits a same-page

--- a/tests/integration/appended-endorsement-render.test.ts
+++ b/tests/integration/appended-endorsement-render.test.ts
@@ -148,4 +148,41 @@ describe('appended acknowledgement — rendered PDF', () => {
     expect(pages).toBe(1);
     expect(text).toMatch(/FIRST ENDORSEMENT/);
   });
+
+  // A letter long enough to push the acknowledgement past the page break used
+  // to tear it in half — endorsement line on one page, the appointee's
+  // signature stranded on the next. Ch 9 para 1 permits a same-page
+  // endorsement only when all of it fits ("If not, use a new-page
+  // endorsement"), so half a signed endorsement is never a legal rendering.
+  // \printAppendedEndorsement wraps the block in a minipage to keep it whole.
+  it.skipIf(!toolchain)('never splits the acknowledgement across a page break', async () => {
+    const filler = Array.from({ length: 6 }, (_, i) => ({
+      text: `Paragraph ${i + 1}. ` + 'Text that consumes vertical space and pushes the signature block down the page. '.repeat(3),
+      level: 0,
+    }));
+    const result = await compileFixture({
+      ...(store({ ...acknowledgement, endorsementDate: '3 Feb 25' }) as unknown as Record<string, unknown>),
+      paragraphs: filler,
+    } as never);
+    expect(result.ok, `pdflatex failed; work dir: ${result.workDir}`).toBe(true);
+
+    const dir = await mkdtemp(join(tmpdir(), 'dondocs-ack-split-'));
+    const pdfPath = join(dir, 'out.pdf');
+    await writeFile(pdfPath, result.pdfBytes!);
+    const { stdout } = spawnSync('pdftotext', [pdfPath, '-'], { encoding: 'utf-8' });
+    expect(stdout.trim().length).toBeGreaterThan(0);
+
+    const pages = stdout.split('\f');
+    const pageOf = (re: RegExp) => pages.findIndex((p) => re.test(p));
+    const endorsementLine = pageOf(/FIRST ENDORSEMENT/);
+    const dateLine = pageOf(/3 Feb 25/);
+    // Anchored to end-of-line so the letter's "To: Sergeant J. A. DOE" does not
+    // masquerade as the appointee's signature.
+    const signature = pageOf(/J\. A\. DOE\s*$/m);
+
+    expect(endorsementLine).toBeGreaterThanOrEqual(0);
+    expect(signature).toBeGreaterThanOrEqual(0);
+    expect(dateLine).toBe(endorsementLine);
+    expect(signature).toBe(endorsementLine);
+  });
 });

--- a/tests/integration/appended-endorsement-render.test.ts
+++ b/tests/integration/appended-endorsement-render.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Rendered-output check for the appended acknowledgement (#203).
+ *
+ * The unit tests (tests/unit/appendedEndorsement.test.ts) assert the generators
+ * emit the right LaTeX *source*. That is not enough here: `generator.ts` only
+ * calls `\setAppendedEndorsement{...}`, and it is `main.tex`'s
+ * `\printAppendedEndorsement` that actually prints it. A source-only test stays
+ * green even if the render site is dropped and the appointee's half silently
+ * vanishes from the page.
+ *
+ * The whole point of the feature is that both halves land on ONE sheet, so the
+ * page count is the assertion that matters most — a two-page result would be a
+ * regression even with every string present.
+ *
+ * Requires pdflatex + pdftotext + pdfinfo; skipped (not falsely passed) without.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { writeFile, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { compileFixture } from '../_helpers/compileLatex';
+import { hasPdfToolchain, describeToolchainRequirement } from '../_helpers/pdfToolchain';
+
+const toolchain = hasPdfToolchain;
+
+function store(extra: Record<string, unknown>) {
+  return {
+    docType: 'naval_letter',
+    formData: {
+      docType: 'naval_letter',
+      fontSize: '12pt',
+      fontFamily: 'times',
+      pageNumbering: 'none',
+      department: 'usmc',
+      unitLine1: '1ST BATTALION, 6TH MARINES',
+      unitLine2: '2D MARINE DIVISION, II MEF',
+      unitAddress: 'PSC BOX 20123, CAMP LEJEUNE, NC 28542-0123',
+      sealType: 'dow',
+      letterheadColor: 'blue',
+      ssic: '5216',
+      serial: '0123',
+      date: '15 Jan 25',
+      from: 'Commanding Officer, 1st Battalion, 6th Marines',
+      to: 'Sergeant J. A. DOE, USMC',
+      subject: 'APPOINTMENT AS MARINE SECURITY GUARD REPRESENTATIVE',
+      sigFirst: 'Robert',
+      sigMiddle: 'L',
+      sigLast: 'SMITH',
+      classLevel: 'unclassified',
+      ...extra,
+    },
+    references: [],
+    enclosures: [],
+    paragraphs: [
+      { text: 'Per the references, you are hereby appointed as the MSG Representative.', level: 0 },
+      { text: 'This appointment is automatically revoked upon your transfer.', level: 0 },
+    ],
+    copyTos: [],
+    distributions: [],
+  } as never;
+}
+
+const acknowledgement = {
+  appendEndorsement: true,
+  endorsementBody:
+    'I have read and understand the references listed above.\nI hereby assume the duties and responsibilities as the MSG Representative.',
+  endorsementSigFirst: 'John',
+  endorsementSigMiddle: 'A',
+  endorsementSigLast: 'DOE',
+};
+
+async function render(extra: Record<string, unknown>): Promise<{ text: string; pages: number }> {
+  const result = await compileFixture(store(extra));
+  expect(result.ok, `pdflatex failed; work dir: ${result.workDir}`).toBe(true);
+  const dir = await mkdtemp(join(tmpdir(), 'dondocs-ack-'));
+  const pdfPath = join(dir, 'out.pdf');
+  await writeFile(pdfPath, result.pdfBytes!);
+  const { stdout } = spawnSync('pdftotext', [pdfPath, '-'], { encoding: 'utf-8' });
+  // A blank extraction would make the assertions below vacuous.
+  expect(stdout.trim().length).toBeGreaterThan(0);
+  const info = spawnSync('pdfinfo', [pdfPath], { encoding: 'utf-8' }).stdout;
+  const pages = Number(info.match(/Pages:\s+(\d+)/)?.[1]);
+  expect(Number.isFinite(pages)).toBe(true);
+  return { text: stdout, pages };
+}
+
+describe('appended acknowledgement — rendered PDF', () => {
+  describeToolchainRequirement('appended-endorsement-render');
+
+  it.skipIf(!toolchain)('puts the appointment and the acknowledgement on one sheet', async () => {
+    const { text, pages } = await render(acknowledgement);
+
+    // The reason the feature exists: one sheet, not two.
+    expect(pages).toBe(1);
+
+    // The appointing officer's half.
+    expect(text).toMatch(/APPOINTMENT AS MARINE SECURITY GUARD REPRESENTATIVE/);
+    expect(text).toMatch(/R\. L\. SMITH/);
+
+    // The appointee's half, below it.
+    expect(text).toMatch(/FIRST ENDORSEMENT/);
+    expect(text).toMatch(/I have read and understand the references listed above\./);
+    expect(text).toMatch(/J\. A\. DOE/);
+
+    // Addressees invert without the user typing them.
+    const ack = text.slice(text.indexOf('FIRST ENDORSEMENT'));
+    expect(ack).toMatch(/From:\s*Sergeant J\. A\. DOE, USMC/);
+    expect(ack).toMatch(/To:\s*Commanding Officer, 1st Battalion, 6th Marines/);
+
+    // The appointee's name appears twice — once in the letter's To: line, once
+    // as the signature below the rule. lastIndexOf pins the *signature*: an
+    // endorsement that rendered its addressees but dropped the signer would
+    // still satisfy indexOf.
+    expect(text.lastIndexOf('J. A. DOE')).toBeGreaterThan(text.indexOf('FIRST ENDORSEMENT'));
+  });
+
+  it.skipIf(!toolchain)('leaves the letter untouched when not requested', async () => {
+    const { text, pages } = await render({});
+    expect(pages).toBe(1);
+    expect(text).toMatch(/R\. L\. SMITH/);
+    expect(text).not.toMatch(/FIRST ENDORSEMENT/);
+  });
+});

--- a/tests/integration/appended-endorsement-render.test.ts
+++ b/tests/integration/appended-endorsement-render.test.ts
@@ -121,4 +121,31 @@ describe('appended acknowledgement — rendered PDF', () => {
     expect(text).toMatch(/R\. L\. SMITH/);
     expect(text).not.toMatch(/FIRST ENDORSEMENT/);
   });
+
+  // Ch 9 ¶2.1a starts the endorsement line "on the second line below the date
+  // line". A same-page endorsement may omit the SSIC, subject and basic letter
+  // ID — not the date — so the line must render and must sit above the
+  // endorsement line, as Fig 9-1 shows.
+  it.skipIf(!toolchain)('prints the date line above the endorsement line', async () => {
+    const { text, pages } = await render({
+      ...acknowledgement,
+      endorsementSerial: 'Ser 1710/024',
+      endorsementDate: '3 Feb 25',
+    });
+
+    expect(pages).toBe(1);
+    expect(text).toMatch(/Ser 1710\/024/);
+    expect(text).toMatch(/3 Feb 25/);
+    expect(text.indexOf('3 Feb 25')).toBeLessThan(text.indexOf('FIRST ENDORSEMENT'));
+    expect(text.indexOf('Ser 1710/024')).toBeLessThan(text.indexOf('3 Feb 25'));
+
+    // The letter's own date must not be mistaken for the endorsement's.
+    expect(text.indexOf('15 Jan 25')).toBeLessThan(text.indexOf('Ser 1710/024'));
+  });
+
+  it.skipIf(!toolchain)('still lands on one sheet when hand-dated at signature', async () => {
+    const { pages, text } = await render(acknowledgement);
+    expect(pages).toBe(1);
+    expect(text).toMatch(/FIRST ENDORSEMENT/);
+  });
 });

--- a/tests/integration/by-direction-render.test.ts
+++ b/tests/integration/by-direction-render.test.ts
@@ -18,14 +18,9 @@ import { writeFile, mkdtemp } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { compileFixture } from '../_helpers/compileLatex';
+import { hasPdfToolchain, describeToolchainRequirement } from '../_helpers/pdfToolchain';
 
-const toolchain =
-  spawnSync('pdflatex', ['--version'], { encoding: 'utf-8' }).status === 0 &&
-  spawnSync('pdftotext', ['-v'], { encoding: 'utf-8' }).status === 0;
-
-if (!toolchain) {
-  console.warn('[by-direction-render] pdflatex/pdftotext missing — SKIPPING.');
-}
+const toolchain = hasPdfToolchain;
 
 function store(byDirectionAuthority: string) {
   return {
@@ -78,6 +73,8 @@ async function renderedText(authority: string): Promise<string> {
 }
 
 describe('by-direction signature — rendered PDF', () => {
+  describeToolchainRequirement('by-direction-render');
+
   it.skipIf(!toolchain)('prints a bare "By direction" when no authority is named', async () => {
     const text = await renderedText('');
     expect(text).toMatch(/By direction/);

--- a/tests/unit/appendedEndorsement.test.ts
+++ b/tests/unit/appendedEndorsement.test.ts
@@ -1,0 +1,124 @@
+/**
+ * An appointment letter carries the appointee's acknowledgement on its own
+ * page: the appointing officer signs, a rule divides the sheet, the appointee
+ * endorses back below it (#203). DonDocs could previously only emit the
+ * endorsement as its own standalone document — never both halves together.
+ *
+ * These pin the resolver (who is addressed, when it renders at all) and that
+ * both generators agree, since a PDF and a DOCX that disagree about a signed
+ * appointment is the worst outcome here.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAppendedEndorsement,
+  appendedEndorsementSigner,
+  canAppendEndorsement,
+} from '@/lib/appendedEndorsement';
+import { generateFlatLatex } from '@/services/latex/flat-generator';
+import { generateSignatoryTex } from '@/services/latex/generator';
+
+const base = {
+  appendEndorsement: true,
+  endorsementBody: 'I have read and understand the references listed above.\nI hereby assume the duties.',
+  endorsementSigFirst: 'John',
+  endorsementSigMiddle: 'A',
+  endorsementSigLast: 'Doe',
+  from: 'Commanding Officer, 1st Battalion, 6th Marines',
+  to: 'Sergeant J. A. DOE, USMC',
+};
+
+describe('resolveAppendedEndorsement', () => {
+  it('inverts the letter: the appointee answers back to the appointing officer', () => {
+    const ack = resolveAppendedEndorsement('naval_letter', base)!;
+    expect(ack.from).toBe('Sergeant J. A. DOE, USMC');
+    expect(ack.to).toBe('Commanding Officer, 1st Battalion, 6th Marines');
+  });
+
+  it('lets an explicit addressee override the inversion', () => {
+    const ack = resolveAppendedEndorsement('naval_letter', {
+      ...base,
+      endorsementFrom: 'Corporal R. J. LEE, USMC',
+    })!;
+    expect(ack.from).toBe('Corporal R. J. LEE, USMC');
+    expect(ack.to).toBe('Commanding Officer, 1st Battalion, 6th Marines');
+  });
+
+  it('splits the body into numbered paragraphs, ignoring blank lines', () => {
+    const ack = resolveAppendedEndorsement('naval_letter', {
+      ...base,
+      endorsementBody: 'One.\n\n  \nTwo.\n',
+    })!;
+    expect(ack.paragraphs).toEqual(['One.', 'Two.']);
+  });
+
+  it('renders nothing when the toggle is off', () => {
+    expect(resolveAppendedEndorsement('naval_letter', { ...base, appendEndorsement: false })).toBeNull();
+  });
+
+  it('renders nothing without addressees to invert', () => {
+    expect(
+      resolveAppendedEndorsement('naval_letter', { ...base, from: '', to: '' })
+    ).toBeNull();
+  });
+
+  // An endorsement belongs to a letter. Leaving a stale toggle on after
+  // switching to a form or an endorsement must not staple one to it.
+  it.each([
+    ['naval_letter', true],
+    ['standard_letter', true],
+    ['same_page_endorsement', false],
+    ['moa', false],
+    ['business_letter', false],
+  ])('%s eligible: %s', (docType, eligible) => {
+    expect(canAppendEndorsement(docType)).toBe(eligible);
+    if (!eligible) {
+      expect(resolveAppendedEndorsement(docType, base)).toBeNull();
+    }
+  });
+});
+
+describe('appendedEndorsementSigner', () => {
+  it('abbreviates to initials and surname per Ch 9', () => {
+    expect(appendedEndorsementSigner(base)).toBe('J. A. DOE');
+  });
+
+  it('handles a missing middle initial', () => {
+    expect(appendedEndorsementSigner({ ...base, endorsementSigMiddle: '' })).toBe('J. DOE');
+  });
+});
+
+describe('both generators emit the acknowledgement', () => {
+  const store = {
+    docType: 'naval_letter',
+    formData: { ...base, docType: 'naval_letter', subject: 'APPOINTMENT', sigFirst: 'Robert', sigLast: 'Smith' },
+    references: [],
+    enclosures: [],
+    paragraphs: [{ text: 'You are hereby appointed.', level: 0 }],
+    copyTos: [],
+    distributions: [],
+  } as never;
+
+  it('flat generator (DOCX) draws the rule, the line, and the signer', () => {
+    const tex = generateFlatLatex(store);
+    expect(tex).toContain('\\rule{\\textwidth}{0.4pt}');
+    expect(tex).toContain('FIRST ENDORSEMENT');
+    expect(tex).toContain('Sergeant J. A. DOE, USMC');
+    expect(tex).toMatch(/read and understand/);
+  });
+
+  it('PDF generator sets the macro main.tex renders', () => {
+    const tex = generateSignatoryTex(store);
+    expect(tex).toContain('\\setAppendedEndorsement');
+    expect(tex).toContain('Sergeant J. A. DOE, USMC');
+    expect(tex).toMatch(/read and understand/);
+  });
+
+  it('neither emits anything when the letter carries no acknowledgement', () => {
+    const plain = {
+      ...(store as Record<string, unknown>),
+      formData: { ...base, appendEndorsement: false, docType: 'naval_letter' },
+    } as never;
+    expect(generateFlatLatex(plain)).not.toContain('FIRST ENDORSEMENT');
+    expect(generateSignatoryTex(plain)).not.toContain('\\setAppendedEndorsement');
+  });
+});

--- a/tests/unit/appendedEndorsement.test.ts
+++ b/tests/unit/appendedEndorsement.test.ts
@@ -113,6 +113,26 @@ describe('both generators emit the acknowledgement', () => {
     expect(tex).toMatch(/read and understand/);
   });
 
+  // Ch 9 ¶2.1a: the endorsement line sits below the date line, which the
+  // same-page omission list does not cover. Both outputs must carry it, or a
+  // PDF and a DOCX of the same appointment disagree about a signed document.
+  it('both carry the endorsement\'s own date and serial', () => {
+    const dated = {
+      ...(store as Record<string, unknown>),
+      formData: { ...base, docType: 'naval_letter', endorsementSerial: 'Ser 1710/024', endorsementDate: '3 Feb 25' },
+    } as never;
+    for (const tex of [generateFlatLatex(dated), generateSignatoryTex(dated)]) {
+      expect(tex).toContain('Ser 1710/024');
+      expect(tex).toContain('3 Feb 25');
+    }
+  });
+
+  it('omits the serial row when hand-dated, without dropping the date line', () => {
+    const tex = generateFlatLatex(store);
+    expect(tex).not.toContain('Ser 1710/024');
+    expect(tex).toContain('FIRST ENDORSEMENT');
+  });
+
   it('neither emits anything when the letter carries no acknowledgement', () => {
     const plain = {
       ...(store as Record<string, unknown>),

--- a/tests/unit/appendedEndorsement.test.ts
+++ b/tests/unit/appendedEndorsement.test.ts
@@ -91,6 +91,18 @@ describe('appendedEndorsementSigner', () => {
   it('handles a missing middle initial', () => {
     expect(appendedEndorsementSigner({ ...base, endorsementSigMiddle: '' })).toBe('J. DOE');
   });
+
+  // First and middle are positional. A middle initial with no first must not
+  // slide into the first slot and sign the wrong name.
+  it('drops the middle initial when there is no first name', () => {
+    expect(
+      appendedEndorsementSigner({ endorsementSigMiddle: 'A', endorsementSigLast: 'Doe' })
+    ).toBe('DOE');
+  });
+
+  it('is empty when nothing is filled in', () => {
+    expect(appendedEndorsementSigner({})).toBe('');
+  });
 });
 
 describe('both generators emit the acknowledgement', () => {

--- a/tests/unit/appendedEndorsement.test.ts
+++ b/tests/unit/appendedEndorsement.test.ts
@@ -61,11 +61,17 @@ describe('resolveAppendedEndorsement', () => {
     ).toBeNull();
   });
 
-  // An endorsement belongs to a letter. Leaving a stale toggle on after
-  // switching to a form or an endorsement must not staple one to it.
+  // An endorsement belongs to a letter — Ch 9 ¶1, "When a *letter* is
+  // transmitted via your activity", and Chs 10-12 never mention endorsements.
+  // Memoranda are listed explicitly because they were briefly eligible on
+  // judgement rather than a cite, and the DOCX silently dropped the block for
+  // them (buildAppendedEndorsement is only reachable from buildStandardLayout).
+  // Leaving a stale toggle on after switching doc type must not staple one on.
   it.each([
     ['naval_letter', true],
     ['standard_letter', true],
+    ['letterhead_memorandum', false],
+    ['plain_paper_memorandum', false],
     ['same_page_endorsement', false],
     ['moa', false],
     ['business_letter', false],
@@ -100,7 +106,9 @@ describe('both generators emit the acknowledgement', () => {
 
   it('flat generator (DOCX) draws the rule, the line, and the signer', () => {
     const tex = generateFlatLatex(store);
-    expect(tex).toContain('\\rule{\\textwidth}{0.4pt}');
+    // 0.5pt matches the DOCX same-page endorsement divider (flat-generator's
+    // other rules are all 0.5pt); the PDF path uses 0.4pt to match its own.
+    expect(tex).toContain('\\rule{\\textwidth}{0.5pt}');
     expect(tex).toContain('FIRST ENDORSEMENT');
     expect(tex).toContain('Sergeant J. A. DOE, USMC');
     expect(tex).toMatch(/read and understand/);

--- a/tex/main.tex
+++ b/tex/main.tex
@@ -799,6 +799,14 @@
 \newcommand{\printAppendedEndorsement}{%
     \ifdefempty{\AckFrom}{}{%
         \vspace{24pt}%
+        % Ch 9 para 1 allows a same-page endorsement only when the whole of it
+        % fits on the signature page -- "If not, use a new-page endorsement." A
+        % minipage cannot be broken, so an endorsement that does not fit moves
+        % whole rather than stranding the appointee's signature on the next
+        % page. It cannot make an over-long endorsement conform (that needs a
+        % new-page endorsement, which is its own doc type), but it does keep the
+        % signature with the block it belongs to.
+        \noindent\begin{minipage}{\textwidth}%
         \noindent\rule{\textwidth}{0.4pt}\par
         \vspace{12pt}%
         % Ch 9 para 2.1a starts the endorsement line "on the second line below the
@@ -827,6 +835,7 @@
         % 4 lines below the last paragraph, matching the basic signature block.
         \vspace{48pt}%
         \noindent\hspace*{3.25in}\AckSignature\par
+        \end{minipage}%
     }%
 }
 

--- a/tex/main.tex
+++ b/tex/main.tex
@@ -785,17 +785,34 @@
 \newcommand{\AckTo}{}
 \newcommand{\AckBody}{}
 \newcommand{\AckSignature}{}
-\newcommand{\setAppendedEndorsement}[4]{%
+\newcommand{\AckSerial}{}
+\newcommand{\AckDate}{}
+\newcommand{\setAppendedEndorsement}[6]{%
     \renewcommand{\AckFrom}{#1}%
     \renewcommand{\AckTo}{#2}%
     \renewcommand{\AckBody}{#3}%
     \renewcommand{\AckSignature}{#4}%
+    \renewcommand{\AckSerial}{#5}%
+    \renewcommand{\AckDate}{#6}%
 }
 
 \newcommand{\printAppendedEndorsement}{%
     \ifdefempty{\AckFrom}{}{%
         \vspace{24pt}%
         \noindent\rule{\textwidth}{0.4pt}\par
+        \vspace{12pt}%
+        % Ch 9 para 2.1a starts the endorsement line "on the second line below the
+        % date line". A same-page endorsement may omit the SSIC, subject and the
+        % basic letter's ID symbols — the date line is not on that list, and
+        % Fig 9-1 shows it. The serial is optional: an appointee endorsing back
+        % is not assigning one. Both stay blank for hand-dating at signature.
+        \hfill
+        \begin{tabular}[t]{@{}l@{}}
+            \ifdefempty{\AckSerial}{}{%
+                \AckSerial\\
+            }%
+            \AckDate
+        \end{tabular}\par
         \vspace{12pt}%
         \noindent FIRST ENDORSEMENT\par
         \vspace{12pt}%

--- a/tex/main.tex
+++ b/tex/main.tex
@@ -768,6 +768,51 @@
 \newcommand{\ByDirection}{}
 \newcommand{\setByDirection}[1]{\renewcommand{\ByDirection}{#1}}
 
+%=============================================================================
+% APPENDED ACKNOWLEDGEMENT ENDORSEMENT
+%=============================================================================
+% An appointment letter commonly carries the appointee's acknowledgement on the
+% same page: the appointing officer signs above the rule, the appointee signs
+% below it, and the whole thing is one sheet (SECNAV M-5216.5 Ch 9 — a
+% same-page endorsement may omit the SSIC, subject, and basic-letter ID because
+% it sits on the basic letter's own page, which is exactly the case here).
+%
+% Unlike a standalone same-page endorsement, both halves are authored at once,
+% so the endorsement carries its own From/To/body/signer rather than reusing
+% the letter's. Empty From = nothing renders, so every doc type can call
+% \printAppendedEndorsement unconditionally.
+\newcommand{\AckFrom}{}
+\newcommand{\AckTo}{}
+\newcommand{\AckBody}{}
+\newcommand{\AckSignature}{}
+\newcommand{\setAppendedEndorsement}[4]{%
+    \renewcommand{\AckFrom}{#1}%
+    \renewcommand{\AckTo}{#2}%
+    \renewcommand{\AckBody}{#3}%
+    \renewcommand{\AckSignature}{#4}%
+}
+
+\newcommand{\printAppendedEndorsement}{%
+    \ifdefempty{\AckFrom}{}{%
+        \vspace{24pt}%
+        \noindent\rule{\textwidth}{0.4pt}\par
+        \vspace{12pt}%
+        \noindent FIRST ENDORSEMENT\par
+        \vspace{12pt}%
+        % Colon spacing matches the basic letter's From/To block (Ch 7 para 11b).
+        \noindent
+        \begin{tabular}[t]{@{}l@{}p{5.75in}@{}}
+            From:\hspace{2\fontdimen2\font} & \AckFrom\tabularnewline
+            To:\hspace{6\fontdimen2\font} & \AckTo
+        \end{tabular}\par
+        \vspace{12pt}%
+        \AckBody
+        % 4 lines below the last paragraph, matching the basic signature block.
+        \vspace{48pt}%
+        \noindent\hspace*{3.25in}\AckSignature\par
+    }%
+}
+
 % setSignatureImage: If non-empty, redefine SignatureImage so \ifx check works
 \newcommand{\setSignatureImage}[1]{%
     \def\temp{#1}%
@@ -1409,6 +1454,16 @@
 %=============================================================================
 
 \printSignature
+
+
+%=============================================================================
+% APPENDED ACKNOWLEDGEMENT - The appointee's endorsement on the same page
+%=============================================================================
+% Renders nothing unless \setAppendedEndorsement has been called. Sits between
+% the signature and Distribution/Copy to, matching Ch 9 Figure 9-1 where the
+% "Copy to:" block is the last thing on the sheet, below the endorsement.
+
+\printAppendedEndorsement
 
 
 %=============================================================================


### PR DESCRIPTION
Refs #203.

An appointment letter is two halves written at once: the officer signs, a rule divides the sheet, and the appointee endorses back below it — one page, two signatures. DonDocs couldn't produce that. `same_page_endorsement` emits *only* the endorsement half, which is right when a different command endorses later, and wrong when the CO writes both halves together.

## Using it

Pick a naval letter, standard letter, or memorandum, then tick **"Add an acknowledgement endorsement"** in the Signature section. Type the acknowledgement (one paragraph per line) and the appointee's name. Leave From/To blank — they invert the letter automatically. Leave the date blank and it prints an empty line for the Marine to hand-date when he signs.

## What it renders

```
1. Per the references, you are hereby appointed as the MSG Representative.
2. This appointment is automatically revoked upon your transfer.

                                        R. L. SMITH
------------------------------------------------------------
                                        Ser 1710/024
                                        3 Feb 25

FIRST ENDORSEMENT

From: Sergeant J. A. DOE, USMC
To:   Commanding Officer, 1st Battalion, 6th Marines

1. I have read and understand the references listed above.
2. I hereby assume the duties and responsibilities as the MSG Representative.

                                        J. A. DOE
```

One sheet. The date line above the endorsement line is required by Ch 9 ¶2.1a — the same-page relief covers the SSIC, subject and basic letter ID, not the date (Fig 9-1).

## Correcting the record

Earlier in #203 I said DonDocs could already do this. That was wrong — I'd read a `\rule` in the generator and assumed, instead of compiling. This supersedes that.

## Known limit

Past roughly three body paragraphs the acknowledgement no longer fits on the signature page and moves to its own page. Ch 9 wants a *new-page* endorsement there (with its own SSIC and subject), which is a different doc type this doesn't build. It stays intact rather than splitting, and the preview shows you what you're getting.

## Verification

Compiled PDFs and a real Word file, not string matching — a source-only test passes even if the template never renders the macro. Two of these tests caught real bugs.

- **`appended-endorsement-differential.test.ts`** — compiles both PDF *and* DOCX and asserts the acknowledgement survives into each. **This caught a real bug:** the Word export dropped the paragraph numbers, printing `.I have read...` where the PDF printed `1. I have read...`. Pandoc's list-marker detection was eating the digit because the appended body skipped the `\mbox{}` guard the rest of the file uses. Fixed.
- **`appended-endorsement-render.test.ts`** — one page, both signatures, inverted addressees, date above the endorsement line, and never split across a page break. **The split was a real bug too:** the appointee's signature used to strand on page 2.
- **`appended-endorsement-escaping.test.ts`** — the acknowledgement is free text typed into LaTeX; nothing proved `&` or `%` compiled. It does, but `%` would have silently commented the rest of the line away, so the assertions read the characters off the page.
- `appendedEndorsement.test.ts` — the resolver and both generators.
- Driven in the browser: absent on ineligible doc types, fields hidden until opt-in, renders on one page.

Also fixes two CI holes: the rendered-PDF tests were silently skipping (poppler-utils was never installed), and `test.yml` filtered `pull_request: branches: [main]`, so a stacked PR ran none of the eight jobs — only the Cloudflare previews, which look green and test nothing.

build 0, lint 0, 1658 unit tests, 11 render/differential/escaping tests.
The endorsement numbering fix that was here is now stacked on top: #212


