### PR TITLE
fix(endorsements): number the paragraphs of an endorsement body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
 - Endorsements now number their paragraphs, and their editor offers paragraph
   labels, Tab to indent, and subparagraphs like any other letter. Both same-page
   and new-page endorsements rendered their bodies unnumbered, against SECNAV
-  M-5216.5 Ch 2 ¶13a ("Identify all paragraphs or subparagraphs with a number or
+  M-5216.5 Ch 7 ¶13a ("Identify all paragraphs or subparagraphs with a number or
   letter"), to which Ch 9 states no exception — Fig 9-1 numbers its body even
   though it is a single paragraph, and Fig 9-2 numbers "1." and "2.". Ch 9's
   "continue the sequence" language, which had been read as a paragraph rule,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.100] — 2026-07-16
+
+### Fixed
+
+- Endorsements now number their paragraphs, and their editor offers paragraph
+  labels, Tab to indent, and subparagraphs like any other letter. Both same-page
+  and new-page endorsements rendered their bodies unnumbered, against SECNAV
+  M-5216.5 Ch 2 ¶13a ("Identify all paragraphs or subparagraphs with a number or
+  letter"), to which Ch 9 states no exception — Fig 9-1 numbers its body even
+  though it is a single paragraph, and Fig 9-2 numbers "1." and "2.". Ch 9's
+  "continue the sequence" language, which had been read as a paragraph rule,
+  never is: it governs references (letters), enclosures (numbers), and page
+  numbers.
+  **If you render endorsements, their paragraphs will now be numbered.**
+
 ## [1.2.99] — 2026-07-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dondocs",
-  "version": "1.2.99",
+  "version": "1.2.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dondocs",
-      "version": "1.2.99",
+      "version": "1.2.100",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.99",
+  "version": "1.2.100",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/public/lib/latex-templates.js
+++ b/public/lib/latex-templates.js
@@ -4370,7 +4370,9 @@ const LATEX_TEMPLATES = {
 %   - Horizontal line separates basic letter from endorsement
 %   - DO NOT repeat references already in basic letter
 %   - DO NOT repeat enclosures already in basic letter
-%   - Continue numbering sequences from basic letter
+%   - Continue the REFERENCE and ENCLOSURE sequences from the basic letter
+%     (Ch 9 ¶3, ¶4). This does not apply to paragraphs: the body is numbered
+%     from 1., as Figure 9-1 shows for its single paragraph.
 %
 %=============================================================================
 

--- a/public/lib/latex-templates.js
+++ b/public/lib/latex-templates.js
@@ -4370,9 +4370,10 @@ const LATEX_TEMPLATES = {
 %   - Horizontal line separates basic letter from endorsement
 %   - DO NOT repeat references already in basic letter
 %   - DO NOT repeat enclosures already in basic letter
-%   - Continue the REFERENCE and ENCLOSURE sequences from the basic letter
-%     (Ch 9 ¶3, ¶4). This does not apply to paragraphs: the body is numbered
-%     from 1., as Figure 9-1 shows for its single paragraph.
+%   - Continue the REFERENCE (letters, Ch 9 ¶3), ENCLOSURE (numbers, ¶4) and
+%     PAGE-number (Fig 9-2 ¶1) sequences from the basic letter. None of these
+%     is a paragraph rule: the body is numbered from 1. per Ch 2 ¶13a, as
+%     Figure 9-1 shows for its single paragraph.
 %
 %=============================================================================
 

--- a/public/lib/latex-templates.js
+++ b/public/lib/latex-templates.js
@@ -4372,7 +4372,7 @@ const LATEX_TEMPLATES = {
 %   - DO NOT repeat enclosures already in basic letter
 %   - Continue the REFERENCE (letters, Ch 9 ¶3), ENCLOSURE (numbers, ¶4) and
 %     PAGE-number (Fig 9-2 ¶1) sequences from the basic letter. None of these
-%     is a paragraph rule: the body is numbered from 1. per Ch 2 ¶13a, as
+%     is a paragraph rule: the body is numbered from 1. per Ch 7 ¶13a, as
 %     Figure 9-1 shows for its single paragraph.
 %
 %=============================================================================

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -789,7 +789,7 @@ export function VariableChipEditor({
           }
           // Tab indents / Shift+Tab outdents — but ONLY when indent is enabled for
           // this doc type. When the handlers are absent (compliant business letter,
-          // endorsement, executive memo: numberedParagraphs=false), let Tab fall
+          // executive memo: numberedParagraphs=false), let Tab fall
           // through to the browser's native focus move instead of swallowing it,
           // otherwise the editor becomes a keyboard trap (WCAG 2.1.2).
           if (event.key === 'Tab' && !event.shiftKey) {

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -685,7 +685,9 @@ export function generateBodyTex(store: DocumentStore): string {
   const labels = calculateLabels(store.paragraphs);
   const config = DOC_TYPE_CONFIG[store.docType] || DOC_TYPE_CONFIG.naval_letter;
 
-  // Business letters and endorsements don't use numbered paragraphs
+  // Business letters (Ch 11 ¶6) and the bullet-style executive memos
+  // (Ch 12 ¶3a(2)) don't number paragraphs. Endorsements do -- see Ch 9 in
+  // DOC_TYPE_CONFIG.
   const useNumberedParagraphs = config.compliance.numberedParagraphs;
   // Business letters and executive correspondence use 0.5" first-line indent instead of numbers
   const isBusinessLetter = config.uiMode === 'business';

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -685,8 +685,9 @@ export function generateBodyTex(store: DocumentStore): string {
   const labels = calculateLabels(store.paragraphs);
   const config = DOC_TYPE_CONFIG[store.docType] || DOC_TYPE_CONFIG.naval_letter;
 
-  // Business letters (Ch 11 ¶6) and the bullet-style executive memos
-  // (Ch 12 ¶3a(2)) don't number paragraphs. Endorsements do -- see Ch 9 in
+  // Business letters (Ch 11 ¶6, "Do not number main paragraphs") and executive
+  // correspondence (Ch 12 ¶3.2c(2), "Do not number the paragraphs") don't
+  // number theirs. Endorsements do -- see the Ch 9 note in
   // DOC_TYPE_CONFIG.
   const useNumberedParagraphs = config.compliance.numberedParagraphs;
   // Business letters and executive correspondence use 0.5" first-line indent instead of numbers

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -377,10 +377,18 @@ export const DOC_TYPE_CONFIG: Record<string, DocTypeConfig> = {
     regulations: { fontSize: '12pt', fontSizeOptions: ['10pt', '11pt', '12pt'], fontFamily: 'times', ref: 'Ch 7' },
     compliance: DUAL_SIGNATURE_COMPLIANCE,
   },
-  // Endorsements number their paragraphs like any letter: Figs 9-1 and 9-2 both
-  // show a numbered body (9-1 numbers even its single paragraph). Ch 9's
-  // "continue the sequence from the basic letter" governs *enclosures*, not
-  // paragraphs — reading it as the latter is what left these unnumbered.
+  // Endorsements number their paragraphs. Ch 2 ¶13a is the general rule --
+  // "Identify all paragraphs or subparagraphs with a number or letter" -- and
+  // Ch 9 states no exception to it. Where this manual wants paragraphs
+  // unnumbered it says so in those words (Ch 11 ¶6, Ch 12 ¶3.2c(2)); Ch 9 has
+  // no such sentence, and Figs 9-1 and 9-2 both show a numbered body (9-1
+  // numbers even its single paragraph). The only "do not number" in Ch 9 is for
+  // Via addressees.
+  //
+  // These rendered unnumbered because Ch 9's "continue the sequence" language
+  // was read as a paragraph rule. It never is: ¶3 continues a sequence of
+  // *letters* (references), ¶4 a sequence of *numbers* (enclosures), and
+  // Fig 9-2's own first paragraph continues *page* numbers.
   same_page_endorsement: {
     letterhead: false, ssic: false, fromTo: true, via: true, memoHeader: false, signature: 'abbrev', uiMode: 'standard',
     showSignatureRankTitle: false, // Endorsements use abbreviated name only per Ch 9

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -329,12 +329,6 @@ const BUSINESS_COMPLIANCE = {
   dateFormat: 'spelled' as const,  // "January 4, 2026" format
 };
 
-// Endorsement compliance - NO numbered paragraphs (continues basic letter sequence)
-const ENDORSEMENT_COMPLIANCE = {
-  ...DEFAULT_COMPLIANCE,
-  numberedParagraphs: false,
-};
-
 // Dual signature compliance (MOA/MOU/Joint)
 const DUAL_SIGNATURE_COMPLIANCE = {
   ...DEFAULT_COMPLIANCE,
@@ -383,18 +377,22 @@ export const DOC_TYPE_CONFIG: Record<string, DocTypeConfig> = {
     regulations: { fontSize: '12pt', fontSizeOptions: ['10pt', '11pt', '12pt'], fontFamily: 'times', ref: 'Ch 7' },
     compliance: DUAL_SIGNATURE_COMPLIANCE,
   },
+  // Endorsements number their paragraphs like any letter: Figs 9-1 and 9-2 both
+  // show a numbered body (9-1 numbers even its single paragraph). Ch 9's
+  // "continue the sequence from the basic letter" governs *enclosures*, not
+  // paragraphs — reading it as the latter is what left these unnumbered.
   same_page_endorsement: {
     letterhead: false, ssic: false, fromTo: true, via: true, memoHeader: false, signature: 'abbrev', uiMode: 'standard',
     showSignatureRankTitle: false, // Endorsements use abbreviated name only per Ch 9
     skipSubject: true,
     regulations: { fontSize: '12pt', fontSizeOptions: ['10pt', '11pt', '12pt'], fontFamily: 'times', ref: 'Ch 9' },
-    compliance: ENDORSEMENT_COMPLIANCE,
+    compliance: DEFAULT_COMPLIANCE,
   },
   new_page_endorsement: {
     letterhead: true, ssic: true, fromTo: true, via: true, memoHeader: false, signature: 'abbrev', uiMode: 'standard',
     showSignatureRankTitle: false, // Endorsements use abbreviated name only per Ch 9
     regulations: { fontSize: '12pt', fontSizeOptions: ['10pt', '11pt', '12pt'], fontFamily: 'times', ref: 'Ch 9' },
-    compliance: ENDORSEMENT_COMPLIANCE,
+    compliance: DEFAULT_COMPLIANCE,
   },
   mfr: {
     letterhead: true, ssic: true, fromTo: false, via: false, memoHeader: true, signature: 'abbrev', uiMode: 'memo',

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -377,13 +377,15 @@ export const DOC_TYPE_CONFIG: Record<string, DocTypeConfig> = {
     regulations: { fontSize: '12pt', fontSizeOptions: ['10pt', '11pt', '12pt'], fontFamily: 'times', ref: 'Ch 7' },
     compliance: DUAL_SIGNATURE_COMPLIANCE,
   },
-  // Endorsements number their paragraphs. Ch 2 ¶13a is the general rule --
-  // "Identify all paragraphs or subparagraphs with a number or letter" -- and
-  // Ch 9 states no exception to it. Where this manual wants paragraphs
-  // unnumbered it says so in those words (Ch 11 ¶6, Ch 12 ¶3.2c(2)); Ch 9 has
-  // no such sentence, and Figs 9-1 and 9-2 both show a numbered body (9-1
-  // numbers even its single paragraph). The only "do not number" in Ch 9 is for
-  // Via addressees.
+  // Endorsements number their paragraphs. The rule is Ch 7 ¶13a
+  // (Correspondence Format) -- "Identify all paragraphs or subparagraphs with a
+  // number or letter" -- which an endorsement inherits by being
+  // letter-formatted: Ch 9 sets only the endorsement line, addressees and
+  // signature, and states no paragraph rule of its own. Figs 9-1 and 9-2 settle
+  // it directly, both showing a numbered body (9-1 numbers even its single
+  // paragraph). Where this manual wants paragraphs unnumbered it says so in
+  // those words (Ch 11 ¶6, Ch 12 ¶3.2c(2)); Ch 9 has no such sentence, and its
+  // only "do not number" is for Via addressees.
   //
   // These rendered unnumbered because Ch 9's "continue the sequence" language
   // was read as a paragraph rule. It never is: ¶3 continues a sequence of

--- a/tests/integration/endorsement-numbering-render.test.ts
+++ b/tests/integration/endorsement-numbering-render.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Endorsement bodies are numbered, proved against a compiled PDF.
+ *
+ * The unit regression (tests/regressions/endorsement-numbered-paragraphs.test.ts)
+ * asserts on LaTeX source, which is the wrong tier of proof for the most
+ * user-visible change on this branch: source assertions pass even when the
+ * template never renders the label. This reads the numbers off the page.
+ *
+ * The rule is Ch 2 ¶13a ("Identify all paragraphs or subparagraphs with a
+ * number or letter"), to which Ch 9 states no exception. Fig 9-1 numbers a
+ * single-paragraph body; Fig 9-2 numbers "1." and "2.".
+ *
+ * Requires pdflatex + pdftotext; fails rather than skips in CI.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { writeFile, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { compileFixture } from '../_helpers/compileLatex';
+import { hasPdfToolchain, describeToolchainRequirement } from '../_helpers/pdfToolchain';
+
+const toolchain = hasPdfToolchain;
+
+async function renderEndorsement(paragraphs: { text: string; level: number }[]): Promise<string> {
+  const result = await compileFixture({
+    docType: 'same_page_endorsement',
+    formData: {
+      docType: 'same_page_endorsement',
+      fontSize: '12pt',
+      fontFamily: 'times',
+      pageNumbering: 'none',
+      department: 'usmc',
+      classLevel: 'unclassified',
+      from: 'Commander, Sea Based Anti-Submarine Warfare Wing, Atlantic',
+      to: 'Commander, Fleet Forces Command',
+      subject: 'HOW TO PREPARE AN ENDORSEMENT',
+      basicLetterId: 'NAS Meridian ltr 5216 Ser 11/273 of 22 Apr 15',
+      endorsementOrdinal: 'FIRST',
+      sigFirst: 'Robert',
+      sigLast: 'GABEL',
+    },
+    references: [],
+    enclosures: [],
+    paragraphs,
+    copyTos: [],
+    distributions: [],
+  } as never);
+
+  expect(result.ok, `pdflatex failed; work dir: ${result.workDir}`).toBe(true);
+  const dir = await mkdtemp(join(tmpdir(), 'dondocs-endnum-'));
+  const pdfPath = join(dir, 'out.pdf');
+  await writeFile(pdfPath, result.pdfBytes!);
+  const { stdout } = spawnSync('pdftotext', [pdfPath, '-'], { encoding: 'utf-8' });
+  // A blank extraction would make the assertions below vacuous.
+  expect(stdout.trim().length).toBeGreaterThan(0);
+  return stdout;
+}
+
+describe('endorsement paragraph numbering — rendered PDF', () => {
+  describeToolchainRequirement('endorsement-numbering-render');
+
+  it.skipIf(!toolchain)('numbers a multi-paragraph body (Fig 9-2)', async () => {
+    const text = await renderEndorsement([
+      { text: 'Start an endorsement on a new page.', level: 0 },
+      { text: 'Every new-page endorsement must repeat the basic letter subject.', level: 0 },
+    ]);
+    expect(text).toMatch(/1\.\s+Start an endorsement on a new page\./);
+    expect(text).toMatch(/2\.\s+Every new-page endorsement must repeat/);
+  });
+
+  // Fig 9-1's body is a single paragraph and is still numbered "1." — the
+  // lone-item exception Ch 9 grants Via addressees does not reach paragraphs.
+  it.skipIf(!toolchain)('numbers a solitary paragraph (Fig 9-1)', async () => {
+    const text = await renderEndorsement([
+      { text: 'Forwarded, recommending approval.', level: 0 },
+    ]);
+    expect(text).toMatch(/1\.\s+Forwarded, recommending approval\./);
+  });
+});

--- a/tests/integration/endorsement-numbering-render.test.ts
+++ b/tests/integration/endorsement-numbering-render.test.ts
@@ -6,7 +6,7 @@
  * user-visible change on this branch: source assertions pass even when the
  * template never renders the label. This reads the numbers off the page.
  *
- * The rule is Ch 2 ¶13a ("Identify all paragraphs or subparagraphs with a
+ * The rule is Ch 7 ¶13a ("Identify all paragraphs or subparagraphs with a
  * number or letter"), to which Ch 9 states no exception. Fig 9-1 numbers a
  * single-paragraph body; Fig 9-2 numbers "1." and "2.".
  *

--- a/tests/regressions/endorsement-numbered-paragraphs.test.ts
+++ b/tests/regressions/endorsement-numbered-paragraphs.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Endorsement bodies are numbered (SECNAV M-5216.5 Ch 9, Figs 9-1 and 9-2).
+ *
+ * These shipped unnumbered from the original doc-type import: Ch 9 says to
+ * "continue the sequence of numbers from the basic letter", which governs
+ * ENCLOSURES ("Assign a number to all enclosures that you add by continuing the
+ * sequence…"). Read as a paragraph rule, it turned numbering off for both
+ * endorsement types.
+ *
+ * The figures are unambiguous:
+ *   Fig 9-1 (same-page): "1...A same-page endorsement may omit the SSIC…"
+ *                        — numbered despite being a *single* paragraph, so the
+ *                          don't-number-a-lone-item rule Ch 9 states for Via
+ *                          addressees does not extend to paragraphs.
+ *   Fig 9-2 (new-page):  "1...Start an endorsement on a new page."
+ *                        "2...Every 'new page' endorsement must repeat…"
+ */
+import { describe, it, expect } from 'vitest';
+import { DOC_TYPE_CONFIG } from '@/types/document';
+import { generateFlatLatex } from '@/services/latex/flat-generator';
+
+const ENDORSEMENTS = ['same_page_endorsement', 'new_page_endorsement'] as const;
+
+function store(docType: string, paragraphs: { text: string; level: number }[]) {
+  return {
+    docType,
+    formData: {
+      docType,
+      from: 'Sergeant J. A. DOE, USMC',
+      to: 'Commanding Officer, 1st Battalion, 6th Marines',
+      subject: 'HOW TO PREPARE AN ENDORSEMENT',
+      basicLetterId: 'CO 1stBn 6thMar ltr 5216 Ser 0123 of 15 Jan 25',
+      endorsementOrdinal: 'FIRST',
+      sigFirst: 'John',
+      sigLast: 'DOE',
+    },
+    references: [],
+    enclosures: [],
+    paragraphs,
+    copyTos: [],
+    distributions: [],
+  } as never;
+}
+
+describe.each(ENDORSEMENTS)('%s', (docType) => {
+  it('numbers its paragraphs', () => {
+    expect(DOC_TYPE_CONFIG[docType].compliance.numberedParagraphs).toBe(true);
+  });
+
+  it('renders a numbered body (Fig 9-2)', () => {
+    const tex = generateFlatLatex(
+      store(docType, [
+        { text: 'Start an endorsement on a new page.', level: 0 },
+        { text: 'Every new-page endorsement must repeat the basic letter subject.', level: 0 },
+      ])
+    );
+    expect(tex).toContain('\\mbox{1.}');
+    expect(tex).toContain('\\mbox{2.}');
+  });
+
+  // Fig 9-1's body is one paragraph and is still numbered "1." — the lone-item
+  // exception Ch 9 grants Via addressees does not apply here.
+  it('numbers a solitary paragraph too (Fig 9-1)', () => {
+    const tex = generateFlatLatex(
+      store(docType, [{ text: 'Forwarded, recommending approval.', level: 0 }])
+    );
+    expect(tex).toContain('\\mbox{1.}');
+  });
+});

--- a/tests/regressions/endorsement-numbered-paragraphs.test.ts
+++ b/tests/regressions/endorsement-numbered-paragraphs.test.ts
@@ -1,7 +1,7 @@
 /**
  * Endorsement bodies are numbered (SECNAV M-5216.5).
  *
- * The rule is Ch 2 ¶13a: "Identify all paragraphs or subparagraphs with a
+ * The rule is Ch 7 ¶13a: "Identify all paragraphs or subparagraphs with a
  * number or letter." Ch 9 states no exception, so endorsements inherit it.
  * Where the manual wants paragraphs unnumbered it says so in those words --
  * Ch 11 ¶6 "Do not number main paragraphs", Ch 12 ¶3.2c(2) "Do not number the

--- a/tests/regressions/endorsement-numbered-paragraphs.test.ts
+++ b/tests/regressions/endorsement-numbered-paragraphs.test.ts
@@ -1,19 +1,23 @@
 /**
- * Endorsement bodies are numbered (SECNAV M-5216.5 Ch 9, Figs 9-1 and 9-2).
+ * Endorsement bodies are numbered (SECNAV M-5216.5).
  *
- * These shipped unnumbered from the original doc-type import: Ch 9 says to
- * "continue the sequence of numbers from the basic letter", which governs
- * ENCLOSURES ("Assign a number to all enclosures that you add by continuing the
- * sequence…"). Read as a paragraph rule, it turned numbering off for both
- * endorsement types.
+ * The rule is Ch 2 ¶13a: "Identify all paragraphs or subparagraphs with a
+ * number or letter." Ch 9 states no exception, so endorsements inherit it.
+ * Where the manual wants paragraphs unnumbered it says so in those words --
+ * Ch 11 ¶6 "Do not number main paragraphs", Ch 12 ¶3.2c(2) "Do not number the
+ * paragraphs" -- and Ch 9 contains no such sentence. Its only "do not number"
+ * is for Via addressees.
  *
- * The figures are unambiguous:
+ * The figures agree:
  *   Fig 9-1 (same-page): "1...A same-page endorsement may omit the SSIC…"
- *                        — numbered despite being a *single* paragraph, so the
- *                          don't-number-a-lone-item rule Ch 9 states for Via
- *                          addressees does not extend to paragraphs.
+ *                        — numbered despite being a *single* paragraph.
  *   Fig 9-2 (new-page):  "1...Start an endorsement on a new page."
  *                        "2...Every 'new page' endorsement must repeat…"
+ *
+ * These shipped unnumbered because Ch 9's "continue the sequence" language was
+ * read as a paragraph rule. It never is: ¶3 continues a sequence of *letters*
+ * (references), ¶4 a sequence of *numbers* (enclosures), and Fig 9-2's own
+ * first paragraph continues *page* numbers.
  */
 import { describe, it, expect } from 'vitest';
 import { DOC_TYPE_CONFIG } from '@/types/document';

--- a/tex/README.md
+++ b/tex/README.md
@@ -521,7 +521,7 @@ Per Ch 7 ¶13c:
 - **Chapter:** Ch 9
 - **Letterhead:** N/A (continues on basic letter's signature page) — *Figure 9-1*
 - **When to Use:** "If it will completely fit on the signature page of the basic letter or the preceding endorsement" — *Ch 9 ¶1*
-- **Numbered Paragraphs:** NO (continues basic letter sequence) — *Ch 9 ¶1a*
+- **Numbered Paragraphs:** YES *(REQUIRED)* — *Figure 9-1* (numbers its body even though it is a single paragraph). What continues from the basic letter is the reference and enclosure sequence, not paragraph numbering — *Ch 9 ¶3, ¶4*
 - **May Omit:** SSIC, subject, basic letter's identification symbols "if the entire page will be photocopied" — *Ch 9 ¶1a*
 - **Font:** 10-12pt *(REQUIRED)*, Times New Roman *(RECOMMENDED)* — *Ch 2 ¶20*
 
@@ -532,7 +532,7 @@ Per Ch 7 ¶13c:
 - **Endorsement Line Format:** "FIRST ENDORSEMENT on [basic letter reference]" — *Ch 9 ¶1b*
 - **Endorsement Numbering:** Use ordinal numbers: FIRST, SECOND, THIRD, etc. Number each endorsement in sequence as it is added to the basic letter — *Ch 9 ¶1b*
 - **Heading Overflow:** When the endorsement heading exceeds one line, start the succeeding line with the word "on" — *Ch 9 ¶1b*
-- **Numbered Paragraphs:** NO (continues basic letter sequence) — *Ch 9 ¶1*
+- **Numbered Paragraphs:** YES *(REQUIRED)* — *Figure 9-2* (numbers "1." and "2."). What continues from the basic letter is the reference and enclosure sequence, not paragraph numbering — *Ch 9 ¶3, ¶4*
 - **"Via:" Line in Endorsements:** Include any remaining "Via" addressees. If only one remains, do not number it. If more than one remains, number starting with (1) — *Ch 9 ¶2*
 - **Adding References:** Continue sequence from basic letter (if basic had up to (f), start with (g)) — *Ch 9 ¶3*
 - **Adding Enclosures:** Continue sequence from basic letter (if basic had up to (5), start with (6)) — *Ch 9 ¶4*

--- a/tex/README.md
+++ b/tex/README.md
@@ -234,7 +234,7 @@ Encl:   (1) Title of First Enclosure
 | Never duplicate | Never list item in both enclosure AND reference line | Ch 7 ¶11a |
 
 ### Marking Enclosures
-Per Ch 2 ¶13a:
+Per Ch 7 ¶13a:
 
 | Page | Marking | Position |
 |------|---------|----------|
@@ -521,7 +521,7 @@ Per Ch 7 ¶13c:
 - **Chapter:** Ch 9
 - **Letterhead:** N/A (continues on basic letter's signature page) — *Figure 9-1*
 - **When to Use:** "If it will completely fit on the signature page of the basic letter or the preceding endorsement" — *Ch 9 ¶1*
-- **Numbered Paragraphs:** YES *(REQUIRED)* — *Ch 2 ¶13a* ("Identify all paragraphs or subparagraphs with a number or letter"); Ch 9 states no exception. *Figure 9-1* numbers its body even though it is a single paragraph. What continues from the basic letter is the reference sequence (letters, ¶3), the enclosure sequence (numbers, ¶4), and page numbers (Fig 9-2) — never paragraph numbering
+- **Numbered Paragraphs:** YES *(REQUIRED)* — *Ch 7 ¶13a* ("Identify all paragraphs or subparagraphs with a number or letter"); Ch 9 states no exception. *Figure 9-1* numbers its body even though it is a single paragraph. What continues from the basic letter is the reference sequence (letters, ¶3), the enclosure sequence (numbers, ¶4), and page numbers (Fig 9-2) — never paragraph numbering
 - **May Omit:** SSIC, subject, basic letter's identification symbols "if the entire page will be photocopied" — *Ch 9 ¶1a*
 - **Font:** 10-12pt *(REQUIRED)*, Times New Roman *(RECOMMENDED)* — *Ch 2 ¶20*
 
@@ -532,7 +532,7 @@ Per Ch 7 ¶13c:
 - **Endorsement Line Format:** "FIRST ENDORSEMENT on [basic letter reference]" — *Ch 9 ¶1b*
 - **Endorsement Numbering:** Use ordinal numbers: FIRST, SECOND, THIRD, etc. Number each endorsement in sequence as it is added to the basic letter — *Ch 9 ¶1b*
 - **Heading Overflow:** When the endorsement heading exceeds one line, start the succeeding line with the word "on" — *Ch 9 ¶1b*
-- **Numbered Paragraphs:** YES *(REQUIRED)* — *Ch 2 ¶13a*; Ch 9 states no exception. *Figure 9-2* numbers "1." and "2.". What continues from the basic letter is the reference sequence (letters, ¶3), the enclosure sequence (numbers, ¶4), and page numbers (Fig 9-2 ¶1) — never paragraph numbering
+- **Numbered Paragraphs:** YES *(REQUIRED)* — *Ch 7 ¶13a*; Ch 9 states no exception. *Figure 9-2* numbers "1." and "2.". What continues from the basic letter is the reference sequence (letters, ¶3), the enclosure sequence (numbers, ¶4), and page numbers (Fig 9-2 ¶1) — never paragraph numbering
 - **"Via:" Line in Endorsements:** Include any remaining "Via" addressees. If only one remains, do not number it. If more than one remains, number starting with (1) — *Ch 9 ¶2*
 - **Adding References:** Continue sequence from basic letter (if basic had up to (f), start with (g)) — *Ch 9 ¶3*
 - **Adding Enclosures:** Continue sequence from basic letter (if basic had up to (5), start with (6)) — *Ch 9 ¶4*

--- a/tex/README.md
+++ b/tex/README.md
@@ -521,7 +521,7 @@ Per Ch 7 ¶13c:
 - **Chapter:** Ch 9
 - **Letterhead:** N/A (continues on basic letter's signature page) — *Figure 9-1*
 - **When to Use:** "If it will completely fit on the signature page of the basic letter or the preceding endorsement" — *Ch 9 ¶1*
-- **Numbered Paragraphs:** YES *(REQUIRED)* — *Figure 9-1* (numbers its body even though it is a single paragraph). What continues from the basic letter is the reference and enclosure sequence, not paragraph numbering — *Ch 9 ¶3, ¶4*
+- **Numbered Paragraphs:** YES *(REQUIRED)* — *Ch 2 ¶13a* ("Identify all paragraphs or subparagraphs with a number or letter"); Ch 9 states no exception. *Figure 9-1* numbers its body even though it is a single paragraph. What continues from the basic letter is the reference sequence (letters, ¶3), the enclosure sequence (numbers, ¶4), and page numbers (Fig 9-2) — never paragraph numbering
 - **May Omit:** SSIC, subject, basic letter's identification symbols "if the entire page will be photocopied" — *Ch 9 ¶1a*
 - **Font:** 10-12pt *(REQUIRED)*, Times New Roman *(RECOMMENDED)* — *Ch 2 ¶20*
 
@@ -532,7 +532,7 @@ Per Ch 7 ¶13c:
 - **Endorsement Line Format:** "FIRST ENDORSEMENT on [basic letter reference]" — *Ch 9 ¶1b*
 - **Endorsement Numbering:** Use ordinal numbers: FIRST, SECOND, THIRD, etc. Number each endorsement in sequence as it is added to the basic letter — *Ch 9 ¶1b*
 - **Heading Overflow:** When the endorsement heading exceeds one line, start the succeeding line with the word "on" — *Ch 9 ¶1b*
-- **Numbered Paragraphs:** YES *(REQUIRED)* — *Figure 9-2* (numbers "1." and "2."). What continues from the basic letter is the reference and enclosure sequence, not paragraph numbering — *Ch 9 ¶3, ¶4*
+- **Numbered Paragraphs:** YES *(REQUIRED)* — *Ch 2 ¶13a*; Ch 9 states no exception. *Figure 9-2* numbers "1." and "2.". What continues from the basic letter is the reference sequence (letters, ¶3), the enclosure sequence (numbers, ¶4), and page numbers (Fig 9-2 ¶1) — never paragraph numbering
 - **"Via:" Line in Endorsements:** Include any remaining "Via" addressees. If only one remains, do not number it. If more than one remains, number starting with (1) — *Ch 9 ¶2*
 - **Adding References:** Continue sequence from basic letter (if basic had up to (f), start with (g)) — *Ch 9 ¶3*
 - **Adding Enclosures:** Continue sequence from basic letter (if basic had up to (5), start with (6)) — *Ch 9 ¶4*

--- a/tex/templates/same_page_endorsement.tex
+++ b/tex/templates/same_page_endorsement.tex
@@ -22,9 +22,10 @@
 %   - Horizontal line separates basic letter from endorsement
 %   - DO NOT repeat references already in basic letter
 %   - DO NOT repeat enclosures already in basic letter
-%   - Continue the REFERENCE and ENCLOSURE sequences from the basic letter
-%     (Ch 9 ¶3, ¶4). This does not apply to paragraphs: the body is numbered
-%     from 1., as Figure 9-1 shows for its single paragraph.
+%   - Continue the REFERENCE (letters, Ch 9 ¶3), ENCLOSURE (numbers, ¶4) and
+%     PAGE-number (Fig 9-2 ¶1) sequences from the basic letter. None of these
+%     is a paragraph rule: the body is numbered from 1. per Ch 2 ¶13a, as
+%     Figure 9-1 shows for its single paragraph.
 %
 %=============================================================================
 

--- a/tex/templates/same_page_endorsement.tex
+++ b/tex/templates/same_page_endorsement.tex
@@ -22,7 +22,9 @@
 %   - Horizontal line separates basic letter from endorsement
 %   - DO NOT repeat references already in basic letter
 %   - DO NOT repeat enclosures already in basic letter
-%   - Continue numbering sequences from basic letter
+%   - Continue the REFERENCE and ENCLOSURE sequences from the basic letter
+%     (Ch 9 ¶3, ¶4). This does not apply to paragraphs: the body is numbered
+%     from 1., as Figure 9-1 shows for its single paragraph.
 %
 %=============================================================================
 

--- a/tex/templates/same_page_endorsement.tex
+++ b/tex/templates/same_page_endorsement.tex
@@ -24,7 +24,7 @@
 %   - DO NOT repeat enclosures already in basic letter
 %   - Continue the REFERENCE (letters, Ch 9 ¶3), ENCLOSURE (numbers, ¶4) and
 %     PAGE-number (Fig 9-2 ¶1) sequences from the basic letter. None of these
-%     is a paragraph rule: the body is numbered from 1. per Ch 2 ¶13a, as
+%     is a paragraph rule: the body is numbered from 1. per Ch 7 ¶13a, as
 %     Figure 9-1 shows for its single paragraph.
 %
 %=============================================================================


### PR DESCRIPTION
Stacked on #211 — review that first; this diff is only the two commits on top.

## The bug

Same-page and new-page endorsements rendered their body paragraphs unnumbered. They shouldn't.

**Ch 2 ¶13a:** "Identify all paragraphs or subparagraphs with a number or letter." Ch 9 states no exception, so endorsements inherit it.

The tell is that when this manual wants paragraphs unnumbered, it says so in those words — Ch 11 ¶6 "Do not number main paragraphs", Ch 12 ¶3.2c(2) "Do not number the paragraphs". Ch 9 has no such sentence. Its only "do not number" is for Via addressees.

The figures agree: Fig 9-1 numbers its body `1.` even though it's a single paragraph; Fig 9-2 numbers `1.` and `2.`.

## Where it came from

A misreading of Ch 9's "continue the sequence from the basic letter", which was taken as a paragraph rule. It never is — it governs references (a sequence of *letters*, ¶3), enclosures (*numbers*, ¶4), and page numbers (Fig 9-2's own first paragraph). The old comment said "NO numbered paragraphs (continues basic letter sequence)", citing a paragraph that is actually about enclosures.

`tex/README.md` and the same-page template header carried the same misreading, so both are corrected with the citation.

## Effect

```
 FIRST ENDORSEMENT on CO 1stBn 6thMar ltr 5216 Ser 0123 of 15 Jan 25
 From: Sergeant J. A. DOE, USMC
 To:   Commanding Officer, 1st Battalion, 6th Marines
-I have read and understand the references listed above...
-I hereby assume the duties and responsibilities as the [DUTY TITLE]...
+1. I have read and understand the references listed above...
+2. I hereby assume the duties and responsibilities as the [DUTY TITLE]...
                                       J. A. DOE
```

**This changes output for anyone who renders endorsements today** — their paragraphs will now be numbered on re-export. Previously exported PDFs are untouched. The same flag also gates the editor, so endorsement authors now get paragraph labels, Tab to indent, and subparagraphs.

Two doc types are affected (`same_page_endorsement`, `new_page_endorsement`). The other two `numberedParagraphs: false` sites are correct and untouched — I checked both cites: business letters (Ch 11 ¶6) and bullet-style executive memos (Ch 12 ¶3a(2)).

## Why it's separate from #211

#203 never used this flag — the appended acknowledgement numbers its own body directly. The two changes are unrelated, and this one deserves its own revert handle: #211 is opt-in and changes nothing for existing documents, while this changes everyone's endorsements.

## Verification

- `tests/integration/endorsement-numbering-render.test.ts` — reads the numbers off a compiled PDF, for both the Fig 9-2 multi-paragraph case and the Fig 9-1 single-paragraph case. Reintroducing the bug fails it.
- `tests/regressions/endorsement-numbered-paragraphs.test.ts` — pins the config and both generators.
- Nothing regressed: the 827-test compile matrix passes. No existing test broke, because nothing had ever asserted the old behavior — which is how it survived since the original doc-type import.
- build 0, lint 0, 1664 unit tests.

Worth a second opinion from someone who reads Ch 9 for a living before merging.
