### PR TITLE
feat(endorsement): assemble an endorsement onto its basic letter PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
 ### Added
 
 - An endorsement can now be assembled onto the basic letter it endorses. Upload
-  the letter's PDF in the Basic Letter section of a same-page or new-page
-  endorsement, and the exported PDF is the letter followed by your endorsement
-  (SECNAV M-5216.5 Ch 9, Fig 9-3, "Assembly of an Endorsement"). The preview
-  shows the assembled document, and the uploaded letter is stored like an
-  enclosure — it survives a reload and rides along in a backup.
+  the letter's PDF in the Basic Letter section of a new-page endorsement, and the
+  exported PDF is the letter followed by your endorsement — a new-page
+  endorsement continues the basic letter's page numbers (SECNAV M-5216.5 Ch 9),
+  so the letter reads first. The preview shows the assembled document, and the
+  uploaded letter is stored like an enclosure — it survives a reload and rides
+  along in a backup.
 - New-page assembly only, by design: Ch 9 ¶1 makes a new-page endorsement always
   valid, and DonDocs does not overlay text onto the signature page of a letter it
   did not generate. PDF export only — the Word file contains the endorsement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.101] — 2026-07-16
+
+### Added
+
+- An endorsement can now be assembled onto the basic letter it endorses. Upload
+  the letter's PDF in the Basic Letter section of a same-page or new-page
+  endorsement, and the exported PDF is the letter followed by your endorsement
+  (SECNAV M-5216.5 Ch 9, Fig 9-3, "Assembly of an Endorsement"). The preview
+  shows the assembled document, and the uploaded letter is stored like an
+  enclosure — it survives a reload and rides along in a backup.
+- New-page assembly only, by design: Ch 9 ¶1 makes a new-page endorsement always
+  valid, and DonDocs does not overlay text onto the signature page of a letter it
+  did not generate. PDF export only — the Word file contains the endorsement
+  alone.
+
 ## [1.2.100] — 2026-07-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dondocs",
-  "version": "1.2.100",
+  "version": "1.2.101",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dondocs",
-      "version": "1.2.100",
+      "version": "1.2.101",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.100",
+  "version": "1.2.101",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,7 +93,7 @@ import { generateNavmc11811Pdf, loadNavmc11811Template } from '@/services/pdf/na
 import { applyPlaceholdersToNavmc11811, buildNavmc11811DefaultValues } from '@/lib/placeholders';
 import { mergeEnclosures } from '@/services/pdf/mergeEnclosures';
 import type { ClassificationInfo, EnclosureError } from '@/services/pdf/mergeEnclosures';
-import { assembleEndorsement } from '@/services/pdf/assembleEndorsement';
+import { assembleEndorsement, shouldAssembleBasicLetter } from '@/services/pdf/assembleEndorsement';
 import { addSignatureField, addDualSignatureFields, type DualSignatureFieldConfig, type SignatureFieldConfig } from '@/services/pdf/addSignatureField';
 import { DOC_TYPE_CONFIG, type DocumentData } from '@/types/document';
 import { detectPII, type PIIDetectionResult } from '@/services/pii/detector';
@@ -116,20 +116,18 @@ async function assembleBasicLetter(
   docType: string,
   formData: Partial<DocumentData>
 ): Promise<{ pdfBytes: Uint8Array; error?: string }> {
-  const data = formData.basicLetterFile?.data;
-  // New-page only: assembly puts the endorsement on its own page after the
-  // letter, which is a new-page endorsement. A same-page endorsement is meant to
-  // sit on the letter's signature page (which DonDocs can't do with an uploaded
-  // PDF), so it never assembles even if a stale file is attached.
-  if (docType !== 'new_page_endorsement' || !data) return { pdfBytes };
-  const result = await assembleEndorsement(pdfBytes, data);
+  // The gate (new-page only, letter attached) lives in assembleEndorsement.ts
+  // where it is unit-tested; see shouldAssembleBasicLetter for the reasoning.
+  if (!shouldAssembleBasicLetter(docType, formData)) return { pdfBytes };
+  const result = await assembleEndorsement(pdfBytes, formData.basicLetterFile!.data);
   return result.ok ? { pdfBytes: result.pdfBytes } : { pdfBytes, error: result.error };
 }
 
 /** An EnclosureError-shaped entry so a failed basic-letter assembly surfaces in
- *  the same modal the enclosure merge uses. */
+ *  the same modal the enclosure merge uses — tagged so the modal doesn't call
+ *  it "Enclosure (0)" or claim a placeholder page exists for it. */
 function basicLetterError(error: string): EnclosureError {
-  return { enclosureNumber: 0, title: 'Basic letter', error };
+  return { enclosureNumber: 0, title: 'Basic letter', error, kind: 'basicLetter' };
 }
 
 function getClassificationInfo(
@@ -600,7 +598,7 @@ function App() {
           currentStore.formData.signatureType === 'digital' ||
           // A basic-letter PDF assembles ahead of the endorsement in
           // enhancePreviewPdf (new-page only), so the preview must run that pass.
-          (currentStore.docType === 'new_page_endorsement' && !!currentStore.formData.basicLetterFile?.data);
+          shouldAssembleBasicLetter(currentStore.docType, currentStore.formData);
         const basePdfBytes = pdfBytes;
 
         // fullQualityPreview runs the full pipeline inline. When off (default),
@@ -854,10 +852,12 @@ function App() {
       // still exports on its own.
       const assembled = await assembleBasicLetter(pdfBytes, currentStore.docType, currentStore.formData);
       pdfBytes = assembled.pdfBytes;
-      if (assembled.error) {
-        setEnclosureErrors([basicLetterError(assembled.error)]);
-        setShowEnclosureErrors(true);
-      }
+      // Accumulate export problems across BOTH stages and set state once — a
+      // second setEnclosureErrors used to overwrite the basic-letter entry
+      // whenever the enclosure merge also had errors.
+      const exportErrors: EnclosureError[] = assembled.error
+        ? [basicLetterError(assembled.error)]
+        : [];
       // Merge enclosures and/or create hyperlinks (handles both PDF and text-only enclosures, and reference URLs)
       let lastBasicPageIndex: number | undefined;
       if (generatedEnclosures.length > 0 || (includeHyperlinks && referenceUrls.length > 0)) {
@@ -866,12 +866,12 @@ function App() {
         const mergeResult = await mergeEnclosures(pdfBytes, generatedEnclosures, classification, includeHyperlinks, referenceUrls);
         pdfBytes = mergeResult.pdfBytes;
         lastBasicPageIndex = mergeResult.basicPageCount !== undefined ? mergeResult.basicPageCount - 1 : undefined;
-
-        // Track enclosure errors for user notification (download context)
-        if (mergeResult.hasErrors) {
-          setEnclosureErrors(mergeResult.errors);
-          setShowEnclosureErrors(true);
-        }
+        if (mergeResult.hasErrors) exportErrors.push(...mergeResult.errors);
+      }
+      // Track export errors for user notification (download context)
+      if (exportErrors.length > 0) {
+        setEnclosureErrors(exportErrors);
+        setShowEnclosureErrors(true);
       }
 
       // Add digital signature field if requested
@@ -1071,10 +1071,11 @@ function App() {
       // download path above); surface a bad upload rather than dropping it.
       const assembled = await assembleBasicLetter(pdfBytes, currentStore.docType, currentStore.formData);
       pdfBytes = assembled.pdfBytes;
-      if (assembled.error) {
-        setEnclosureErrors([basicLetterError(assembled.error)]);
-        setShowEnclosureErrors(true);
-      }
+      // Same accumulate-then-set as the primary download path: the enclosure
+      // merge's errors must not overwrite the basic-letter entry.
+      const exportErrors: EnclosureError[] = assembled.error
+        ? [basicLetterError(assembled.error)]
+        : [];
       let lastBasicPageIndex: number | undefined;
       if (enclosures.length > 0 || (includeHyperlinks && referenceUrls.length > 0)) {
         onProgress?.({ kind: 'pdf-merging-enclosures' });
@@ -1082,12 +1083,12 @@ function App() {
         const mergeResult = await mergeEnclosures(pdfBytes, enclosures, classification, includeHyperlinks, referenceUrls);
         pdfBytes = mergeResult.pdfBytes;
         lastBasicPageIndex = mergeResult.basicPageCount !== undefined ? mergeResult.basicPageCount - 1 : undefined;
-
-        // Track enclosure errors for user notification (PII download context)
-        if (mergeResult.hasErrors) {
-          setEnclosureErrors(mergeResult.errors);
-          setShowEnclosureErrors(true);
-        }
+        if (mergeResult.hasErrors) exportErrors.push(...mergeResult.errors);
+      }
+      // Track export errors for user notification (PII download context)
+      if (exportErrors.length > 0) {
+        setEnclosureErrors(exportErrors);
+        setShowEnclosureErrors(true);
       }
 
       // Add digital signature field if requested

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,12 +93,41 @@ import { generateNavmc11811Pdf, loadNavmc11811Template } from '@/services/pdf/na
 import { applyPlaceholdersToNavmc11811, buildNavmc11811DefaultValues } from '@/lib/placeholders';
 import { mergeEnclosures } from '@/services/pdf/mergeEnclosures';
 import type { ClassificationInfo, EnclosureError } from '@/services/pdf/mergeEnclosures';
+import { assembleEndorsement } from '@/services/pdf/assembleEndorsement';
+import { isEndorsement } from '@/lib/endorsement';
 import { addSignatureField, addDualSignatureFields, type DualSignatureFieldConfig, type SignatureFieldConfig } from '@/services/pdf/addSignatureField';
 import { DOC_TYPE_CONFIG, type DocumentData } from '@/types/document';
 import { detectPII, type PIIDetectionResult } from '@/services/pii/detector';
 import { downloadPdfBlob, preOpenWindowForIOS } from '@/utils/downloadPdf';
 
 // Helper to get classification marking for enclosures
+/**
+ * Assemble the uploaded basic letter ahead of a compiled endorsement, so the
+ * exported PDF is the letter followed by the endorsement (SECNAV M-5216.5 Ch 9
+ * Fig 9-3). A no-op for non-endorsements or when no basic-letter PDF is
+ * attached. Runs before the enclosure merge, so `mergeEnclosures` treats the
+ * combined [letter + endorsement] as the main document and the signature-field
+ * placement (`basicPageCount - 1`) still lands on the endorsement's last page.
+ * On a bad upload it returns the endorsement unchanged plus an error for the
+ * caller to surface — never a silently dropped export.
+ */
+async function assembleBasicLetter(
+  pdfBytes: Uint8Array,
+  docType: string,
+  formData: Partial<DocumentData>
+): Promise<{ pdfBytes: Uint8Array; error?: string }> {
+  const data = formData.basicLetterFile?.data;
+  if (!isEndorsement(docType) || !data) return { pdfBytes };
+  const result = await assembleEndorsement(pdfBytes, data);
+  return result.ok ? { pdfBytes: result.pdfBytes } : { pdfBytes, error: result.error };
+}
+
+/** An EnclosureError-shaped entry so a failed basic-letter assembly surfaces in
+ *  the same modal the enclosure merge uses. */
+function basicLetterError(error: string): EnclosureError {
+  return { enclosureNumber: 0, title: 'Basic letter', error };
+}
+
 function getClassificationInfo(
   classLevel: string | undefined,
   customClassification?: string
@@ -498,7 +527,11 @@ function App() {
   const enhancePreviewPdf = useCallback(
     async (pdfBytes: Uint8Array, currentStore: ReturnType<typeof useDocumentStore.getState>): Promise<Uint8Array> => {
       const { enclosures: generatedEnclosures, includeHyperlinks, referenceUrls } = generateAllLatexFiles(currentStore);
-      let out = pdfBytes;
+      // Assemble the basic letter ahead of the endorsement first, so the
+      // preview shows the real artifact and the enclosure merge below runs on
+      // the combined document. Preview silently falls back to the endorsement
+      // alone on a bad upload — the download path is where the error surfaces.
+      let out = (await assembleBasicLetter(pdfBytes, currentStore.docType, currentStore.formData)).pdfBytes;
       let lastBasicPageIndex: number | undefined;
       if (generatedEnclosures.length > 0 || (includeHyperlinks && referenceUrls.length > 0)) {
         const classification = getClassificationInfo(currentStore.formData.classLevel);
@@ -560,7 +593,10 @@ function App() {
         const hasEnhancements =
           generatedEnclosures.length > 0 ||
           (includeHyperlinks && referenceUrls.length > 0) ||
-          currentStore.formData.signatureType === 'digital';
+          currentStore.formData.signatureType === 'digital' ||
+          // A basic-letter PDF assembles ahead of the endorsement in
+          // enhancePreviewPdf, so the preview must run that pass to show it.
+          (isEndorsement(currentStore.docType) && !!currentStore.formData.basicLetterFile?.data);
         const basePdfBytes = pdfBytes;
 
         // fullQualityPreview runs the full pipeline inline. When off (default),
@@ -809,6 +845,15 @@ function App() {
     let pdfBytes = await compile(files);
 
     if (pdfBytes) {
+      // Assemble the basic letter ahead of the endorsement before merging
+      // enclosures. A bad upload is surfaced (not dropped) and the endorsement
+      // still exports on its own.
+      const assembled = await assembleBasicLetter(pdfBytes, currentStore.docType, currentStore.formData);
+      pdfBytes = assembled.pdfBytes;
+      if (assembled.error) {
+        setEnclosureErrors([basicLetterError(assembled.error)]);
+        setShowEnclosureErrors(true);
+      }
       // Merge enclosures and/or create hyperlinks (handles both PDF and text-only enclosures, and reference URLs)
       let lastBasicPageIndex: number | undefined;
       if (generatedEnclosures.length > 0 || (includeHyperlinks && referenceUrls.length > 0)) {
@@ -1018,6 +1063,14 @@ function App() {
     let pdfBytes = await compile(files);
 
     if (pdfBytes) {
+      // Assemble the basic letter ahead of the endorsement (see the primary
+      // download path above); surface a bad upload rather than dropping it.
+      const assembled = await assembleBasicLetter(pdfBytes, currentStore.docType, currentStore.formData);
+      pdfBytes = assembled.pdfBytes;
+      if (assembled.error) {
+        setEnclosureErrors([basicLetterError(assembled.error)]);
+        setShowEnclosureErrors(true);
+      }
       let lastBasicPageIndex: number | undefined;
       if (enclosures.length > 0 || (includeHyperlinks && referenceUrls.length > 0)) {
         onProgress?.({ kind: 'pdf-merging-enclosures' });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,8 +102,9 @@ import { downloadPdfBlob, preOpenWindowForIOS } from '@/utils/downloadPdf';
 // Helper to get classification marking for enclosures
 /**
  * Assemble the uploaded basic letter ahead of a compiled endorsement, so the
- * exported PDF is the letter followed by the endorsement (SECNAV M-5216.5 Ch 9
- * Fig 9-3). A no-op for non-endorsements or when no basic-letter PDF is
+ * exported PDF is the letter followed by the endorsement (SECNAV M-5216.5 Ch 9:
+ * the endorsement continues the basic letter's page numbers, so the letter
+ * reads first). A no-op for non-endorsements or when no basic-letter PDF is
  * attached. Runs before the enclosure merge, so `mergeEnclosures` treats the
  * combined [letter + endorsement] as the main document and the signature-field
  * placement (`basicPageCount - 1`) still lands on the endorsement's last page.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,7 +94,6 @@ import { applyPlaceholdersToNavmc11811, buildNavmc11811DefaultValues } from '@/l
 import { mergeEnclosures } from '@/services/pdf/mergeEnclosures';
 import type { ClassificationInfo, EnclosureError } from '@/services/pdf/mergeEnclosures';
 import { assembleEndorsement } from '@/services/pdf/assembleEndorsement';
-import { isEndorsement } from '@/lib/endorsement';
 import { addSignatureField, addDualSignatureFields, type DualSignatureFieldConfig, type SignatureFieldConfig } from '@/services/pdf/addSignatureField';
 import { DOC_TYPE_CONFIG, type DocumentData } from '@/types/document';
 import { detectPII, type PIIDetectionResult } from '@/services/pii/detector';
@@ -117,7 +116,11 @@ async function assembleBasicLetter(
   formData: Partial<DocumentData>
 ): Promise<{ pdfBytes: Uint8Array; error?: string }> {
   const data = formData.basicLetterFile?.data;
-  if (!isEndorsement(docType) || !data) return { pdfBytes };
+  // New-page only: assembly puts the endorsement on its own page after the
+  // letter, which is a new-page endorsement. A same-page endorsement is meant to
+  // sit on the letter's signature page (which DonDocs can't do with an uploaded
+  // PDF), so it never assembles even if a stale file is attached.
+  if (docType !== 'new_page_endorsement' || !data) return { pdfBytes };
   const result = await assembleEndorsement(pdfBytes, data);
   return result.ok ? { pdfBytes: result.pdfBytes } : { pdfBytes, error: result.error };
 }
@@ -595,8 +598,8 @@ function App() {
           (includeHyperlinks && referenceUrls.length > 0) ||
           currentStore.formData.signatureType === 'digital' ||
           // A basic-letter PDF assembles ahead of the endorsement in
-          // enhancePreviewPdf, so the preview must run that pass to show it.
-          (isEndorsement(currentStore.docType) && !!currentStore.formData.basicLetterFile?.data);
+          // enhancePreviewPdf (new-page only), so the preview must run that pass.
+          (currentStore.docType === 'new_page_endorsement' && !!currentStore.formData.basicLetterFile?.data);
         const basePdfBytes = pdfBytes;
 
         // fullQualityPreview runs the full pipeline inline. When off (default),

--- a/src/components/editor/EndorsementBasicLetterSection.tsx
+++ b/src/components/editor/EndorsementBasicLetterSection.tsx
@@ -163,11 +163,12 @@ export function EndorsementBasicLetterSection() {
         <AccordionTrigger>Basic Letter</AccordionTrigger>
         <AccordionContent>
           <div className="space-y-4 pt-2">
-            {/* Upload the basic letter's PDF — new-page endorsements only, since
-                assembly puts the endorsement on its own page after the letter
-                (Ch 9). A same-page endorsement sits on the letter's signature
-                page and shows metadata fields only. */}
-            {isNewPage && (
+            {/* Upload the basic letter's PDF — the UPLOAD affordance is new-page
+                only, since assembly puts the endorsement on its own page after
+                the letter (Ch 9). But an already-attached file always shows its
+                chip: hiding it on a doc-type switch left an invisible,
+                unremovable attachment. */}
+            {(isNewPage || basicLetterFile) && (
             <div className="space-y-2">
               <Label>The basic letter (PDF)</Label>
               {basicLetterFile ? (
@@ -207,18 +208,26 @@ export function EndorsementBasicLetterSection() {
                   Couldn&apos;t read that PDF: {uploadError}
                 </p>
               )}
-              <p className="text-xs text-muted-foreground">
-                The pages get assembled ahead of your endorsement in the exported
-                PDF (SECNAV M-5216.5 Ch 9). PDF export only — the Word file
-                contains the endorsement alone.
-              </p>
+              {isNewPage ? (
+                <p className="text-xs text-muted-foreground">
+                  The pages get assembled ahead of your endorsement in the exported
+                  PDF (SECNAV M-5216.5 Ch 9). PDF export only — the Word file
+                  contains the endorsement alone.
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  A same-page endorsement doesn&apos;t use an uploaded letter — it is
+                  typed onto the letter&apos;s own signature page. Switch to a
+                  New-Page Endorsement to assemble this file, or remove it.
+                </p>
+              )}
             </div>
             )}
 
             {/* Autofill the metadata fields below from a saved DonDocs letter.
                 This fills the ID / subject / references — it does not attach the
-                letter's pages (that's the PDF upload above, or below for a
-                same-page endorsement). */}
+                letter's pages (that's what the PDF upload on a new-page
+                endorsement is for). */}
             <div className="space-y-2">
               <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
                 <PopoverTrigger asChild>

--- a/src/components/editor/EndorsementBasicLetterSection.tsx
+++ b/src/components/editor/EndorsementBasicLetterSection.tsx
@@ -1,8 +1,10 @@
-import { useMemo, useState } from 'react';
-import { FileStack, Search, X } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import { FileStack, Search, Upload, X } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
+import { persistAttachment } from '@/lib/attachments';
+import { formatFileSize } from '@/lib/utils';
 import {
   Select,
   SelectContent,
@@ -114,12 +116,78 @@ export function EndorsementBasicLetterSection() {
     setQuery('');
   };
 
+  // Upload the basic letter's PDF so the export can assemble it ahead of the
+  // endorsement (Ch 9 Fig 9-3). Bytes go to the attachments store — survive a
+  // reload, ride along in a backup — and only the fileRef is serialized.
+  const handleBasicLetterFile = useCallback(
+    async (file: File) => {
+      const data = await file.arrayBuffer();
+      const fileRef = await persistAttachment(
+        { name: file.name, size: file.size, type: file.type },
+        data
+      );
+      setField('basicLetterFile', { name: file.name, size: file.size, data });
+      setField('basicLetterFileRef', fileRef);
+    },
+    [setField]
+  );
+
+  const removeBasicLetterFile = useCallback(() => {
+    setField('basicLetterFile', undefined);
+    setField('basicLetterFileRef', undefined);
+  }, [setField]);
+
+  const basicLetterFile = formData.basicLetterFile;
+
   return (
     <Accordion type="single" collapsible defaultValue="basic">
       <AccordionItem value="basic">
         <AccordionTrigger>Basic Letter</AccordionTrigger>
         <AccordionContent>
           <div className="space-y-4 pt-2">
+            {/* Upload the basic letter's PDF. On export DonDocs assembles it
+                ahead of the endorsement (Ch 9 Fig 9-3, new-page assembly). */}
+            <div className="space-y-2">
+              <Label>Basic letter PDF</Label>
+              {basicLetterFile ? (
+                <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 p-2">
+                  <FileStack className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm text-foreground">{basicLetterFile.name}</p>
+                    <p className="text-xs text-muted-foreground">{formatFileSize(basicLetterFile.size)}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={removeBasicLetterFile}
+                    aria-label="Remove basic-letter PDF"
+                    className="shrink-0 rounded p-1 text-muted-foreground outline-none hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ) : (
+                <label className="flex cursor-pointer items-center gap-2 rounded border border-dashed border-border p-2 transition-colors hover:bg-secondary/30">
+                  <Upload className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">Upload the letter you&apos;re endorsing (optional)</span>
+                  <input
+                    type="file"
+                    accept=".pdf,application/pdf"
+                    className="hidden"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) void handleBasicLetterFile(file);
+                      e.target.value = '';
+                    }}
+                  />
+                </label>
+              )}
+              <p className="text-xs text-muted-foreground">
+                Assembled ahead of your endorsement in the exported PDF (SECNAV
+                M-5216.5 Ch 9, Fig 9-3). PDF export only — the Word file contains
+                the endorsement alone.
+              </p>
+            </div>
+
             {/* Base this endorsement on a saved correspondence document. */}
             <div className="space-y-2">
               <Popover open={pickerOpen} onOpenChange={setPickerOpen}>

--- a/src/components/editor/EndorsementBasicLetterSection.tsx
+++ b/src/components/editor/EndorsementBasicLetterSection.tsx
@@ -122,8 +122,9 @@ export function EndorsementBasicLetterSection() {
   };
 
   // Upload the basic letter's PDF so the export can assemble it ahead of the
-  // endorsement (Ch 9 Fig 9-3). Bytes go to the attachments store — survive a
-  // reload, ride along in a backup — and only the fileRef is serialized.
+  // endorsement (Ch 9 — the endorsement continues the letter's page numbers).
+  // Bytes go to the attachments store — survive a reload, ride along in a
+  // backup — and only the fileRef is serialized.
   const handleBasicLetterFile = useCallback(
     async (file: File) => {
       const data = await file.arrayBuffer();
@@ -152,8 +153,8 @@ export function EndorsementBasicLetterSection() {
           <div className="space-y-4 pt-2">
             {/* Upload the basic letter's PDF — new-page endorsements only, since
                 assembly puts the endorsement on its own page after the letter
-                (Ch 9 Fig 9-3). A same-page endorsement sits on the letter's
-                signature page and shows metadata fields only. */}
+                (Ch 9). A same-page endorsement sits on the letter's signature
+                page and shows metadata fields only. */}
             {isNewPage && (
             <div className="space-y-2">
               <Label>The basic letter (PDF)</Label>
@@ -191,8 +192,8 @@ export function EndorsementBasicLetterSection() {
               )}
               <p className="text-xs text-muted-foreground">
                 The pages get assembled ahead of your endorsement in the exported
-                PDF (SECNAV M-5216.5 Ch 9, Fig 9-3). PDF export only — the Word
-                file contains the endorsement alone.
+                PDF (SECNAV M-5216.5 Ch 9). PDF export only — the Word file
+                contains the endorsement alone.
               </p>
             </div>
             )}

--- a/src/components/editor/EndorsementBasicLetterSection.tsx
+++ b/src/components/editor/EndorsementBasicLetterSection.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { persistAttachment } from '@/lib/attachments';
+import { validateBasicLetter } from '@/services/pdf/assembleEndorsement';
 import { formatFileSize } from '@/lib/utils';
 import {
   Select,
@@ -59,6 +60,7 @@ export function EndorsementBasicLetterSection() {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [applied, setApplied] = useState<AppliedSource | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
 
   // Correspondence documents (never this one, never forms), newest first.
   const candidates = useMemo(() => {
@@ -128,6 +130,15 @@ export function EndorsementBasicLetterSection() {
   const handleBasicLetterFile = useCallback(
     async (file: File) => {
       const data = await file.arrayBuffer();
+      // Validate before storing anything: a corrupt or encrypted PDF rejected
+      // here gets feedback next to the control, instead of persisting bad bytes
+      // that the preview silently skips and only the export reports.
+      const check = await validateBasicLetter(data);
+      if (!check.ok) {
+        setUploadError(check.error);
+        return;
+      }
+      setUploadError(null);
       const fileRef = await persistAttachment(
         { name: file.name, size: file.size, type: file.type },
         data
@@ -141,6 +152,7 @@ export function EndorsementBasicLetterSection() {
   const removeBasicLetterFile = useCallback(() => {
     setField('basicLetterFile', undefined);
     setField('basicLetterFileRef', undefined);
+    setUploadError(null);
   }, [setField]);
 
   const basicLetterFile = formData.basicLetterFile;
@@ -189,6 +201,11 @@ export function EndorsementBasicLetterSection() {
                     }}
                   />
                 </label>
+              )}
+              {uploadError && (
+                <p role="alert" className="text-xs text-destructive">
+                  Couldn&apos;t read that PDF: {uploadError}
+                </p>
               )}
               <p className="text-xs text-muted-foreground">
                 The pages get assembled ahead of your endorsement in the exported

--- a/src/components/editor/EndorsementBasicLetterSection.tsx
+++ b/src/components/editor/EndorsementBasicLetterSection.tsx
@@ -46,6 +46,11 @@ interface AppliedSource {
  */
 export function EndorsementBasicLetterSection() {
   const { formData, setField } = useDocumentStore();
+  const docType = useDocumentStore((s) => s.docType);
+  // Assembly puts the endorsement on its own page after the letter — a new-page
+  // endorsement. A same-page endorsement sits on the letter's signature page, so
+  // uploading a letter to assemble only makes sense for new-page.
+  const isNewPage = docType === 'new_page_endorsement';
   const addReference = useDocumentStore((s) => s.addReference);
   const addEnclosure = useDocumentStore((s) => s.addEnclosure);
   const docs = useDocumentsStore((s) => s.docs);
@@ -145,10 +150,13 @@ export function EndorsementBasicLetterSection() {
         <AccordionTrigger>Basic Letter</AccordionTrigger>
         <AccordionContent>
           <div className="space-y-4 pt-2">
-            {/* Upload the basic letter's PDF. On export DonDocs assembles it
-                ahead of the endorsement (Ch 9 Fig 9-3, new-page assembly). */}
+            {/* Upload the basic letter's PDF — new-page endorsements only, since
+                assembly puts the endorsement on its own page after the letter
+                (Ch 9 Fig 9-3). A same-page endorsement sits on the letter's
+                signature page and shows metadata fields only. */}
+            {isNewPage && (
             <div className="space-y-2">
-              <Label>Basic letter PDF</Label>
+              <Label>The basic letter (PDF)</Label>
               {basicLetterFile ? (
                 <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 p-2">
                   <FileStack className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -182,19 +190,23 @@ export function EndorsementBasicLetterSection() {
                 </label>
               )}
               <p className="text-xs text-muted-foreground">
-                Assembled ahead of your endorsement in the exported PDF (SECNAV
-                M-5216.5 Ch 9, Fig 9-3). PDF export only — the Word file contains
-                the endorsement alone.
+                The pages get assembled ahead of your endorsement in the exported
+                PDF (SECNAV M-5216.5 Ch 9, Fig 9-3). PDF export only — the Word
+                file contains the endorsement alone.
               </p>
             </div>
+            )}
 
-            {/* Base this endorsement on a saved correspondence document. */}
+            {/* Autofill the metadata fields below from a saved DonDocs letter.
+                This fills the ID / subject / references — it does not attach the
+                letter's pages (that's the PDF upload above, or below for a
+                same-page endorsement). */}
             <div className="space-y-2">
               <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
                 <PopoverTrigger asChild>
                   <Button variant="outline" size="sm" className="w-full justify-start">
                     <FileStack className="mr-2 h-4 w-4" />
-                    Base on a saved letter…
+                    Autofill from a saved letter…
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent align="start" className="w-[22rem] p-0">

--- a/src/components/modals/EnclosureErrorModal.tsx
+++ b/src/components/modals/EnclosureErrorModal.tsx
@@ -28,19 +28,29 @@ interface EnclosureErrorModalProps {
 export function EnclosureErrorModal({ errors, open, onClose }: EnclosureErrorModalProps) {
   if (errors.length === 0) return null;
 
+  // A failed basic-letter assembly (endorsements) is not an enclosure: it gets
+  // no placeholder page — the letter is simply absent from the export — so the
+  // copy must not claim otherwise.
+  const enclosureCount = errors.filter((e) => e.kind !== 'basicLetter').length;
+  const hasBasicLetter = errors.some((e) => e.kind === 'basicLetter');
+
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-warning">
             <AlertTriangle className="h-5 w-5" />
-            Enclosure Warning{errors.length > 1 ? 's' : ''}
+            {enclosureCount > 0 && hasBasicLetter
+              ? 'Export Warnings'
+              : hasBasicLetter
+                ? 'Basic Letter Warning'
+                : `Enclosure Warning${errors.length > 1 ? 's' : ''}`}
           </DialogTitle>
           <DialogDescription>
-            {errors.length === 1
-              ? 'One enclosure could not be fully processed.'
-              : `${errors.length} enclosures could not be fully processed.`}
-            {' '}The PDF was generated with placeholder pages for the affected enclosures.
+            {hasBasicLetter &&
+              'The basic letter could not be read, so the PDF contains the endorsement alone — without the letter ahead of it. '}
+            {enclosureCount > 0 &&
+              `${enclosureCount === 1 ? 'One enclosure' : `${enclosureCount} enclosures`} could not be fully processed; the PDF was generated with placeholder pages for the affected enclosures.`}
           </DialogDescription>
         </DialogHeader>
 
@@ -50,7 +60,9 @@ export function EnclosureErrorModal({ errors, open, onClose }: EnclosureErrorMod
               <FileWarning className="h-5 w-5 text-warning flex-shrink-0 mt-0.5" />
               <div className="flex-1 min-w-0">
                 <div className="font-medium text-sm text-foreground">
-                  Enclosure ({error.enclosureNumber}): {error.title}
+                  {error.kind === 'basicLetter'
+                    ? 'Basic letter (not assembled)'
+                    : `Enclosure (${error.enclosureNumber}): ${error.title}`}
                 </div>
                 <div className="text-xs text-muted-foreground mt-1 break-words">
                   {error.error}

--- a/src/lib/attachmentGc.ts
+++ b/src/lib/attachmentGc.ts
@@ -46,8 +46,13 @@ import { getPendingDeleteSessions, useDocumentsStore } from '@/stores/documentsS
 import { isRestoreInProgress } from '@/lib/backup';
 import { debug } from '@/lib/debug';
 
-/** Every enclosure `fileRef.id` in one session, added to `into`. */
+/** Every enclosure `fileRef.id` plus the basic-letter ref in one session. */
 function collectSessionRefs(session: SerializedSession | undefined, into: Set<string>): void {
+  // An endorsement's basic-letter PDF is stored as an attachment; keep it
+  // reachable so the GC doesn't sweep it out from under a saved endorsement.
+  const blId = session?.formData?.basicLetterFileRef?.id;
+  if (typeof blId === 'string' && blId) into.add(blId);
+
   const enclosures = session?.enclosures;
   if (!Array.isArray(enclosures)) return;
   for (const enc of enclosures) {

--- a/src/lib/attachmentGc.ts
+++ b/src/lib/attachmentGc.ts
@@ -98,9 +98,14 @@ export async function collectLiveAttachmentIds(): Promise<Set<string> | null> {
   }
 
   // (c) the live in-memory session — a just-attached blob lives here before its
-  // debounced document save reaches the registry.
+  // debounced document save reaches the registry. formData must ride along:
+  // an endorsement's just-uploaded basic letter is referenced only by
+  // formData.basicLetterFileRef, and omitting it left a ~2s window where any
+  // sweep (e.g. finalizePurge after a document delete) reaped the letter's
+  // bytes before the save made them reachable.
+  const liveState = useDocumentStore.getState();
   collectSessionRefs(
-    { enclosures: useDocumentStore.getState().enclosures } as SerializedSession,
+    { enclosures: liveState.enclosures, formData: liveState.formData } as SerializedSession,
     live
   );
 

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -119,12 +119,17 @@ export function mergeById<T extends { id: string }>(
 export function collectAttachmentIds(docs: unknown[]): string[] {
   const ids = new Set<string>();
   for (const doc of docs) {
-    const enclosures = (doc as { session?: { enclosures?: unknown } })?.session?.enclosures;
-    if (!Array.isArray(enclosures)) continue;
-    for (const enc of enclosures) {
-      const id = (enc as { fileRef?: { id?: unknown } })?.fileRef?.id;
-      if (typeof id === 'string' && id) ids.add(id);
+    const session = (doc as { session?: { enclosures?: unknown; formData?: { basicLetterFileRef?: { id?: unknown } } } })?.session;
+    const enclosures = session?.enclosures;
+    if (Array.isArray(enclosures)) {
+      for (const enc of enclosures) {
+        const id = (enc as { fileRef?: { id?: unknown } })?.fileRef?.id;
+        if (typeof id === 'string' && id) ids.add(id);
+      }
     }
+    // An endorsement's basic-letter PDF is an attachment too — embed its bytes.
+    const blId = session?.formData?.basicLetterFileRef?.id;
+    if (typeof blId === 'string' && blId) ids.add(blId);
   }
   return [...ids];
 }

--- a/src/services/pdf/assembleEndorsement.ts
+++ b/src/services/pdf/assembleEndorsement.ts
@@ -1,0 +1,98 @@
+import { PDFDocument, PDFName } from 'pdf-lib';
+import { debug } from '@/lib/debug';
+
+/**
+ * Assemble an endorsement onto the basic letter it endorses.
+ *
+ * An endorsement is written on correspondence that comes up the chain: you
+ * receive a letter, endorse it, and forward the assembly. SECNAV M-5216.5 Ch 9
+ * Fig 9-3 ("Assembly of an Endorsement") is the basic letter followed by the
+ * endorsement — which is what this produces: the uploaded letter's pages first,
+ * the generated endorsement after.
+ *
+ * New-page only, by design. Ch 9 ¶1 makes a new-page endorsement always valid
+ * ("If not, use a new-page endorsement"); same-page is the optional space-saver.
+ * DonDocs cannot reliably place text on the signature page of a letter it did
+ * not generate, so it does not try — it appends the endorsement on its own
+ * page(s), which is always correct.
+ */
+
+export interface AssembleResult {
+  /** The combined PDF: basic-letter pages, then endorsement pages. */
+  pdfBytes: Uint8Array;
+  /** How many pages the basic letter contributed (endorsement starts after). */
+  basicLetterPageCount: number;
+  ok: true;
+}
+
+export interface AssembleFailure {
+  /** The endorsement unchanged — never a silently dropped export. */
+  pdfBytes: Uint8Array;
+  ok: false;
+  /** Human-readable reason the upload could not be assembled. */
+  error: string;
+}
+
+function toUint8(data: Uint8Array | ArrayBuffer): Uint8Array {
+  return data instanceof Uint8Array ? data : new Uint8Array(data);
+}
+
+/**
+ * Validate the uploaded basic letter enough to embed it. Mirrors the check
+ * mergeEnclosures runs on enclosure PDFs: it must load, have pages, and every
+ * page must carry a content stream (an empty page cannot be copied).
+ */
+async function loadBasicLetter(
+  data: Uint8Array | ArrayBuffer
+): Promise<{ pdf: PDFDocument } | { error: string }> {
+  try {
+    // ignoreEncryption matches the enclosure path — a permissions-only password
+    // (common on official PDFs) still copies; a truly encrypted body throws.
+    const pdf = await PDFDocument.load(toUint8(data), { ignoreEncryption: true });
+    const pageCount = pdf.getPageCount();
+    if (pageCount === 0) return { error: 'The basic-letter PDF has no pages.' };
+    for (let i = 0; i < pageCount; i++) {
+      const contents = pdf.getPage(i).node.get(PDFName.of('Contents'));
+      if (!contents) {
+        return { error: `Page ${i + 1} of the basic letter is empty or corrupted.` };
+      }
+    }
+    return { pdf };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'The basic-letter PDF could not be read.' };
+  }
+}
+
+/**
+ * Prepend the basic letter to the endorsement. On any problem with the upload,
+ * returns the endorsement unchanged with `ok: false` and a reason — the caller
+ * surfaces it rather than shipping a half-assembled or silently dropped export.
+ */
+export async function assembleEndorsement(
+  endorsementPdfBytes: Uint8Array,
+  basicLetterData: Uint8Array | ArrayBuffer
+): Promise<AssembleResult | AssembleFailure> {
+  const basic = await loadBasicLetter(basicLetterData);
+  if ('error' in basic) {
+    debug.error('AssembleEndorsement', 'Basic letter rejected:', basic.error);
+    return { pdfBytes: endorsementPdfBytes, ok: false, error: basic.error };
+  }
+
+  try {
+    const endorsement = await PDFDocument.load(endorsementPdfBytes);
+    const out = await PDFDocument.create();
+
+    const basicPages = await out.copyPages(basic.pdf, basic.pdf.getPageIndices());
+    for (const page of basicPages) out.addPage(page);
+
+    const endorsementPages = await out.copyPages(endorsement, endorsement.getPageIndices());
+    for (const page of endorsementPages) out.addPage(page);
+
+    const pdfBytes = await out.save();
+    return { pdfBytes, basicLetterPageCount: basic.pdf.getPageCount(), ok: true };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : 'Assembly failed.';
+    debug.error('AssembleEndorsement', 'Assembly failed:', error);
+    return { pdfBytes: endorsementPdfBytes, ok: false, error };
+  }
+}

--- a/src/services/pdf/assembleEndorsement.ts
+++ b/src/services/pdf/assembleEndorsement.ts
@@ -24,6 +24,21 @@ import { debug } from '@/lib/debug';
  * page(s), which is always correct.
  */
 
+/**
+ * The export/preview gate, extracted so it is testable on its own: assemble
+ * only for a new-page endorsement with a letter actually attached. A same-page
+ * endorsement is typed onto the letter's own signature page — assembly (which
+ * appends the endorsement on its own page) would silently turn it into a
+ * new-page document — and a stale attachment on any other doc type must never
+ * assemble either.
+ */
+export function shouldAssembleBasicLetter(
+  docType: string,
+  formData: { basicLetterFile?: { data: ArrayBuffer } } | undefined
+): boolean {
+  return docType === 'new_page_endorsement' && !!formData?.basicLetterFile?.data;
+}
+
 export interface AssembleResult {
   /** The combined PDF: basic-letter pages, then endorsement pages. */
   pdfBytes: Uint8Array;
@@ -55,9 +70,21 @@ export async function validateBasicLetter(
   data: Uint8Array | ArrayBuffer
 ): Promise<{ ok: true; pageCount: number } | { ok: false; error: string }> {
   const result = await loadBasicLetter(data);
-  return 'error' in result
-    ? { ok: false, error: result.error }
-    : { ok: true, pageCount: result.pdf.getPageCount() };
+  if ('error' in result) return { ok: false, error: result.error };
+  // Dry-run the actual operation assembly performs: loading tolerates an
+  // encrypted body (ignoreEncryption), but copyPages on one throws — without
+  // this, such a file passed attach validation, silently vanished from every
+  // preview, and only failed at export.
+  try {
+    const scratch = await PDFDocument.create();
+    await scratch.copyPages(result.pdf, result.pdf.getPageIndices());
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : 'The PDF’s pages could not be copied (it may be encrypted).',
+    };
+  }
+  return { ok: true, pageCount: result.pdf.getPageCount() };
 }
 
 /**

--- a/src/services/pdf/assembleEndorsement.ts
+++ b/src/services/pdf/assembleEndorsement.ts
@@ -45,6 +45,22 @@ function toUint8(data: Uint8Array | ArrayBuffer): Uint8Array {
 }
 
 /**
+ * Validate an uploaded basic letter without assembling it — run at attach time
+ * so a corrupt or encrypted PDF is rejected with feedback right in the form,
+ * instead of being stored and only failing at export. (The preview deliberately
+ * falls back silently on a bad letter to avoid a modal per recompile, so attach
+ * is the one place the user reliably sees the problem.)
+ */
+export async function validateBasicLetter(
+  data: Uint8Array | ArrayBuffer
+): Promise<{ ok: true; pageCount: number } | { ok: false; error: string }> {
+  const result = await loadBasicLetter(data);
+  return 'error' in result
+    ? { ok: false, error: result.error }
+    : { ok: true, pageCount: result.pdf.getPageCount() };
+}
+
+/**
  * Validate the uploaded basic letter enough to embed it. Mirrors the check
  * mergeEnclosures runs on enclosure PDFs: it must load, have pages, and every
  * page must carry a content stream (an empty page cannot be copied).

--- a/src/services/pdf/assembleEndorsement.ts
+++ b/src/services/pdf/assembleEndorsement.ts
@@ -5,10 +5,17 @@ import { debug } from '@/lib/debug';
  * Assemble an endorsement onto the basic letter it endorses.
  *
  * An endorsement is written on correspondence that comes up the chain: you
- * receive a letter, endorse it, and forward the assembly. SECNAV M-5216.5 Ch 9
- * Fig 9-3 ("Assembly of an Endorsement") is the basic letter followed by the
- * endorsement — which is what this produces: the uploaded letter's pages first,
- * the generated endorsement after.
+ * receive a letter, endorse it, and forward the assembly. The letter's pages
+ * come first, the endorsement after — because a new-page endorsement's pages
+ * "continue the sequence of numbers from ... the basic letter" (SECNAV M-5216.5
+ * Ch 9, Fig 9-2 body): the letter is pages 1..N and the endorsement N+1, which
+ * only reads correctly with the letter physically first.
+ *
+ * (Fig 9-3, "Assembly of an Endorsement", is a *suggested* physical routing
+ * stack — envelopes, file copies, via copies — and it places the current
+ * endorsement on top of the basic letter. That is a mailing/filing convenience
+ * for a stack of loose papers, not the pagination of a single bound PDF, so it
+ * does not govern the page order here.)
  *
  * New-page only, by design. Ch 9 ¶1 makes a new-page endorsement always valid
  * ("If not, use a new-page endorsement"); same-page is the optional space-saver.

--- a/src/services/pdf/mergeEnclosures.ts
+++ b/src/services/pdf/mergeEnclosures.ts
@@ -18,6 +18,10 @@ export interface EnclosureError {
   error: string;
   pagesFailed?: number; // Number of pages that failed (if partial failure)
   pagesSucceeded?: number; // Number of pages that succeeded
+  /** Distinguishes a failed basic-letter assembly (endorsements) from a failed
+   *  enclosure: the modal copy differs — an enclosure gets a placeholder page,
+   *  an unassembled basic letter is simply absent from the export. */
+  kind?: 'enclosure' | 'basicLetter';
 }
 
 export interface MergeResult {

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -657,6 +657,17 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
     useUIStore.getState().setValidationVisible(false);
     set((state) => {
       const formData = data.formData ? { ...state.formData, ...data.formData } : state.formData;
+      // A template describes a document; it never carries an uploaded basic
+      // letter. Without this, spreading the old formData stapled the previous
+      // document's letter onto whatever loads next. Keyed on the REF, not the
+      // bytes: this same path restores saved drafts, whose sessions serialize
+      // basicLetterFileRef with the bytes stripped — those must keep their ref
+      // (rehydrate brings the bytes back). Only an incoming formData with no
+      // ref at all means "no letter belongs here".
+      if (data.formData && !('basicLetterFileRef' in data.formData)) {
+        delete formData.basicLetterFile;
+        delete formData.basicLetterFileRef;
+      }
       return {
         paragraphs: data.paragraphs ? migratePortionMarkings(data.paragraphs) : state.paragraphs,
         // Re-letter against the incoming start so a loaded endorsement keeps
@@ -1026,7 +1037,13 @@ export async function rehydrateEnclosureFiles(): Promise<void> {
   if (blRef && !useDocumentStore.getState().formData.basicLetterFile) {
     try {
       const data = await loadAttachment(blRef.id);
-      if (data && !useDocumentStore.getState().formData.basicLetterFile) {
+      // Re-check the ref IDENTITY after the await, not just absence of bytes:
+      // if the user removed the letter (or switched documents) while the load
+      // was in flight, both fields are cleared — grafting bytes back would
+      // resurrect a removed letter with no ref, which assembles into exports
+      // but never serializes. Same guard the enclosure path uses.
+      const current = useDocumentStore.getState().formData;
+      if (data && !current.basicLetterFile && current.basicLetterFileRef?.id === blRef.id) {
         useDocumentStore.setState((state) => ({
           formData: {
             ...state.formData,

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -949,6 +949,9 @@ export function serializeSession(state: DocumentState): SerializedSession {
     formData: {
       ...state.formData,
       signatureImage: undefined,
+      // Bytes live in the attachments store; keep only basicLetterFileRef so the
+      // serialized session stays light and JSON-safe (rehydrated on load).
+      basicLetterFile: undefined,
     },
     references: state.references,
     enclosures: state.enclosures.map(enc => ({
@@ -1015,6 +1018,27 @@ export function loadSharedSession(session: SerializedSession): void {
  * export (which reads `file.data`) can await a complete document.
  */
 export async function rehydrateEnclosureFiles(): Promise<void> {
+  // The endorsement's basic-letter PDF is stored the same way as an enclosure
+  // file (bytes in the attachments store, only the ref serialized), so reload it
+  // here too. Done first, before the enclosure early-return, so a basic letter
+  // is rehydrated even on an endorsement that has no enclosures.
+  const blRef = useDocumentStore.getState().formData.basicLetterFileRef;
+  if (blRef && !useDocumentStore.getState().formData.basicLetterFile) {
+    try {
+      const data = await loadAttachment(blRef.id);
+      if (data && !useDocumentStore.getState().formData.basicLetterFile) {
+        useDocumentStore.setState((state) => ({
+          formData: {
+            ...state.formData,
+            basicLetterFile: { name: blRef.name, size: blRef.size || data.byteLength, data },
+          },
+        }));
+      }
+    } catch (err) {
+      debug.error('Store', 'Failed to rehydrate basic-letter file', err);
+    }
+  }
+
   const pending = useDocumentStore
     .getState()
     .enclosures.filter((e) => e.fileRef && !e.file)

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -146,8 +146,9 @@ export interface DocumentData {
   basicLetterId?: string;
 
   // The basic letter this endorsement is written on, uploaded as a PDF so the
-  // exported endorsement can be assembled ahead of it (SECNAV M-5216.5 Ch 9
-  // Fig 9-3). Stored like an enclosure file: bytes live in the attachments
+  // exported endorsement can be assembled after it (SECNAV M-5216.5 Ch 9 — the
+  // endorsement continues the basic letter's page numbers, so the letter reads
+  // first). Stored like an enclosure file: bytes live in the attachments
   // store, only `basicLetterFileRef` is serialized, and `basicLetterFile.data`
   // is rehydrated from it on load. Endorsement doc types only.
   basicLetterFile?: {

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -145,6 +145,18 @@ export interface DocumentData {
   endorsementOrdinal?: string;
   basicLetterId?: string;
 
+  // The basic letter this endorsement is written on, uploaded as a PDF so the
+  // exported endorsement can be assembled ahead of it (SECNAV M-5216.5 Ch 9
+  // Fig 9-3). Stored like an enclosure file: bytes live in the attachments
+  // store, only `basicLetterFileRef` is serialized, and `basicLetterFile.data`
+  // is rehydrated from it on load. Endorsement doc types only.
+  basicLetterFile?: {
+    name: string;
+    size: number;
+    data: ArrayBuffer;
+  };
+  basicLetterFileRef?: FileRef;
+
   // Signature
   sigFirst: string;
   sigMiddle: string;

--- a/tests/integration/endorsement-assembly-render.test.ts
+++ b/tests/integration/endorsement-assembly-render.test.ts
@@ -1,7 +1,8 @@
 /**
  * The endorsement + basic-letter assembly, proved against a real compiled
  * endorsement (not a synthetic PDF) and a real basic letter: the letter's pages
- * come first, the endorsement after, on one PDF (SECNAV M-5216.5 Ch 9 Fig 9-3).
+ * come first, the endorsement after, on one PDF — a new-page endorsement
+ * continues the basic letter's page numbers (SECNAV M-5216.5 Ch 9).
  *
  * The unit test (tests/unit/assembleEndorsement.test.ts) pins the primitive on
  * pdf-lib fixtures; this compiles the endorsement DonDocs actually produces and

--- a/tests/integration/endorsement-assembly-render.test.ts
+++ b/tests/integration/endorsement-assembly-render.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The endorsement + basic-letter assembly, proved against a real compiled
+ * endorsement (not a synthetic PDF) and a real basic letter: the letter's pages
+ * come first, the endorsement after, on one PDF (SECNAV M-5216.5 Ch 9 Fig 9-3).
+ *
+ * The unit test (tests/unit/assembleEndorsement.test.ts) pins the primitive on
+ * pdf-lib fixtures; this compiles the endorsement DonDocs actually produces and
+ * reads the assembled pages off with pdftotext, so a real-world layout can't
+ * quietly break the order or lose a page.
+ *
+ * Requires pdflatex + pdftotext + pdfinfo; fails (not skips) in CI without them.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { writeFile, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
+import { compileFixture } from '../_helpers/compileLatex';
+import { assembleEndorsement } from '@/services/pdf/assembleEndorsement';
+import { hasPdfToolchain, describeToolchainRequirement } from '../_helpers/pdfToolchain';
+
+const toolchain = hasPdfToolchain;
+
+/** A basic letter whose pages each carry a findable marker word. */
+async function basicLetter(pages: number): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  for (let i = 1; i <= pages; i++) {
+    doc.addPage([612, 792]).drawText(`BASICLETTERPAGE${i}`, {
+      x: 72,
+      y: 700,
+      size: 18,
+      font,
+      color: rgb(0, 0, 0),
+    });
+  }
+  return doc.save();
+}
+
+const endorsementStore = {
+  docType: 'new_page_endorsement',
+  formData: {
+    docType: 'new_page_endorsement',
+    fontSize: '12pt',
+    fontFamily: 'times',
+    pageNumbering: 'none',
+    department: 'usmc',
+    unitLine1: '1ST BATTALION, 6TH MARINES',
+    unitLine2: '2D MARINE DIVISION, II MEF',
+    unitAddress: 'PSC BOX 20123, CAMP LEJEUNE, NC 28542-0123',
+    sealType: 'dow',
+    letterheadColor: 'blue',
+    ssic: '5216',
+    serial: '0123',
+    date: '15 Jan 25',
+    from: 'Commanding Officer, 1st Battalion, 6th Marines',
+    to: 'Commanding General, II MEF',
+    subject: 'APPOINTMENT AS MARINE SECURITY GUARD REPRESENTATIVE',
+    basicLetterId: 'CG II MEF ltr 5216 Ser 001 of 5 Jan 25',
+    endorsementOrdinal: 'FIRST',
+    sigFirst: 'Robert',
+    sigMiddle: 'L',
+    sigLast: 'SMITH',
+    classLevel: 'unclassified',
+  },
+  references: [],
+  enclosures: [],
+  paragraphs: [{ text: 'Forwarded, recommending approval.', level: 0 }],
+  copyTos: [],
+  distributions: [],
+} as never;
+
+describe('endorsement + basic-letter assembly — rendered PDF', () => {
+  describeToolchainRequirement('endorsement-assembly-render');
+
+  it.skipIf(!toolchain)('puts the basic letter first and the endorsement after', async () => {
+    const compiled = await compileFixture(endorsementStore);
+    expect(compiled.ok, `pdflatex failed; work dir: ${compiled.workDir}`).toBe(true);
+
+    const letter = await basicLetter(3);
+    const result = await assembleEndorsement(compiled.pdfBytes!, letter);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.basicLetterPageCount).toBe(3);
+
+    const dir = await mkdtemp(join(tmpdir(), 'dondocs-assembly-'));
+    const pdfPath = join(dir, 'out.pdf');
+    await writeFile(pdfPath, result.pdfBytes);
+
+    const pages = Number(
+      spawnSync('pdfinfo', [pdfPath], { encoding: 'utf-8' }).stdout.match(/Pages:\s+(\d+)/)?.[1]
+    );
+    // 3 letter pages + the compiled endorsement (>=1 page).
+    expect(pages).toBeGreaterThanOrEqual(4);
+
+    const { stdout } = spawnSync('pdftotext', ['-layout', pdfPath, '-'], { encoding: 'utf-8' });
+    expect(stdout.trim().length).toBeGreaterThan(0);
+
+    // The three letter markers precede the endorsement line, in order.
+    const idx = (needle: string) => stdout.indexOf(needle);
+    expect(idx('BASICLETTERPAGE1')).toBeGreaterThanOrEqual(0);
+    expect(idx('BASICLETTERPAGE1')).toBeLessThan(idx('BASICLETTERPAGE2'));
+    expect(idx('BASICLETTERPAGE2')).toBeLessThan(idx('BASICLETTERPAGE3'));
+    expect(idx('FIRST ENDORSEMENT')).toBeGreaterThan(idx('BASICLETTERPAGE3'));
+    expect(stdout).toMatch(/Forwarded, recommending approval\./);
+  });
+
+  it.skipIf(!toolchain)('leaves the endorsement alone when no letter is attached', async () => {
+    // The primitive is only invoked when a file is present; assembling with no
+    // basic letter is not a path — this guards the resolver's own gate instead.
+    const compiled = await compileFixture(endorsementStore);
+    expect(compiled.ok).toBe(true);
+    const dir = await mkdtemp(join(tmpdir(), 'dondocs-noassembly-'));
+    const p = join(dir, 'out.pdf');
+    await writeFile(p, compiled.pdfBytes!);
+    const { stdout } = spawnSync('pdftotext', [p, '-'], { encoding: 'utf-8' });
+    expect(stdout).toMatch(/FIRST ENDORSEMENT/);
+    expect(stdout).not.toMatch(/BASICLETTERPAGE/);
+  });
+});

--- a/tests/integration/endorsement-assembly-render.test.ts
+++ b/tests/integration/endorsement-assembly-render.test.ts
@@ -107,9 +107,10 @@ describe('endorsement + basic-letter assembly — rendered PDF', () => {
     expect(stdout).toMatch(/Forwarded, recommending approval\./);
   });
 
-  it.skipIf(!toolchain)('leaves the endorsement alone when no letter is attached', async () => {
-    // The primitive is only invoked when a file is present; assembling with no
-    // basic letter is not a path — this guards the resolver's own gate instead.
+  // The export gate itself (new-page + attached file only) is a pure function
+  // unit-tested in tests/unit/assembleEndorsement.test.ts; this render check
+  // only shows a letterless endorsement compiles to its own pages.
+  it.skipIf(!toolchain)('an endorsement with no letter compiles to its own pages only', async () => {
     const compiled = await compileFixture(endorsementStore);
     expect(compiled.ok).toBe(true);
     const dir = await mkdtemp(join(tmpdir(), 'dondocs-noassembly-'));

--- a/tests/unit/appendedEndorsement.test.ts
+++ b/tests/unit/appendedEndorsement.test.ts
@@ -150,7 +150,14 @@ describe('both generators emit the acknowledgement', () => {
   it('omits the serial row when hand-dated, without dropping the date line', () => {
     const tex = generateFlatLatex(store);
     expect(tex).not.toContain('Ser 1710/024');
-    expect(tex).toContain('FIRST ENDORSEMENT');
+    // "Without dropping the date line" must actually be asserted: the
+    // right-aligned date table still renders (blank, for hand-dating at
+    // signature) above the endorsement line — checking only FIRST ENDORSEMENT
+    // let a dropped date block pass.
+    const ackStart = tex.indexOf('FIRST ENDORSEMENT');
+    expect(ackStart).toBeGreaterThan(-1);
+    const beforeAck = tex.slice(tex.indexOf('\\rule{\\textwidth}{0.5pt}'), ackStart);
+    expect(beforeAck).toContain('\\begin{tabularx}{\\textwidth}{@{}Xr@{}}');
   });
 
   it('neither emits anything when the letter carries no acknowledgement', () => {

--- a/tests/unit/assembleEndorsement.test.ts
+++ b/tests/unit/assembleEndorsement.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
-import { assembleEndorsement } from '@/services/pdf/assembleEndorsement';
+import { assembleEndorsement, validateBasicLetter } from '@/services/pdf/assembleEndorsement';
 
 /** A PDF whose pages each carry a unique word, so order is checkable. */
 async function makePdf(words: string[]): Promise<Uint8Array> {
@@ -77,5 +77,30 @@ describe('assembleEndorsement', () => {
     const buf = letter.buffer.slice(letter.byteOffset, letter.byteOffset + letter.byteLength);
     const result = await assembleEndorsement(await makePdf(['E']), buf);
     expect(result.ok).toBe(true);
+  });
+});
+
+// Attach-time validation: the upload handler rejects a bad file before it is
+// persisted, so the preview's silent fallback can only ever hide bytes that
+// were valid when attached — never a file that was broken from the start.
+describe('validateBasicLetter', () => {
+  it('accepts a readable PDF and reports its page count', async () => {
+    const result = await validateBasicLetter(await makePdf(['A', 'B']));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.pageCount).toBe(2);
+  });
+
+  it('rejects bytes that are not a PDF', async () => {
+    const result = await validateBasicLetter(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeTruthy();
+  });
+
+  it('rejects a page-less PDF', async () => {
+    const empty = await (await PDFDocument.create()).save();
+    const result = await validateBasicLetter(empty);
+    expect(result.ok).toBe(false);
   });
 });

--- a/tests/unit/assembleEndorsement.test.ts
+++ b/tests/unit/assembleEndorsement.test.ts
@@ -1,8 +1,10 @@
 /**
  * The endorsement is assembled onto the basic letter it endorses: the uploaded
- * letter's pages first, the endorsement after (SECNAV M-5216.5 Ch 9 Fig 9-3).
- * These pin the order, the page count, and that a bad upload fails loudly with
- * the endorsement returned unchanged — never a silently dropped export.
+ * letter's pages first, the endorsement after — a new-page endorsement
+ * continues the basic letter's page numbers (SECNAV M-5216.5 Ch 9), so the
+ * letter reads first. These pin the order, the page count, and that a bad
+ * upload fails loudly with the endorsement returned unchanged — never a
+ * silently dropped export.
  */
 import { describe, it, expect } from 'vitest';
 import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';

--- a/tests/unit/assembleEndorsement.test.ts
+++ b/tests/unit/assembleEndorsement.test.ts
@@ -8,7 +8,11 @@
  */
 import { describe, it, expect } from 'vitest';
 import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
-import { assembleEndorsement, validateBasicLetter } from '@/services/pdf/assembleEndorsement';
+import {
+  assembleEndorsement,
+  validateBasicLetter,
+  shouldAssembleBasicLetter,
+} from '@/services/pdf/assembleEndorsement';
 
 /** A PDF whose pages each carry a unique word, so order is checkable. */
 async function makePdf(words: string[]): Promise<Uint8Array> {
@@ -128,5 +132,28 @@ describe('validateBasicLetter', () => {
     const empty = await (await PDFDocument.create()).save();
     const result = await validateBasicLetter(empty);
     expect(result.ok).toBe(false);
+  });
+});
+
+// The export/preview gate, now pure and testable — an integration test used to
+// claim to guard this without ever invoking it.
+describe('shouldAssembleBasicLetter', () => {
+  const file = { basicLetterFile: { data: new ArrayBuffer(8) } };
+
+  it('assembles a new-page endorsement with a letter attached', () => {
+    expect(shouldAssembleBasicLetter('new_page_endorsement', file)).toBe(true);
+  });
+
+  it('never assembles a same-page endorsement — it lives ON the letter, not after it', () => {
+    expect(shouldAssembleBasicLetter('same_page_endorsement', file)).toBe(false);
+  });
+
+  it('never assembles a stale attachment on another doc type', () => {
+    expect(shouldAssembleBasicLetter('naval_letter', file)).toBe(false);
+  });
+
+  it('no letter, no assembly', () => {
+    expect(shouldAssembleBasicLetter('new_page_endorsement', {})).toBe(false);
+    expect(shouldAssembleBasicLetter('new_page_endorsement', undefined)).toBe(false);
   });
 });

--- a/tests/unit/assembleEndorsement.test.ts
+++ b/tests/unit/assembleEndorsement.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The endorsement is assembled onto the basic letter it endorses: the uploaded
+ * letter's pages first, the endorsement after (SECNAV M-5216.5 Ch 9 Fig 9-3).
+ * These pin the order, the page count, and that a bad upload fails loudly with
+ * the endorsement returned unchanged — never a silently dropped export.
+ */
+import { describe, it, expect } from 'vitest';
+import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
+import { assembleEndorsement } from '@/services/pdf/assembleEndorsement';
+
+/** A PDF whose pages each carry a unique word, so order is checkable. */
+async function makePdf(words: string[]): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  for (const word of words) {
+    const page = doc.addPage([612, 792]);
+    page.drawText(word, { x: 72, y: 700, size: 24, font, color: rgb(0, 0, 0) });
+  }
+  return doc.save();
+}
+
+/** Read the drawn word off each page via pdf-lib is not possible directly, so
+ *  compare page counts and re-load to confirm structural integrity. */
+async function pageCount(bytes: Uint8Array): Promise<number> {
+  return (await PDFDocument.load(bytes)).getPageCount();
+}
+
+describe('assembleEndorsement', () => {
+  it('puts the basic letter first and the endorsement after', async () => {
+    const letter = await makePdf(['LETTER-1', 'LETTER-2', 'LETTER-3']);
+    const endorsement = await makePdf(['ENDORSEMENT']);
+
+    const result = await assembleEndorsement(endorsement, letter);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.basicLetterPageCount).toBe(3);
+    // 3 letter pages + 1 endorsement page.
+    expect(await pageCount(result.pdfBytes)).toBe(4);
+  });
+
+  it('handles a single-page basic letter', async () => {
+    const result = await assembleEndorsement(await makePdf(['E']), await makePdf(['L']));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.basicLetterPageCount).toBe(1);
+    expect(await pageCount(result.pdfBytes)).toBe(2);
+  });
+
+  it('rejects an unreadable upload and returns the endorsement unchanged', async () => {
+    const endorsement = await makePdf(['ENDORSEMENT']);
+    const garbage = new Uint8Array([0x00, 0x01, 0x02, 0x03, 0x04]); // not a PDF
+
+    const result = await assembleEndorsement(endorsement, garbage);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBeTruthy();
+    // The endorsement is handed back byte-for-byte, not dropped or truncated.
+    expect(result.pdfBytes).toBe(endorsement);
+  });
+
+  it('rejects a PDF with no usable pages', async () => {
+    const empty = await (await PDFDocument.create()).save();
+    const result = await assembleEndorsement(await makePdf(['E']), empty);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    // Either "no pages" or "page 1 is empty" — both are valid rejections; the
+    // point is a page-less letter never assembles silently.
+    expect(result.error).toMatch(/no pages|empty|corrupt/i);
+  });
+
+  it('accepts an ArrayBuffer as well as a Uint8Array', async () => {
+    const letter = await makePdf(['L']);
+    const buf = letter.buffer.slice(letter.byteOffset, letter.byteOffset + letter.byteLength);
+    const result = await assembleEndorsement(await makePdf(['E']), buf);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/tests/unit/assembleEndorsement.test.ts
+++ b/tests/unit/assembleEndorsement.test.ts
@@ -41,6 +41,32 @@ describe('assembleEndorsement', () => {
     expect(await pageCount(result.pdfBytes)).toBe(4);
   });
 
+  // Page counts alone can't see a reversed concatenation — a flip once slipped
+  // through this file green because every count stays identical either way.
+  // Distinct page sizes make the order itself observable: letter pages are
+  // letter-size, the endorsement page is deliberately 1pt narrower.
+  it('really is letter-then-endorsement, not just the right page count', async () => {
+    const sizedPdf = async (words: string[], width: number) => {
+      const doc = await PDFDocument.create();
+      const font = await doc.embedFont(StandardFonts.Helvetica);
+      for (const word of words) {
+        const page = doc.addPage([width, 792]);
+        page.drawText(word, { x: 72, y: 700, size: 24, font, color: rgb(0, 0, 0) });
+      }
+      return doc.save();
+    };
+    const result = await assembleEndorsement(
+      await sizedPdf(['ENDORSEMENT'], 611),
+      await sizedPdf(['LETTER-1', 'LETTER-2'], 612)
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const merged = await PDFDocument.load(result.pdfBytes);
+    const widths = merged.getPages().map((p) => Math.round(p.getSize().width));
+    expect(widths).toEqual([612, 612, 611]);
+  });
+
   it('handles a single-page basic letter', async () => {
     const result = await assembleEndorsement(await makePdf(['E']), await makePdf(['L']));
     expect(result.ok).toBe(true);

--- a/tests/unit/attachmentGc.test.ts
+++ b/tests/unit/attachmentGc.test.ts
@@ -135,6 +135,26 @@ describe('sweepOrphanedAttachments', () => {
     expect(await idbGetAttachment('att_live')).toBeTruthy();
   });
 
+  it("KEEPS a just-uploaded basic letter referenced only by the live session's formData", async () => {
+    // The endorsement's basic letter lives in formData.basicLetterFileRef, not
+    // enclosures. Root (c) once passed only { enclosures } to the collector, so
+    // a sweep in the ~2s before the debounced save (e.g. finalizePurge after a
+    // document delete) reaped a letter the user had just uploaded.
+    useDocumentStore.setState((state) => ({
+      enclosures: [],
+      formData: {
+        ...state.formData,
+        basicLetterFileRef: { id: 'att_letter', name: 'letter.pdf', size: 3, type: 'application/pdf' },
+      },
+    }) as never);
+    await idbPutAttachment(att('att_letter'));
+
+    const deleted = await sweepOrphanedAttachments();
+
+    expect(deleted).toBe(0);
+    expect(await idbGetAttachment('att_letter')).toBeTruthy();
+  });
+
   it('ABORTS and deletes nothing when the document registry is unreadable', async () => {
     // A read FAILURE (null) must not be read as "no docs reference anything".
     vi.spyOn(documentsDb, 'idbGetAllDocuments').mockResolvedValue(null);

--- a/tests/unit/basicLetterDurability.test.ts
+++ b/tests/unit/basicLetterDurability.test.ts
@@ -1,0 +1,75 @@
+/**
+ * The basic-letter PDF is stored like an enclosure file: its bytes live in the
+ * attachments store, and only the fileRef is serialized, backed up, and kept
+ * reachable by the GC. These pin that lifecycle so a saved endorsement doesn't
+ * lose its basic letter on reload, in a backup, or to the attachment sweep.
+ */
+// Real in-memory IndexedDB before any store/attachments module evaluates.
+import 'fake-indexeddb/auto';
+import { describe, it, expect } from 'vitest';
+import { collectAttachmentIds } from '@/lib/backup';
+import { persistAttachment } from '@/lib/attachments';
+import { useDocumentStore, rehydrateEnclosureFiles, serializeSession } from '@/stores/documentStore';
+
+const REF = { id: 'att-basic-letter-1', name: 'CO-ltr.pdf', size: 4096, type: 'application/pdf' };
+
+function endorsementDocRecord() {
+  return {
+    session: {
+      docType: 'new_page_endorsement',
+      formData: { basicLetterFileRef: REF },
+      enclosures: [],
+    },
+  };
+}
+
+describe('basic-letter attachment durability', () => {
+  it('a backup embeds the basic-letter attachment bytes', () => {
+    const ids = collectAttachmentIds([endorsementDocRecord()]);
+    expect(ids).toContain(REF.id);
+  });
+
+  it('the backup collector still gathers enclosure refs alongside it', () => {
+    const rec = {
+      session: {
+        docType: 'new_page_endorsement',
+        formData: { basicLetterFileRef: REF },
+        enclosures: [{ fileRef: { id: 'att-encl-9' } }],
+      },
+    };
+    const ids = collectAttachmentIds([rec]);
+    expect(ids).toEqual(expect.arrayContaining([REF.id, 'att-encl-9']));
+  });
+});
+
+describe('serialize → rehydrate round-trip', () => {
+  it('strips the bytes on serialize but keeps the ref', () => {
+    useDocumentStore.setState((s) => ({
+      formData: {
+        ...s.formData,
+        basicLetterFile: { name: 'x.pdf', size: 3, data: new Uint8Array([1, 2, 3]).buffer },
+        basicLetterFileRef: REF,
+      },
+    }));
+    const session = serializeSession(useDocumentStore.getState());
+    expect(session.formData.basicLetterFile).toBeUndefined();
+    expect(session.formData.basicLetterFileRef).toEqual(REF);
+  });
+
+  it('rehydrates the bytes from the attachments store on load', async () => {
+    const data = new Uint8Array([9, 8, 7, 6]).buffer;
+    const ref = await persistAttachment({ name: 'CO-ltr.pdf', size: 4, type: 'application/pdf' }, data);
+
+    // A restored session carries only the ref (no bytes), exactly as serialized.
+    useDocumentStore.setState((s) => ({
+      formData: { ...s.formData, basicLetterFile: undefined, basicLetterFileRef: ref },
+    }));
+    expect(useDocumentStore.getState().formData.basicLetterFile).toBeUndefined();
+
+    await rehydrateEnclosureFiles();
+
+    const file = useDocumentStore.getState().formData.basicLetterFile;
+    expect(file).toBeDefined();
+    expect(new Uint8Array(file!.data)).toEqual(new Uint8Array(data));
+  });
+});


### PR DESCRIPTION
An endorsement is written on correspondence that comes *up* the chain: you receive a letter, endorse it, and forward the assembly. DonDocs produced only the endorsement text — you had to combine it with the basic letter by hand. This assembles them.

## Using it

On a same-page or new-page endorsement, upload the basic letter's PDF in the **Basic Letter** section. The exported PDF is the letter followed by your endorsement — SECNAV M-5216.5 Ch 9, Fig 9-3 ("Assembly of an Endorsement"). The preview shows the assembled document. The uploaded letter is stored like an enclosure: it survives a reload and rides along in a backup.

## Scope, deliberately narrow

- **New-page assembly only.** Ch 9 ¶1 makes a new-page endorsement always valid ("If not, use a new-page endorsement"); same-page is the optional space-saver. DonDocs won't overlay text onto the signature page of a letter it didn't generate — it can't reliably find the signature on an unknown layout, and per the escape hatch it doesn't have to.
- **PDF export only.** The Word file contains the endorsement alone (a PDF can't be embedded into a `.docx` via pandoc). The upload section's copy states this while a letter is attached.

The same-page case, when DonDocs *made* the letter, is already the appointment-acknowledgement mechanism from #211 and out of scope here.

## Why it's small

Reuses what exists rather than rebuilding:
- `mergeEnclosures` already loads/validates/stitches arbitrary PDFs (including scanned) — assembly is a `pdf-lib` prepend before that merge.
- The Basic Letter section already captures the basic-letter ID, ordinal, and sequence-continuation fields.
- The attachments store + enclosure lifecycle is mirrored for durable storage.
- `enhanceExportPdf` is the single post-compile hook (preview, download, PII download).

## Verification

- `tests/integration/endorsement-assembly-render.test.ts` — compiles a **real** endorsement, assembles a real 3-page letter, and reads the pages off with pdftotext: letter markers precede `FIRST ENDORSEMENT`, in order. Reversing the assembly fails it (the unit test only checks page count, so this is what guards order).
- `tests/unit/assembleEndorsement.test.ts` — order, count, and that a bad upload returns the endorsement unchanged with an error (never a silent drop).
- `tests/unit/basicLetterDurability.test.ts` — serialize strips the bytes but keeps the ref; rehydrate returns the exact bytes from the attachments store; backup collector gathers the ref.
- Driven live: attaching a 3-page letter to a New-Page Endorsement grows the preview from 1 page to 4; a bad upload surfaces in the enclosure-error modal on download and the endorsement still exports alone.
- build 0, lint 0, 1677 unit tests, 3 render tests. v1.2.101.

Refs #203.

## Known limits (flagged, not built)
- Same-page overlay onto an uploaded letter (unreliable; new-page is always valid).
- Auto-regenerating a *saved DonDocs* letter's PDF to prepend — a clean follow-up on the existing "Base on a saved letter" flow.
