### PR TITLE
docs(secnav): correct manual citations to the paragraphs they quote

### DIFF
--- a/public/lib/latex-templates.js
+++ b/public/lib/latex-templates.js
@@ -837,7 +837,8 @@ const LATEX_TEMPLATES = {
         \\vspace{12pt}%
         \\noindent FIRST ENDORSEMENT\\par
         \\vspace{12pt}%
-        % Colon spacing matches the basic letter's From/To block (Ch 7 para 11b).
+        % Colon spacing matches the basic letter's From/To block: two spaces
+        % after "From:" (Ch 7 para 6c), six after "To:" (Ch 7 para 7b).
         \\noindent
         \\begin{tabular}[t]{@{}l@{}p{5.75in}@{}}
             From:\\hspace{2\\fontdimen2\\font} & \\AckFrom\\tabularnewline
@@ -4041,7 +4042,7 @@ const LATEX_TEMPLATES = {
 %
 % References:
 %   - SECNAV M-5216.5 (DON Correspondence Manual), Chapter 9
-%   - Figure 9-3
+%   - Figure 9-2
 %
 % What It's For:
 %   Use an endorsement to forward comments, recommendations, or

--- a/src/components/editor/EndorsementBasicLetterSection.tsx
+++ b/src/components/editor/EndorsementBasicLetterSection.tsx
@@ -247,9 +247,11 @@ export function EndorsementBasicLetterSection() {
             </div>
 
             {/* Sequence continuation. An endorsement carries on the basic
-                letter's numbering instead of opening its own (Ch 9 ¶3), but the
-                basic letter is a separate document DonDocs can't read — so the
-                user supplies where this one picks up. */}
+                letter's sequences instead of opening its own — reference
+                letters (Ch 9 ¶3), enclosure numbers (Ch 9 ¶4), page numbers
+                (Fig 9-2 ¶1) — but the basic letter is a separate document
+                DonDocs can't read, so the user supplies where this one picks
+                up. */}
             <div className="space-y-3 border-t border-border pt-4">
               <div className="space-y-1">
                 <h4 className="text-sm font-medium">Continues from the basic letter</h4>

--- a/src/lib/endorsement.ts
+++ b/src/lib/endorsement.ts
@@ -71,9 +71,9 @@ export function referenceStartIndex(docType: string, startingLetter?: string): n
 }
 
 /**
- * The number the enclosure list starts at — the same Ch 9 ¶3 continuation rule
- * as references. Defaults to 1 for anything that isn't an endorsement or has no
- * usable value.
+ * The number the enclosure list starts at — the Ch 9 ¶4 continuation rule,
+ * the enclosure counterpart of ¶3's reference lettering. Defaults to 1 for
+ * anything that isn't an endorsement or has no usable value.
  */
 export function enclosureStartNumber(docType: string, startingNumber?: number): number {
   if (!isEndorsement(docType)) return 1;

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -514,8 +514,8 @@ function buildEnclosures(enclosures: Enclosure[], startNumber = 1): string {
   const rows: string[] = [];
   for (let i = 0; i < enclosures.length; i++) {
     const encl = enclosures[i];
-    // `startNumber` lets an endorsement continue the basic letter's numbering
-    // (Ch 9 ¶3); it is 1 for everything that opens its own sequence.
+    // `startNumber` lets an endorsement continue the basic letter's enclosure
+    // numbering (Ch 9 ¶4); it is 1 for everything that opens its own sequence.
     const n = startNumber + i;
     if (i === 0) {
       rows.push(`Encl:\\hspace{3\\fontdimen2\\font} & (${n})~~${escapeTabular(encl.title)} \\\\`);

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -603,7 +603,7 @@ ${store.enclosures
       // Always use JSPDF marker - JavaScript handles ALL enclosure pages
       // This ensures correct ordering (text-only and PDF enclosures in sequence)
       // The start number lets an endorsement continue the basic letter's
-      // numbering (Ch 9 ¶3); it is 1 for everything else.
+      // enclosure numbering (Ch 9 ¶4); it is 1 for everything else.
       const n = enclosureStartNumber(store.docType, store.formData.startingEnclosureNumber) + i;
       return `\\enclosure{${n}}{JSPDF}{${escapeLatex(e.title || 'Untitled')}}`;
     })

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -108,9 +108,11 @@ export interface DocumentData {
   pageNumbering: string;
   startingPageNumber: number;
   // Endorsements continue the basic letter's sequences rather than opening
-  // their own (SECNAV M-5216.5 Ch 9 ¶3). The basic letter is a separate
-  // document, so the user supplies where this one picks up. See
-  // `referenceStartIndex` / `enclosureStartNumber` in lib/endorsement.ts.
+  // their own: the reference sequence of letters (SECNAV M-5216.5 Ch 9 ¶3),
+  // the enclosure sequence of numbers (Ch 9 ¶4), and the page numbers
+  // (Fig 9-2 ¶1). The basic letter is a separate document, so the user
+  // supplies where this one picks up. See `referenceStartIndex` /
+  // `enclosureStartNumber` in lib/endorsement.ts.
   startingReferenceLetter?: string;
   startingEnclosureNumber?: number;
 
@@ -337,7 +339,7 @@ const DUAL_SIGNATURE_COMPLIANCE = {
 
 // Executive correspondence compliance (Ch 12) - bullets not numbered paragraphs, uses "Attachments:" not "Encl:"
 const EXECUTIVE_COMPLIANCE = {
-  numberedParagraphs: false,     // Uses bullets per Ch 12 ¶3a(2)
+  numberedParagraphs: false,     // Uses bullets per Ch 12 ¶4.3a(2)
   allowReferences: false,        // Avoided for principal signatures per Ch 12 ¶2m
   allowEnclosures: false,        // Uses "Attachments:" not "Encl:" per Ch 12 ¶3
   requiresSalutation: false,

--- a/tex/README.md
+++ b/tex/README.md
@@ -9,7 +9,7 @@
 | Document Category | Font Size | Font Type | Source |
 |-------------------|-----------|-----------|--------|
 | **General Correspondence** (Chs 7-11) | 10-12pt *(REQUIRED)* | Times New Roman *(RECOMMENDED)*; Courier New *(permitted for informal only)* | Ch 2 ¶20 |
-| **Executive Correspondence** (Ch 12) | 12pt *(REQUIRED)* | Times New Roman *(REQUIRED)* | Ch 12 ¶2, ¶2c, ¶3a(3) |
+| **Executive Correspondence** (Ch 12) | 12pt *(REQUIRED)* | Times New Roman *(REQUIRED)* | Ch 12 ¶3.2, ¶4.2c, ¶4.3a(3) |
 
 > **Ch 2 ¶20:** "For text, use 10 to 12 point font size. Times New Roman 12-point is the **preferred** font style and size for official correspondence, but Courier New may be used for informal correspondence."
 
@@ -116,7 +116,7 @@ Per Appendix C ¶4h:
 | **Business Letter** | 1" | 1" (up to 2" for short letters ≤100 words) | 1" | Ch 7 ¶1, Ch 11 Fig 11-6 |
 | **Executive Memo (First Page)** | 2" (adjustable to 1.75"; 1" if no letterhead) | 1" (up to 2" if <11 lines) | 1" | Ch 12 ¶2b |
 | **Executive Memo (Succeeding Pages)** | 1" | 1" | 1" | Ch 12 ¶2b |
-| **Action Memo** | 1" | 1" | 1" | Ch 12 ¶3a(4) |
+| **Action Memo** | 1" | 1" | 1" | Ch 12 ¶4.3a(4) |
 | **Directives** | 1" (header) | 1" | 0.5" (footer) | Ch 7 ¶1 (per OPNAVINST 5215.17) |
 
 ---
@@ -234,7 +234,7 @@ Encl:   (1) Title of First Enclosure
 | Never duplicate | Never list item in both enclosure AND reference line | Ch 7 ¶11a |
 
 ### Marking Enclosures
-Per Ch 7 ¶13a:
+Per Ch 2 ¶13a:
 
 | Page | Marking | Position |
 |------|---------|----------|
@@ -580,10 +580,10 @@ Per Ch 7 ¶13c:
 
 ### Action Memorandum
 - **Use:** "Forwarding material that requires SecDef, DepSecDef, HqDON approval or signature" or "Describing a problem and recommending a solution" — *Ch 12 ¶1b(2)*
-- **Margins:** 1" all sides *(REQUIRED)* — *Ch 12 ¶3a(4)*
-- **Length:** "Limit to one page, unless issue is complex" — *Ch 12 ¶3a(1)*
-- **Style:** "short, concise and clear bullet statements (use of black dot bullet preferred)" — *Ch 12 ¶3a(2)*
-- **Page Numbering:** Number pages at bottom center starting on page 2 — *Ch 12 ¶3a(7)*
+- **Margins:** 1" all sides *(REQUIRED)* — *Ch 12 ¶4.3a(4)*
+- **Length:** "Limit to one page, unless issue is complex" — *Ch 12 ¶4.3a(1)*
+- **Style:** "short, concise and clear bullet statements (use of black dot bullet preferred)" — *Ch 12 ¶4.3a(2)*
+- **Page Numbering:** Number pages at bottom center starting on page 2 — *Ch 12 ¶4.3a(7)*
 - **Required Elements:** FOR:, FROM:, SUBJECT:, bullets, RECOMMENDATION:, COORDINATION:, Attachments:, Prepared By: — *Figure 12-9*
 
 ### Information Memorandum

--- a/tex/main.tex
+++ b/tex/main.tex
@@ -824,7 +824,8 @@
         \vspace{12pt}%
         \noindent FIRST ENDORSEMENT\par
         \vspace{12pt}%
-        % Colon spacing matches the basic letter's From/To block (Ch 7 para 11b).
+        % Colon spacing matches the basic letter's From/To block: two spaces
+        % after "From:" (Ch 7 para 6c), six after "To:" (Ch 7 para 7b).
         \noindent
         \begin{tabular}[t]{@{}l@{}p{5.75in}@{}}
             From:\hspace{2\fontdimen2\font} & \AckFrom\tabularnewline

--- a/tex/templates/new_page_endorsement.tex
+++ b/tex/templates/new_page_endorsement.tex
@@ -6,7 +6,7 @@
 %
 % References:
 %   - SECNAV M-5216.5 (DON Correspondence Manual), Chapter 9
-%   - Figure 9-3
+%   - Figure 9-2
 %
 % What It's For:
 %   Use an endorsement to forward comments, recommendations, or


### PR DESCRIPTION
Six citation defects found by a line-by-line audit of every SECNAV cite against the manual itself (docs/5216.5 CH-1.pdf), each verified before and after:

- **tex/README.md "Marking Enclosures": restored to Ch 2 ¶13a.** A prior citation sweep (#212) blind-replaced this to Ch 7 ¶13a — but Ch 2 ¶13 *is* "Enclosures" (sub-para a: "Marking Enclosures", page 2-9), and the adjacent rows still cite Ch 2 ¶13b/¶13c. The endorsement-numbering rows that correctly cite Ch 7 ¶13a are untouched.
- **tex/main.tex From/To colon spacing: ¶11b → ¶6c + ¶7b** ("The text begins two spaces after the colon" / "Six spaces follow the colon"; ¶11b is the Encl line).
- **Enclosure-sequence continuation: Ch 9 ¶3 → ¶4** in generator.ts — plus the same bug found in endorsement.ts and flat-generator.ts by the post-edit grep ("Assign a number to all enclosures that you add by continuing the sequence of numbers…"; ¶3 is references).
- **document.ts sequence comment**: names all three continued sequences precisely — ¶3 (reference letters), ¶4 (enclosure numbers), Fig 9-2 ¶1 (page numbers).
- **new_page_endorsement.tex header: Figure 9-3 → 9-2** (9-3 is "Assembly of an Endorsement", a routing stack; 9-2 is the new-page figure).
- **Ch 12 cites qualified by section** (¶3a(…) → ¶4.3a(…)): Ch 12 restarts paragraph numbering per section, so the unqualified form pointed at 12-3 ¶3, the Date Line. All four rules verified at 12-4 ¶3a.

Every correction fixed individually with context (no sweeps); post-edit greps prove no other occurrence changed. Bundle regenerated. eslint clean, 1668 unit tests pass. Comments/docs only — no behavior change, no version bump (per #209/#106 precedent).