### PR TITLE
test(docx): run the harness through the production pandoc pipeline

### DIFF
--- a/tests/_helpers/compileDocx.ts
+++ b/tests/_helpers/compileDocx.ts
@@ -12,13 +12,38 @@
  * only. Different inputs, different failure modes (pandoc rejecting
  * unknown commands vs. xelatex undefined-macro errors), so different
  * test files.
+ *
+ * Fidelity: the invocation mirrors the production options object in
+ * `pandoc-converter.ts` (`from: latex+raw_tex`, `filters: dondocs.lua`,
+ * `reference-doc`, layout metadata). Anything less silently changes what
+ * the flat-generator's custom constructs mean — without `+raw_tex` the
+ * reader drops `\enclref{1}` instead of handing it to the Lua filter, so
+ * "See \enclref{1}." extracts as "See ." here while users get
+ * "See Enclosure (1).", and every differential assertion runs against a
+ * pipeline that never ships. The JSZip post-pass (`postProcessDocx`:
+ * cell padding, fonts, classification header) is NOT mirrored — it
+ * rewrites styling XML, not the text content these tests extract.
  */
 import { spawn } from 'node:child_process';
 import { mkdtemp, writeFile, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { generateFlatLatex } from '@/services/latex/flat-generator';
+import { LAYOUT, layoutToMetadata } from '@/services/docx/layout-config';
 import type { TestStore } from './compileLatex';
+
+// Same resolution trick as compileLatex.ts: absolute paths anchored to this
+// file's location so the harness works from any cwd (vitest, cartesian run).
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+
+// The exact support files production ships into pandoc WASM's file map.
+const PANDOC_SUPPORT_DIR = join(REPO_ROOT, 'public', 'lib', 'pandoc');
+// Production maps the seal PNG into pandoc's working dir by filename; the
+// resource path lets `\includegraphics{dow-seal.png}` resolve to the same
+// bytes here without copying a seal into every fixture's workDir.
+const SEAL_DIR = join(REPO_ROOT, 'public', 'attachments');
 
 export interface DocxCompileResult {
   ok: boolean;
@@ -29,7 +54,12 @@ export interface DocxCompileResult {
   workDir: string;
 }
 
-function runPandoc(cwd: string, inputFile: string, outputFile: string): Promise<{
+function runPandoc(
+  cwd: string,
+  inputFile: string,
+  outputFile: string,
+  metadata: Record<string, string>
+): Promise<{
   exitCode: number | null;
   log: string;
 }> {
@@ -38,8 +68,16 @@ function runPandoc(cwd: string, inputFile: string, outputFile: string): Promise<
     const proc = spawn(
       'pandoc',
       [
-        '--from=latex',
+        // CLI spelling of the production options object (pandoc-converter.ts
+        // feeds pandoc WASM a defaults-file-shaped `options`; a `.lua` entry
+        // in a defaults `filters` list runs as a Lua filter, which is what
+        // `--lua-filter` does here).
+        '--from=latex+raw_tex',
         '--to=docx',
+        `--lua-filter=${join(PANDOC_SUPPORT_DIR, 'dondocs.lua')}`,
+        `--reference-doc=${join(PANDOC_SUPPORT_DIR, 'reference.docx')}`,
+        ...Object.entries(metadata).map(([key, value]) => `--metadata=${key}:${value}`),
+        `--resource-path=.${delimiter}${SEAL_DIR}`,
         '--output', outputFile,
         inputFile,
       ],
@@ -67,7 +105,14 @@ export async function compileDocxFixture(store: TestStore): Promise<DocxCompileR
 
   await writeFile(inputFile, tex);
 
-  const { exitCode, log } = await runPandoc(workDir, 'flat.tex', 'out.docx');
+  // Same metadata production builds: layout proportions for the Lua filter's
+  // table-width pass, plus the font size it scales \baselineskip spacing by.
+  const metadata: Record<string, string> = {
+    ...layoutToMetadata(LAYOUT),
+    'font-size-pt': String(parseInt(store.formData.fontSize || '12pt', 10) || 12),
+  };
+
+  const { exitCode, log } = await runPandoc(workDir, 'flat.tex', 'out.docx', metadata);
   const ok = exitCode === 0;
 
   let docxBytes: Uint8Array | undefined;

--- a/tests/integration/docx-pipeline-fidelity.test.ts
+++ b/tests/integration/docx-pipeline-fidelity.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Harness-fidelity regression: the DOCX test harness must run the SAME
+ * pandoc pipeline production runs (`pandoc-converter.ts`), not a bare
+ * `--from=latex --to=docx`.
+ *
+ * Proof by construct: the flat generator rewrites "Enclosure (1)" /
+ * "Reference (a)" in body text into `\enclref{1}` / `\reflink{a}`. Those
+ * only reach the rendered DOCX when the reader keeps raw tex (`+raw_tex`)
+ * AND dondocs.lua converts them back to plain text — exactly the two
+ * pieces a bare invocation lacks. Under the old harness this fixture
+ * rendered "Per , the roster at is updated quarterly." while a user's
+ * export said "Per Reference (a), the roster at Enclosure (1) is updated
+ * quarterly." — so every differential suite was green against a pipeline
+ * nobody ships. This test fails against that harness.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import mammoth from 'mammoth';
+import { generateFlatLatex } from '@/services/latex/flat-generator';
+import { compileDocxFixture, formatDocxFailure } from '../_helpers/compileDocx';
+import { buildBaseline } from '../_helpers/compileMatrix';
+
+// Synchronous toolchain check at module load — see `docx-compile.test.ts`
+// for the rationale. Marks tests as SKIPPED (not falsely PASSED) when
+// pandoc is missing.
+const pandocAvailable =
+  spawnSync('pandoc', ['--version'], { encoding: 'utf-8' }).status === 0;
+
+if (!pandocAvailable) {
+  console.warn(
+    '[docx-pipeline-fidelity] pandoc not found on PATH — the fidelity check below will be SKIPPED.'
+  );
+}
+
+function crossRefStore() {
+  const store = buildBaseline('naval_letter');
+  store.references = [{ letter: 'a', title: 'MCO 5216.20B' }];
+  store.enclosures = [{ title: 'Personnel Roster' }];
+  store.paragraphs = [
+    {
+      text: 'Per Reference (a), the roster at Enclosure (1) is updated quarterly.',
+      level: 0,
+    },
+  ];
+  return store;
+}
+
+describe('DOCX harness pipeline fidelity', () => {
+  it.skipIf(!pandocAvailable)(
+    'cross-reference constructs survive into the rendered DOCX text',
+    async () => {
+      const store = crossRefStore();
+
+      // Premise guard: the fixture must actually exercise the raw-tex
+      // constructs. If the escaper ever stops emitting them, the render
+      // assertions below would go vacuous — fail loudly here instead.
+      const tex = generateFlatLatex(store);
+      expect(tex).toContain('\\enclref{1}');
+      expect(tex).toContain('\\reflink{a}');
+
+      const result = await compileDocxFixture(store);
+      if (!result.ok) {
+        throw new Error(formatDocxFailure('naval_letter:cross-refs', result));
+      }
+
+      const { value } = await mammoth.extractRawText({
+        buffer: Buffer.from(result.docxBytes!),
+      });
+      const text = value.replace(/\s+/g, ' ');
+
+      expect(text).toContain('Enclosure (1)');
+      expect(text).toContain('Reference (a)');
+      // The whole sentence, so a harness that silently drops the raw
+      // inlines ("Per , the roster at is updated quarterly.") cannot pass.
+      expect(text).toContain(
+        'Per Reference (a), the roster at Enclosure (1) is updated quarterly.'
+      );
+    },
+    45_000
+  );
+});


### PR DESCRIPTION
The DOCX test harness ran pandoc with `--from=latex` and no filter, while production runs `latex+raw_tex` with `dondocs.lua`, a reference doc, and layout metadata. Every differential test therefore exercised a pipeline users never see — and constructs the flat generator emits behaved differently: `"Per \reflink{a}, the roster at \enclref{1}…"` extracted as `"Per , the roster at …"` through the old harness, versus the correct `"Per Reference (a), the roster at Enclosure (1)…"` through production.

- `compileDocxFixture` now mirrors the production invocation exactly (reader, filter, reference-doc, metadata, resource path), with absolute paths so it runs from any cwd. The JSZip styling post-pass is deliberately not mirrored (it rewrites styling XML, not extracted text) and the boundary is documented.
- New fidelity regression: asserts the `\reflink`/`\enclref` premise on the LaTeX source (can't go vacuous) and the rewritten text in the mammoth extraction. **Fails against the old harness with the exact dropped-text repro; passes against the new one.**
- Both differential suites and the full 800-fixture pairwise DOCX compile matrix pass through the faithful pipeline (842/842) — no real production divergence was being hidden; the gap was confined to raw-tex constructs no existing assertion touched, which the new test now pins.

Test-only change; no version bump.