### PR TITLE
fix(endorsement): three Ch 9 compliance gaps (via numbering, DOCX serial/date, sequence continuation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.103] — 2026-07-16
+
+### Fixed
+
+- The PDF now numbers via addressees. SECNAV M-5216.5 Ch 9 ¶2: one remaining
+  via addressee is not numbered; two or more are numbered "(1)", "(2)", … The
+  DOCX export always did this; the PDF templates rendered the lines verbatim.
+  Numbering now happens once, in a helper both exports share.
+- The exported DOCX of a same-page endorsement carries its serial and date,
+  right-aligned between the separating rule and the endorsement line, as the
+  PDF already did (Ch 9 Fig 9-1: "Ser 019/870" / "23 Apr 15").
+- "Base on a saved letter" no longer copies the letter's references and
+  enclosures into the endorsement — Ch 9 ¶3-4: "Do not repeat a reference …
+  already … identified in the reference line of the basic letter"; sequences
+  are continued instead. Autofill now sets "First reference" / "First
+  enclosure" just past the source's last item (refs a-c → d, 5 enclosures →
+  6), leaving any start you already typed alone.
+
 ## [1.2.102] — 2026-07-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.102",
+  "version": "1.2.103",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/src/components/editor/EndorsementBasicLetterSection.tsx
+++ b/src/components/editor/EndorsementBasicLetterSection.tsx
@@ -23,7 +23,13 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { useDocumentStore } from '@/stores/documentStore';
 import { useDocumentsStore, searchableText, type DocumentMeta } from '@/stores/documentsStore';
 import { docTypeChip } from '@/types/document';
-import { composeBasicLetterId } from '@/lib/endorsement';
+import {
+  composeBasicLetterId,
+  continuationEnclosureNumber,
+  continuationReferenceLetter,
+  enclosureStartNumber,
+  referenceStartIndex,
+} from '@/lib/endorsement';
 
 /** The basic letter's routing, surfaced read-only so the user can fill the
  *  endorsement's own From/To/Via chain by hand — we never guess the chain. */
@@ -32,8 +38,22 @@ interface AppliedSource {
   from: string;
   to: string;
   via: string;
-  refs: number;
-  encls: number;
+  /** Continuation actually applied ('' / null when the source adds none or
+   *  the user had already supplied a start). */
+  refStart: string;
+  enclStart: number | null;
+}
+
+/** The applied-summary sentence for the sequence continuation, '' when the
+ *  source added nothing (Ch 9 ¶3-4: never repeat, continue instead). */
+function continuationSummary(applied: AppliedSource): string {
+  const parts = [
+    applied.refStart ? `references continue at (${applied.refStart})` : '',
+    applied.enclStart != null ? `enclosures at (${applied.enclStart})` : '',
+  ].filter(Boolean);
+  return parts.length > 0
+    ? ` Its references and enclosures are not repeated (Ch 9) — ${parts.join(' and ')}.`
+    : '';
 }
 
 /**
@@ -41,9 +61,10 @@ interface AppliedSource {
  * identifier together produce the endorsement line per SECNAV M-5216.5 Ch 9
  * §2.1.b: "[ORDINAL] ENDORSEMENT on [basic letter id]". Also lets the user base
  * the endorsement on a saved correspondence document: it composes the
- * basic-letter id and carries the subject + references + enclosures forward,
- * while leaving the endorsement's own From/To/Via to the user (that's routing
- * judgment, not something to infer).
+ * basic-letter id, carries the subject forward, and points the continuation
+ * fields just past the source's references and enclosures (Ch 9 ¶3-4 forbid
+ * repeating them), while leaving the endorsement's own From/To/Via to the user
+ * (that's routing judgment, not something to infer).
  */
 export function EndorsementBasicLetterSection() {
   const { formData, setField } = useDocumentStore();
@@ -52,8 +73,6 @@ export function EndorsementBasicLetterSection() {
   // endorsement. A same-page endorsement sits on the letter's signature page, so
   // uploading a letter to assemble only makes sense for new-page.
   const isNewPage = docType === 'new_page_endorsement';
-  const addReference = useDocumentStore((s) => s.addReference);
-  const addEnclosure = useDocumentStore((s) => s.addEnclosure);
   const docs = useDocumentsStore((s) => s.docs);
   const currentId = useDocumentsStore((s) => s.currentId);
 
@@ -88,36 +107,34 @@ export function EndorsementBasicLetterSection() {
       setField('subject', sourceSubject);
     }
 
-    // 3. Merge references — carry the basic letter's forward, deduped by title,
-    //    keeping any the endorser already added. (The store re-letters them.)
-    const haveRefs = new Set(ds.references.map((r) => r.title.trim().toLowerCase()));
-    for (const r of s.references ?? []) {
-      const title = (r.title ?? '').trim();
-      if (title && !haveRefs.has(title.toLowerCase())) {
-        addReference(title, r.url);
-        haveRefs.add(title.toLowerCase());
-      }
-    }
+    // 3. Never copy the source's references or enclosures — Ch 9 ¶3: "Do not
+    //    repeat a reference in the reference line of your endorsement that has
+    //    already been identified in the reference line of the basic letter"
+    //    (¶4 says the same for enclosures). The endorsement CONTINUES the
+    //    sequences instead, so point the continuation fields just past the
+    //    source's last item — unless the user already supplied a start.
+    const refStart = continuationReferenceLetter(
+      (s.references ?? []).filter((r) => (r.title ?? '').trim()).length,
+      referenceStartIndex(s.docType, fd.startingReferenceLetter)
+    );
+    const applyRefStart = !!refStart && !(ds.formData.startingReferenceLetter ?? '').trim();
+    if (applyRefStart) setField('startingReferenceLetter', refStart);
 
-    // 4. Merge enclosure titles. Files aren't part of a saved session, so only
-    //    the titles carry; the user re-attaches any files.
-    const haveEncls = new Set(ds.enclosures.map((e) => e.title.trim().toLowerCase()));
-    for (const e of s.enclosures ?? []) {
-      const title = (e.title ?? '').trim();
-      if (title && !haveEncls.has(title.toLowerCase())) {
-        addEnclosure(title);
-        haveEncls.add(title.toLowerCase());
-      }
-    }
+    const enclStart = continuationEnclosureNumber(
+      (s.enclosures ?? []).filter((e) => (e.title ?? '').trim()).length,
+      enclosureStartNumber(s.docType, fd.startingEnclosureNumber)
+    );
+    const applyEnclStart = enclStart != null && ds.formData.startingEnclosureNumber == null;
+    if (applyEnclStart) setField('startingEnclosureNumber', enclStart);
 
-    // 5. Record the basic letter's routing as read-only context.
+    // 4. Record the basic letter's routing as read-only context.
     setApplied({
       title: meta.title,
       from: (fd.from ?? '').trim(),
       to: (fd.to ?? '').trim(),
       via: (fd.via ?? '').trim().split('\n').filter(Boolean).join(' → '),
-      refs: (s.references ?? []).length,
-      encls: (s.enclosures ?? []).length,
+      refStart: applyRefStart ? refStart : '',
+      enclStart: applyEnclStart ? enclStart : null,
     });
     setPickerOpen(false);
     setQuery('');
@@ -301,10 +318,8 @@ export function EndorsementBasicLetterSection() {
                     </button>
                   </div>
                   <p className="mt-1 text-muted-foreground">
-                    Composed the basic-letter ID and carried the subject
-                    {applied.refs > 0 ? `, ${applied.refs} reference${applied.refs === 1 ? '' : 's'}` : ''}
-                    {applied.encls > 0 ? `, and ${applied.encls} enclosure${applied.encls === 1 ? '' : 's'}` : ''}
-                    {' '}forward.
+                    Composed the basic-letter ID and carried the subject forward.
+                    {continuationSummary(applied)}
                   </p>
                   {(applied.from || applied.to || applied.via) && (
                     <div className="mt-2 space-y-0.5 text-muted-foreground">

--- a/src/lib/endorsement.ts
+++ b/src/lib/endorsement.ts
@@ -93,6 +93,36 @@ export function pageStartNumber(docType: string, startingPageNumber?: number): n
   return Number.isFinite(n) && n > 1 ? Math.floor(n) : 1;
 }
 
+/**
+ * Where the endorsement's reference lettering picks up when it is based on a
+ * saved letter. Ch 9 ¶3: "Do not repeat a reference in the reference line of
+ * your endorsement that has already been identified in the reference line of
+ * the basic letter" — instead, assign letters "by continuing the sequence of
+ * letters from the basic letter". `count` is how many references the source
+ * identifies; `startIndex` is where the source's own sequence began (0 unless
+ * the source is itself an endorsement), so endorsing an endorsement keeps
+ * counting rather than resetting.
+ *
+ * Returns '' when the source adds nothing to continue, or when the next
+ * letter runs past 'z' — startingReferenceLetter holds a single a–z letter,
+ * so past that there is nothing representable to suggest.
+ */
+export function continuationReferenceLetter(count: number, startIndex = 0): string {
+  if (!Number.isInteger(count) || count <= 0) return '';
+  const next = startIndex + count;
+  return next < 26 ? String.fromCharCode(97 + next) : '';
+}
+
+/**
+ * The enclosure-number counterpart (Ch 9 ¶4): a source whose enclosures ran
+ * "up to number 5" puts this endorsement's first at 6. Returns undefined when
+ * the source adds no enclosures, leaving the field untouched.
+ */
+export function continuationEnclosureNumber(count: number, startNumber = 1): number | undefined {
+  if (!Number.isInteger(count) || count <= 0) return undefined;
+  return startNumber + count;
+}
+
 // Empty or a bracketed placeholder ([SSIC]) counts as absent.
 function usable(value: string | undefined): string {
   const t = (value ?? '').trim();

--- a/src/lib/viaLines.ts
+++ b/src/lib/viaLines.ts
@@ -1,0 +1,25 @@
+/**
+ * Via-addressee numbering, shared by both generators (generator.ts for PDF,
+ * flat-generator.ts for DOCX) so the rule lives in exactly one place and the
+ * two outputs cannot drift.
+ *
+ * SECNAV M-5216.5 Ch 9 ¶2 ("Via:" Line): "If there is only one via addressee
+ * remaining, do not number it. If there is more than one remaining, number
+ * the remaining addresses starting with the number (1) in parenthesis and
+ * consecutively number the rest." Fig 9-2's basic letter carries the same
+ * "(1) … (2) …" numbering, so this applies to every doc type with a Via
+ * line, not just endorsements.
+ *
+ * The form stores one bare addressee per line (the row badge in
+ * AddressingSection shows the number); numbering is applied here, at the data
+ * level, so the tex templates and the DOCX tabular rows both render the
+ * returned lines verbatim.
+ */
+export function formatViaLines(via: string | undefined): string[] {
+  const lines = (via ?? '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length <= 1) return lines;
+  return lines.map((line, i) => `(${i + 1}) ${line}`);
+}

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -23,6 +23,7 @@ import {
   appendedEndorsementSigner,
 } from '@/lib/appendedEndorsement';
 import { splitAddressForLetterhead } from '@/lib/unitAddress';
+import { formatViaLines } from '@/lib/viaLines';
 import { deriveOverallClassLevel } from '@/lib/overallClassification';
 
 interface DocumentStore {
@@ -455,15 +456,14 @@ function buildAddressBlock(data: Partial<DocumentData>, config: DocTypeConfig): 
   }
 
   if (config.via && data.via?.trim()) {
-    const viaLines = data.via.split('\n').filter((l: string) => l.trim());
-    // Per SECNAV Ch 9 ¶2: suppress (1) numbering when only one via
-    const useNumbering = viaLines.length > 1;
+    // formatViaLines applies the Ch 9 ¶2 numbering — single source shared
+    // with the PDF path (generator.ts), so the two outputs cannot drift.
+    const viaLines = formatViaLines(data.via);
     for (let i = 0; i < viaLines.length; i++) {
-      const prefix = useNumbering ? `(${i + 1}) ` : '';
       if (i === 0) {
-        rows.push(`Via:\\hspace{5\\fontdimen2\\font} & ${prefix}${escapeTabularWrapped(viaLines[i])} \\\\`);
+        rows.push(`Via:\\hspace{5\\fontdimen2\\font} & ${escapeTabularWrapped(viaLines[i])} \\\\`);
       } else {
-        rows.push(` & ${prefix}${escapeTabularWrapped(viaLines[i])} \\\\`);
+        rows.push(` & ${escapeTabularWrapped(viaLines[i])} \\\\`);
       }
     }
   }

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -1035,7 +1035,20 @@ function buildEndorsementHeader(docType: string, data: Partial<DocumentData>): s
     : `${ordinalUpper} ENDORSEMENT`;
 
   if (docType === 'same_page_endorsement') {
-    return `\\vspace{24pt}\n\\rule{\\textwidth}{0.5pt}\n\n${endorsementLine}\n\n\\vspace{12pt}\n`;
+    // Serial and date sit right-aligned between the rule and the endorsement
+    // line (Fig 9-1: "Ser 019/870" / "23 Apr 15"); \printDateAndTitle in
+    // same_page_endorsement.tex is the PDF side of this block. tabularx{Xr},
+    // not \hfill — dondocs.lua drops raw LaTeX it doesn't know (see
+    // buildAppendedEndorsement). Serial is optional; both rows drop when the
+    // endorser hand-dates at signature.
+    const idRows = [data.serial, data.date]
+      .filter(Boolean)
+      .map((row) => ` & ${escapeTabular(row)} \\\\`)
+      .join('\n');
+    const idBlock = idRows
+      ? `\\vspace{12pt}\n\\noindent\n\\begin{tabularx}{\\textwidth}{@{}Xr@{}}\n${idRows}\n\\end{tabularx}\n\n`
+      : '';
+    return `\\vspace{24pt}\n\\rule{\\textwidth}{0.5pt}\n\n${idBlock}\\vspace{12pt}\n${endorsementLine}\n\n\\vspace{12pt}\n`;
   }
   return `${endorsementLine}\n\n\\vspace{12pt}\n`;
 }

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -5,6 +5,7 @@ import { base64ToUint8Array } from '@/lib/encoding';
 import { enclosureStartNumber, pageStartNumber } from '@/lib/endorsement';
 import { safeUrl } from '@/lib/url-safety';
 import { splitAddressForLetterhead } from '@/lib/unitAddress';
+import { formatViaLines } from '@/lib/viaLines';
 import { deriveOverallClassLevel } from '@/lib/overallClassification';
 import {
   resolveAppendedEndorsement,
@@ -166,11 +167,12 @@ ${isBusinessLetter ? `% Business letter: format recipient address as block with 
     {}{}{}{}`}
 
 ${data.via?.trim() ? (() => {
-  // Split once and pad to 4 lines so indices 0..3 are always defined.
-  // Previously this called data.via?.split('\n')[N] four separate times and
-  // leaned on `|| ''` to paper over undefined entries — fragile and wasted
-  // work (see #20). Empty strings are rendered as empty LaTeX groups.
-  const viaLines = data.via.split('\n');
+  // formatViaLines numbers the addressees when more than one remains
+  // (Ch 9 ¶2) — shared with flat-generator.ts so PDF and DOCX agree. The
+  // templates render \ViaLineOne..Four verbatim, so numbering here fixes
+  // every template at once. Pad to 4 lines so indices 0..3 are always
+  // defined; empty strings are rendered as empty LaTeX groups.
+  const viaLines = formatViaLines(data.via);
   const [l0 = '', l1 = '', l2 = '', l3 = ''] = viaLines;
   return `\\setVia
     {${escapeLatex(l0)}}

--- a/tests/integration/differential.test.ts
+++ b/tests/integration/differential.test.ts
@@ -120,6 +120,11 @@ const FIXTURES: DiffFixture[] = [
   // endorsement marker — divergence here would mean one path lost
   // the endorsement framing entirely.
   plain('same_page_endorsement', 'baseline', {}, 'ENDORSEMENT'),
+
+  // …and its date must survive in both too. Fig 9-1 places the serial and
+  // date between the separating rule and the endorsement line; the DOCX path
+  // used to drop them while the PDF's \printDateAndTitle rendered them.
+  plain('same_page_endorsement', 'serial-date', {}, '15 Jan 26'),
 ];
 
 async function extractPdfText(pdfBytes: Uint8Array): Promise<string> {

--- a/tests/integration/via-numbering-render.test.ts
+++ b/tests/integration/via-numbering-render.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Via-addressee numbering, proved on the rendered page in BOTH outputs.
+ *
+ * SECNAV M-5216.5 Ch 9 ¶2 ("Via:" Line): "If there is only one via addressee
+ * remaining, do not number it. If there is more than one remaining, number
+ * the remaining addresses starting with the number (1) in parenthesis and
+ * consecutively number the rest."
+ *
+ * The DOCX path numbered via lines from the start; the PDF path never did —
+ * the templates render \ViaLineOne..Four verbatim. The fix numbers the lines
+ * once, in the shared formatViaLines helper, so this suite asserts three
+ * things off the extracted text: the numbers appear in both outputs, a lone
+ * via stays unnumbered in both, and nothing double-numbers ("(1) (1)").
+ *
+ * Requires pdflatex + pdftotext + pandoc; fails rather than skips in CI.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { writeFile, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import mammoth from 'mammoth';
+import { compileFixture } from '../_helpers/compileLatex';
+import { compileDocxFixture } from '../_helpers/compileDocx';
+import { buildBaseline } from '../_helpers/compileMatrix';
+import { hasPdfToolchain, describeToolchainRequirement } from '../_helpers/pdfToolchain';
+
+const pandocAvailable =
+  spawnSync('pandoc', ['--version'], { encoding: 'utf-8' }).status === 0;
+const toolchain = hasPdfToolchain && pandocAvailable;
+
+async function renderBoth(via: string): Promise<{ pdf: string; docx: string }> {
+  const store = buildBaseline('new_page_endorsement');
+  store.formData = { ...store.formData, via };
+  // No references or enclosures: their labels ("(a)", "(1)") would collide
+  // with the only "(N)" these assertions are about — the via numbers.
+  store.references = [];
+  store.enclosures = [];
+
+  const [pdfResult, docxResult] = await Promise.all([
+    compileFixture(store),
+    compileDocxFixture(store),
+  ]);
+  expect(pdfResult.ok, `pdflatex failed; work dir: ${pdfResult.workDir}`).toBe(true);
+  expect(docxResult.ok, `pandoc failed; work dir: ${docxResult.workDir}`).toBe(true);
+
+  const dir = await mkdtemp(join(tmpdir(), 'dondocs-vianum-'));
+  const pdfPath = join(dir, 'out.pdf');
+  await writeFile(pdfPath, pdfResult.pdfBytes!);
+  const { stdout: pdf } = spawnSync('pdftotext', [pdfPath, '-'], { encoding: 'utf-8' });
+  expect(pdf.trim().length).toBeGreaterThan(0);
+
+  const { value: docx } = await mammoth.extractRawText({
+    buffer: Buffer.from(docxResult.docxBytes!),
+  });
+  expect(docx.trim().length).toBeGreaterThan(0);
+
+  return { pdf, docx };
+}
+
+describe('via addressee numbering — rendered PDF and DOCX', () => {
+  describeToolchainRequirement('via-numbering-render');
+
+  it.skipIf(!toolchain)('numbers two remaining via addressees (1), (2) in both outputs', async () => {
+    const { pdf, docx } = await renderBoth(
+      'Commander, Sea Based Anti-Submarine Warfare Wing, Atlantic\nCommander, Naval Air Force, U.S. Atlantic Fleet'
+    );
+    for (const [name, text] of [['PDF', pdf], ['DOCX', docx]] as const) {
+      expect(text, `${name} lost the first via number`).toMatch(
+        /\(1\)\s+Commander, Sea Based/
+      );
+      expect(text, `${name} lost the second via number`).toMatch(
+        /\(2\)\s+Commander, Naval Air Force/
+      );
+      // Numbering must happen in exactly one place — a prefix from each
+      // generator layered on the shared helper would render "(1) (1)".
+      expect(text, `${name} double-numbered the via line`).not.toMatch(/\(1\)\s+\(1\)/);
+    }
+  }, 90_000);
+
+  it.skipIf(!toolchain)('leaves a lone via addressee unnumbered in both outputs', async () => {
+    const { pdf, docx } = await renderBoth('Commander, Naval Air Force, U.S. Atlantic Fleet');
+    for (const [name, text] of [['PDF', pdf], ['DOCX', docx]] as const) {
+      expect(text, `${name} dropped the via line`).toMatch(/Commander, Naval Air Force/);
+      expect(text, `${name} numbered a lone via addressee`).not.toContain('(1)');
+    }
+  }, 90_000);
+});

--- a/tests/regressions/same-page-endorsement-serial-date-docx.test.ts
+++ b/tests/regressions/same-page-endorsement-serial-date-docx.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The DOCX same-page endorsement carries its serial and date (SECNAV
+ * M-5216.5 Ch 9, Fig 9-1).
+ *
+ * Fig 9-1 puts "Ser 019/870" / "23 Apr 15" right-aligned between the rule
+ * that separates the endorsement from the basic letter and the endorsement
+ * line — Ch 9 ¶2.1a's same-page omission list covers the SSIC, subject, and
+ * basic letter's identification symbols, not the endorsement's own date. The
+ * PDF template prints them (\printDateAndTitle in same_page_endorsement.tex);
+ * the flat generator emitted only the rule + endorsement line, so the DOCX
+ * shipped an undated endorsement.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateFlatLatex } from '@/services/latex/flat-generator';
+
+function store(formData: Record<string, string>) {
+  return {
+    docType: 'same_page_endorsement',
+    formData: {
+      docType: 'same_page_endorsement',
+      from: 'Commander, Sea Based Anti-Submarine Warfare Wing, Atlantic',
+      to: 'Commander, Fleet Forces Command',
+      endorsementOrdinal: 'FIRST',
+      sigFirst: 'Robert',
+      sigLast: 'GABEL',
+      ...formData,
+    },
+    references: [],
+    enclosures: [],
+    paragraphs: [{ text: 'Forwarded, recommending approval.', level: 0 }],
+    copyTos: [],
+    distributions: [],
+  } as never;
+}
+
+describe('same-page endorsement serial and date in DOCX', () => {
+  it('emits serial and date right-aligned above the endorsement line (Fig 9-1)', () => {
+    const tex = generateFlatLatex(store({ serial: 'Ser 019/870', date: '23 Apr 15' }));
+
+    // Right-aligned block — the tabularx{Xr} idiom, since dondocs.lua drops
+    // \hfill — with serial above date, before the endorsement line.
+    const block = tex.match(/\\begin\{tabularx\}\{\\textwidth\}\{@\{\}Xr@\{\}\}([\s\S]*?)\\end\{tabularx\}/);
+    expect(block).not.toBeNull();
+    expect(block![1]).toMatch(/Ser 019\/870[\s\S]*23 Apr 15/);
+    expect(tex.indexOf('23 Apr 15')).toBeLessThan(tex.indexOf('FIRST ENDORSEMENT'));
+  });
+
+  it('drops the serial row alone when only the date is set', () => {
+    const tex = generateFlatLatex(store({ date: '23 Apr 15' }));
+    expect(tex).toContain('23 Apr 15');
+    expect(tex).not.toContain('Ser');
+  });
+
+  it('emits no empty block when the endorser hand-dates at signature', () => {
+    const tex = generateFlatLatex(store({}));
+    // No id block between the rule and the endorsement line.
+    const between = tex.slice(tex.indexOf('\\rule'), tex.indexOf('FIRST ENDORSEMENT'));
+    expect(between).not.toContain('tabularx');
+  });
+});

--- a/tests/unit/endorsement-continuation.test.ts
+++ b/tests/unit/endorsement-continuation.test.ts
@@ -12,6 +12,8 @@ import {
   isEndorsement,
   referenceStartIndex,
   enclosureStartNumber,
+  continuationReferenceLetter,
+  continuationEnclosureNumber,
 } from '@/lib/endorsement';
 
 describe('isEndorsement', () => {
@@ -69,5 +71,50 @@ describe('enclosureStartNumber', () => {
 
   it('floors a fractional value rather than emitting "(2.5)"', () => {
     expect(enclosureStartNumber('same_page_endorsement', 2.7)).toBe(2);
+  });
+});
+
+describe('continuationReferenceLetter', () => {
+  it("continues the source's sequence — the reg's own example", () => {
+    // Ch 9 ¶3: "identified up to letter 'f', the first reference of your
+    // endorsement would be letter 'g'" — six references (a-f) → (g).
+    expect(continuationReferenceLetter(6)).toBe('g');
+    expect(continuationReferenceLetter(3)).toBe('d');
+  });
+
+  it('keeps counting when the source itself continued a sequence', () => {
+    // Endorsing an endorsement: the source started at (d) and added (d), (e),
+    // so this one starts at (f) — not back at (c).
+    expect(continuationReferenceLetter(2, 3)).toBe('f');
+  });
+
+  it('returns "" when the source identifies no references', () => {
+    expect(continuationReferenceLetter(0)).toBe('');
+    expect(continuationReferenceLetter(-1)).toBe('');
+    expect(continuationReferenceLetter(1.5)).toBe('');
+  });
+
+  it('returns "" past (z) — the field holds a single letter', () => {
+    expect(continuationReferenceLetter(25)).toBe('z');
+    expect(continuationReferenceLetter(26)).toBe('');
+    expect(continuationReferenceLetter(20, 10)).toBe('');
+  });
+});
+
+describe('continuationEnclosureNumber', () => {
+  it("continues the source's sequence — the reg's own example", () => {
+    // Ch 9 ¶4: "identified up to number '5', the first enclosure of your
+    // endorsement would be number '6'."
+    expect(continuationEnclosureNumber(5)).toBe(6);
+  });
+
+  it('keeps counting when the source itself continued a sequence', () => {
+    expect(continuationEnclosureNumber(2, 6)).toBe(8);
+  });
+
+  it('returns undefined when the source adds no enclosures', () => {
+    expect(continuationEnclosureNumber(0)).toBeUndefined();
+    expect(continuationEnclosureNumber(-2)).toBeUndefined();
+    expect(continuationEnclosureNumber(0.5)).toBeUndefined();
   });
 });

--- a/tests/unit/viaLines.test.ts
+++ b/tests/unit/viaLines.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Via-addressee numbering (SECNAV M-5216.5 Ch 9 ¶2).
+ *
+ * "If there is only one via addressee remaining, do not number it. If there
+ * is more than one remaining, number the remaining addresses starting with
+ * the number (1) in parenthesis and consecutively number the rest."
+ *
+ * The helper is the single source both generators consume, so these cases
+ * pin the rule for PDF and DOCX at once.
+ */
+import { describe, it, expect } from 'vitest';
+import { formatViaLines } from '@/lib/viaLines';
+
+describe('formatViaLines', () => {
+  it('does not number a lone via addressee', () => {
+    expect(formatViaLines('Commander, Naval Air Force, U.S. Atlantic Fleet')).toEqual([
+      'Commander, Naval Air Force, U.S. Atlantic Fleet',
+    ]);
+  });
+
+  it('numbers two or more addressees starting at (1)', () => {
+    expect(
+      formatViaLines(
+        'Commander, Sea Based Anti-Submarine Warfare Wing, Atlantic\nCommander, Naval Air Force, U.S. Atlantic Fleet'
+      )
+    ).toEqual([
+      '(1) Commander, Sea Based Anti-Submarine Warfare Wing, Atlantic',
+      '(2) Commander, Naval Air Force, U.S. Atlantic Fleet',
+    ]);
+  });
+
+  it('skips blank rows so numbering stays consecutive', () => {
+    expect(formatViaLines('XO\n\n  \nS-3')).toEqual(['(1) XO', '(2) S-3']);
+  });
+
+  // A blank line plus one addressee is still "only one remaining" — the
+  // filter must run before the count, or a trailing newline forces numbers.
+  it('treats a lone addressee with stray blank lines as unnumbered', () => {
+    expect(formatViaLines('XO\n\n')).toEqual(['XO']);
+  });
+
+  it('returns an empty list for undefined or all-whitespace input', () => {
+    expect(formatViaLines(undefined)).toEqual([]);
+    expect(formatViaLines('  \n ')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Three pre-existing endorsement defects found by a line-by-line Ch 9 audit, each proved on rendered output from both generators:

- **Via addressees now numbered when more than one remains** (Ch 9 ¶2: "If there is only one via addressee remaining, do not number it. If there is more than one remaining, number the remaining addresses starting with the number (1)"). The PDF never numbered; the DOCX numbered on its own. Numbering now happens once, at the data level (`formatViaLines`), shared by both generators — the DOCX's private copy is removed, and a rendered test guards against double-numbering.
- **The DOCX same-page endorsement carries its serial and date** (Fig 9-1 shows "Ser 019/870" / "23 Apr 15" above FIRST ENDORSEMENT). The Word export emitted only the rule and the endorsement line. Now right-aligned via the tabularx idiom the lua filter keeps, from the same fields the PDF uses; drops cleanly when both are blank. Differential fixture asserts the date in both extracted outputs.
- **"Autofill from a saved letter" no longer copies the letter's references and enclosures into the endorsement's own lines** (Ch 9 ¶3: "Do not repeat a reference in the reference line of your endorsement that has already been identified in the reference line of the basic letter"; ¶4 same for enclosures). It now sets the continuation fields instead — a letter with references a–c starts the endorsement at (d), 5 enclosures at (6) — never clobbering user-entered values. Live-verified in the app.

eslint clean; 1683 unit tests; via/differential/appended render suites plus the full 800-fixture compile matrices all pass. Version 1.2.103.