### PR TITLE
fix(pwa): stop stale-shell cache poisoning at all three layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,14 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
   just-rotated stylesheet cached HTML in its place and rendered the app
   unstyled until a hard refresh. A top-level 404.html switches Pages to real
   404s, matching the Docker/Workers deployments.
-- The service worker's app-shell fetch now bypasses the browser HTTP cache
-  entirely (no-store), removing the mechanism that let a stale shell into the
-  runtime cache in the first place — the 1.2.95 watchdog treated the symptom;
-  this removes the cause.
+- The service worker can no longer cache a non-200 response as the app shell
+  (error pages, redirect bodies, and opaque responses are rejected). The
+  stale-shell-via-HTTP-cache vector itself is closed at the origin — "/" is
+  served no-cache, so a cached shell has zero freshness and must revalidate
+  before it can satisfy the service worker's fetch. (A no-store fetch option
+  on the navigation rule was considered and rejected: workbox silently drops
+  fetchOptions for navigation requests, so it would compile in and do
+  nothing.)
 - The boot watchdog now retries once per distinct broken shell rather than
   once per tab session, so a tab can self-heal again when the first recovery
   didn't stick, and still can never loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.104] — 2026-07-16
+
+### Fixed
+
+- Missing files now return a real 404 instead of the app shell. The Pages
+  deployment served 200 + index.html for every missing path — including hashed
+  bundles an update had replaced — and the request-path header rules stamped
+  that HTML with "cache for a year, immutable". A browser that asked for a
+  just-rotated stylesheet cached HTML in its place and rendered the app
+  unstyled until a hard refresh. A top-level 404.html switches Pages to real
+  404s, matching the Docker/Workers deployments.
+- The service worker's app-shell fetch now bypasses the browser HTTP cache
+  entirely (no-store), removing the mechanism that let a stale shell into the
+  runtime cache in the first place — the 1.2.95 watchdog treated the symptom;
+  this removes the cause.
+- The boot watchdog now retries once per distinct broken shell rather than
+  once per tab session, so a tab can self-heal again when the first recovery
+  didn't stick, and still can never loop.
+
 ## [1.2.103] — 2026-07-16
 
 ### Fixed

--- a/index.html
+++ b/index.html
@@ -80,8 +80,16 @@
             try {
               if (window.__DD_BOOTED__) { sessionStorage.removeItem(KEY); return; }
               if (!navigator.onLine) return;
-              if (sessionStorage.getItem(KEY)) return; // one shot per tab session
-              sessionStorage.setItem(KEY, '1');
+              // One shot per DISTINCT broken shell, not per tab session: the
+              // module script's hashed src fingerprints the build this shell
+              // belongs to. Guarding on the bare session left a tab stuck when
+              // the first heal didn't take (a stale SW re-served a different
+              // stale shell) — a new fingerprint means a new failure worth one
+              // more attempt, while the same shell can still never loop.
+              var s = document.querySelector('script[type="module"][src]');
+              var shellId = (s && s.getAttribute('src')) || 'unknown';
+              if (sessionStorage.getItem(KEY) === shellId) return;
+              sessionStorage.setItem(KEY, shellId);
               var reload = function () { location.reload(); };
               var dropShellCaches = ('caches' in window)
                 ? caches.keys().then(function (keys) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dondocs",
-  "version": "1.2.102",
+  "version": "1.2.104",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dondocs",
-      "version": "1.2.102",
+      "version": "1.2.104",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.103",
+  "version": "1.2.104",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<!-- This file's PRESENCE is the fix, not its content: Cloudflare Pages serves
+     single-page-app fallback (HTTP 200 + index.html) for EVERY missing path
+     unless a top-level 404.html exists. That fallback is what poisoned client
+     caches: a request for a hashed bundle that a deploy had rotated away got
+     200 + HTML — stamped by the request-path _headers rule with
+     "max-age=31536000, immutable" — and browsers cached HTML-as-CSS/JS for a
+     year with no revalidation. The Workers deployment already returns real
+     404s (wrangler.toml not_found_handling = "none", DEP-1); this brings the
+     Pages deployment to parity. The app is a single page at "/" with
+     hash-based share links, so SPA deep-link rewriting is not needed. -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>Not found — DonDocs</title>
+    <style>
+      body { font-family: system-ui, sans-serif; display: grid; place-items: center; min-height: 100vh; margin: 0; background: #0b1220; color: #e2e8f0; }
+      main { text-align: center; padding: 2rem; }
+      a { color: #7dd3fc; }
+      p { color: #94a3b8; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>404 — not found</h1>
+      <p>This file doesn't exist (it may belong to an older build).</p>
+      <p><a href="/">Open DonDocs</a></p>
+    </main>
+  </body>
+</html>

--- a/tests/regressions/boot-watchdog-stale-shell.test.ts
+++ b/tests/regressions/boot-watchdog-stale-shell.test.ts
@@ -36,17 +36,26 @@ function extractWatchdogSource(): string {
   return src;
 }
 
+// The shell fingerprint: the hashed module src of the build this index.html
+// belongs to. The guard stores it so recovery is one-shot PER BROKEN SHELL —
+// a different stale shell (served by a stale SW after the first heal) gets one
+// more attempt, while the same shell can never loop.
+const SHELL_SRC = '/assets/main-abc123.js';
+
 interface RunOptions {
   booted: boolean;
   online?: boolean;
-  guardAlreadySet?: boolean;
+  /** Pre-set guard value: SHELL_SRC = this shell already healed. */
+  guardValue?: string;
   cacheKeys?: string[];
+  /** The module script src the current shell carries (null = none found). */
+  shellSrc?: string | null;
 }
 
 /** Run the extracted watchdog against doubles and fire its timer. */
 async function runWatchdog(opts: RunOptions) {
   const storage = new Map<string, string>();
-  if (opts.guardAlreadySet) storage.set(GUARD_KEY, '1');
+  if (opts.guardValue !== undefined) storage.set(GUARD_KEY, opts.guardValue);
 
   const deleted: string[] = [];
   const fetchCalls: { url: string; init?: RequestInit }[] = [];
@@ -62,6 +71,13 @@ async function runWatchdog(opts: RunOptions) {
   };
   const sandbox = {
     window: { __DD_BOOTED__: opts.booted ? true : undefined, caches: cachesStub },
+    document: {
+      querySelector: (sel: string) => {
+        if (!sel.includes('script')) return null;
+        const src = opts.shellSrc === undefined ? SHELL_SRC : opts.shellSrc;
+        return src === null ? null : { getAttribute: () => src };
+      },
+    },
     navigator: { onLine: opts.online ?? true },
     sessionStorage: {
       getItem: (k: string) => storage.get(k) ?? null,
@@ -117,13 +133,15 @@ describe('boot watchdog — stale shell recovery (v1.2.94 incident)', () => {
       { url: 'https://dondocs.test/', init: { cache: 'reload' } },
     ]);
     expect(r.reloads()).toBe(1);
-    expect(r.storage.get(GUARD_KEY)).toBe('1');
+    // The guard records WHICH shell was healed (the hashed module src), so
+    // recovery is one-shot per broken build rather than per tab session.
+    expect(r.storage.get(GUARD_KEY)).toBe(SHELL_SRC);
   });
 
-  it('never loops: a second firing with the guard set does nothing', async () => {
+  it('never loops: a second firing on the SAME broken shell does nothing', async () => {
     const r = await runWatchdog({
       booted: false,
-      guardAlreadySet: true,
+      guardValue: SHELL_SRC,
       cacheKeys: [`${SHELL_CACHE_PREFIX}-deadbeef`],
     });
     expect(r.deleted).toEqual([]);
@@ -131,10 +149,31 @@ describe('boot watchdog — stale shell recovery (v1.2.94 incident)', () => {
     expect(r.reloads()).toBe(0);
   });
 
+  it('heals again when a DIFFERENT stale shell appears after the first recovery', async () => {
+    // The reported incident: heal #1 ran, but a stale service worker then
+    // served a different stale shell — under the session-wide guard the tab
+    // was stuck until a manual hard refresh. A new shell fingerprint earns
+    // exactly one more attempt.
+    const r = await runWatchdog({
+      booted: false,
+      guardValue: '/assets/main-oldbuild.js',
+      cacheKeys: [`${SHELL_CACHE_PREFIX}-deadbeef`],
+    });
+    expect(r.deleted).toEqual([`${SHELL_CACHE_PREFIX}-deadbeef`]);
+    expect(r.reloads()).toBe(1);
+    expect(r.storage.get(GUARD_KEY)).toBe(SHELL_SRC);
+  });
+
+  it('a shell with no module script still gets a one-shot recovery under a stable key', async () => {
+    const r = await runWatchdog({ booted: false, shellSrc: null, cacheKeys: [] });
+    expect(r.reloads()).toBe(1);
+    expect(r.storage.get(GUARD_KEY)).toBe('unknown');
+  });
+
   it('healthy boot: no recovery, and the one-shot guard is cleared for next time', async () => {
     const r = await runWatchdog({
       booted: true,
-      guardAlreadySet: true, // left over from a prior recovered session
+      guardValue: SHELL_SRC, // left over from a prior recovered session
       cacheKeys: [`${SHELL_CACHE_PREFIX}-deadbeef`],
     });
     expect(r.deleted).toEqual([]);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -327,13 +327,18 @@ export default defineConfig({
             handler: 'NetworkFirst',
             options: {
               cacheName: `dondocs-app-shell-${GIT_SHA || BUILD_TIME.replace(/[:.]/g, '-')}`,
-              // The SW's "network" fetch goes through the browser HTTP cache by
-              // default, which is how a stale shell got stored in the runtime
-              // cache in the first place (the 1.2.95 incident — the watchdog
-              // treats the symptom; this removes the cause). no-store makes the
-              // shell fetch hit the origin every time; offline still falls back
-              // to the versioned cache below.
-              fetchOptions: { cache: 'no-store' },
+              // Do NOT add fetchOptions here: workbox silently DROPS
+              // fetchOptions for navigation requests (StrategyHandler.fetch,
+              // workbox#1796 — fetch(navRequest, init) throws, so it passes
+              // undefined). A `cache: 'no-store'` on this rule compiles into
+              // sw.js and does nothing. The guard against the 1.2.95 vector
+              // (SW's shell fetch satisfied by a stale browser HTTP cache
+              // entry) is the ORIGIN: public/_headers serves "/" with
+              // no-cache, must-revalidate, so a cached shell has zero
+              // freshness and must revalidate before it can satisfy anything.
+              // What we CAN harden here: never let a non-200 (error page,
+              // redirect body, opaque response) be stored as the app shell.
+              cacheableResponse: { statuses: [200] },
               networkTimeoutSeconds: 3,
               expiration: {
                 maxEntries: 1,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -327,6 +327,13 @@ export default defineConfig({
             handler: 'NetworkFirst',
             options: {
               cacheName: `dondocs-app-shell-${GIT_SHA || BUILD_TIME.replace(/[:.]/g, '-')}`,
+              // The SW's "network" fetch goes through the browser HTTP cache by
+              // default, which is how a stale shell got stored in the runtime
+              // cache in the first place (the 1.2.95 incident — the watchdog
+              // treats the symptom; this removes the cause). no-store makes the
+              // shell fetch hit the origin every time; offline still falls back
+              // to the versioned cache below.
+              fetchOptions: { cache: 'no-store' },
               networkTimeoutSeconds: 3,
               expiration: {
                 maxEntries: 1,


### PR DESCRIPTION
A user hit the unstyled-raw-HTML state (works in incognito, hard refresh heals, normal refresh re-breaks). Root-caused with live header probes; three stacked defects, two fixable here:

1. **SPA fallback poisons caches — the big one.** The Pages deployment returns `200 + index.html` for every missing path, and the request-path `/assets/*` header rule stamps that HTML `max-age=31536000, immutable`. Verified live: `GET /assets/nonexistent.css` → 200, `text/html`, immutable. After a deploy rotates bundles, a client asking for the old stylesheet caches **HTML-as-CSS for a year with no revalidation**. `public/404.html` flips Pages to real 404s (presence is the fix — Pages only does SPA fallback when no top-level 404.html exists), matching the Workers deployment's existing `not_found_handling = "none"`. **Must be confirmed by probe after first deploy:** `GET /assets/nonexistent.css` must return 404.
2. **The shell cache can never store a non-200** (`cacheableResponse: { statuses: [200] }` on the navigation rule) — an error page, redirect body, or opaque response can't become the app shell. *Honesty note: an earlier revision of this PR used `fetchOptions: { cache: 'no-store' }` here; deep review found workbox silently drops fetchOptions for navigation requests (workbox#1796), so it compiled in and did nothing. The actual guard against the 1.2.95 HTTP-cache vector is the origin serving `/` with `no-cache, must-revalidate` (verified live); the rule's comment now documents both facts.*
3. **Watchdog heals per distinct broken shell**, keyed by the hashed module `src`, instead of once per tab session — a tab whose first heal didn't stick (a stale SW re-serving a different broken build, the reported incident) recovers again, and the same shell still can't loop. The 1.2.95 regression suite is rewritten to pin this contract, including that incident as a named case.

**Needs the Cloudflare dashboard (can't be fixed in-repo):** the marines.dev zone edge-caches `.js` by extension and rewrites `Cache-Control` on `/sw.js` from `no-cache` to `max-age=14400` (verified: pages.dev serves it correctly, the custom domain doesn't). Until a zone Cache Rule bypasses `/sw.js`, clients can ride a stale service worker up to 4h after each deploy — with this PR that degrades to one automatic self-heal reload rather than a stuck tab, but the rule should still be added: Caching → Cache Rules → Bypass cache, URI Path equals `/sw.js`, then purge that URL.

**Known residual, self-limiting:** with real 404s, a request for an old build's asset can cache the 404 under the `/assets/*` immutable header. Those URLs belong to dead builds and are never requested again once the shell updates (hash rotation + watchdog), so the entry is inert.

**Merge-order note:** this PR is v1.2.104; #213/#216/#217 carry v1.2.101–103. Merge in ascending version order (#213 → #216 → #217 → #218) or the auto-release "latest" marker will point at whichever lower version lands last.

Verified: `dist/404.html` ships; built `sw.js` carries `CacheableResponsePlugin({statuses:[200]})` on the shell rule and no decorative options; built `index.html` carries the fingerprinted watchdog; 1670 unit tests green (8 watchdog contract tests, including the different-shell re-heal).