### PR TITLE
feat(forms): signature blocks on both NAVMC forms — typed, image, and CAC-signable (1.2.108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,15 +22,23 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
   your profile in one click, and a signature block never splits across the
   page break: if it won't fit, the whole block (statement, signing space, and
   name) moves to the continuation page together.
-- Any AA-form signature block can carry a digital signature field. Tick
-  "Digital signature field (CAC)" on a block and the exported PDF gets a real,
-  empty AcroForm signature field in that block's signing space — the same kind
-  of field the naval letter already offers, which Adobe Acrobat and CAC
-  middleware recognize as signable. DonDocs embeds the field; the cryptographic
-  signature is applied later in Acrobat (a browser cannot reach a CAC's private
-  key). The field is placed by computed geometry, not a text search, and
-  follows its block onto the continuation page so it can never be stranded away
-  from the name it belongs to.
+- Each AA-form signature block now chooses how it signs — **Typed** name,
+  **Image** (upload a scanned signature, drawn into the signing space), or
+  **Digital** (an empty CAC-signable AcroForm field, signed later in Acrobat) —
+  the same three-way choice the naval letter offers. Image and digital marks are
+  placed by computed geometry, not a text search, and follow their block onto
+  the continuation page so they can never be stranded away from the name. (The
+  cryptographic CAC signature is applied in Acrobat; a browser cannot reach a
+  CAC's private key.)
+- The **NAVMC 118(11) / Page 11 (6105)** entry can now carry its signatures too.
+  A counseling entry is authenticated by the counselor and the counseled Marine
+  (MCO 1610.7 / IRAM); DonDocs appends signature blocks — typed, image, or
+  digital — to the end of the remarks, with the acknowledgement wording yours to
+  set. The form's three pre-printed "(Signature)" cells (Art 137, SBP) are left
+  alone; these close the entry text, where a 6105's signatures actually go.
+- Under the hood, both forms now share one signature model and one set of
+  pdf-lib primitives, so the AA form and the 118(11) can't drift apart as
+  signing grows.
 
 ### Fixed
 
@@ -41,7 +49,7 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
   paragraph.
 - Removed a phantom "13." from that field's label (the printed form has no
   field 13) and a never-rendered, never-collected signature field from the
-  6105 generator (the printed NAVMC 118(11) carries its own signature lines).
+  6105 generator.
 
 ## [1.2.106] — 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.107] — 2026-07-18
+
+### Added
+
+- The AA form (NAVMC 10274) now types its signature blocks for you — up to
+  four, in signing order, because a counseling action carries more than one:
+  the originator (whose block the form's own caption mandates — "type name of
+  originator and sign 3 lines below text"), the counseled Marine's
+  acknowledgement, and sometimes a witness. Each block takes an optional
+  statement ("I acknowledge receipt…", "Witnessed:") printed above its signing
+  space, with the typed name on the third line below. Users had to fake all of
+  this by hand, tabbing across the supplemental-information box or editing the
+  exported file — and tabs are normalized to spaces in a proportional font, so
+  that alignment could never come out right. The originator's name fills from
+  your profile in one click, and a signature block never splits across the
+  page break: if it won't fit, the whole block (statement, signing space, and
+  name) moves to the continuation page together.
+- Any AA-form signature block can carry a digital signature field. Tick
+  "Digital signature field (CAC)" on a block and the exported PDF gets a real,
+  empty AcroForm signature field in that block's signing space — the same kind
+  of field the naval letter already offers, which Adobe Acrobat and CAC
+  middleware recognize as signable. DonDocs embeds the field; the cryptographic
+  signature is applied later in Acrobat (a browser cannot reach a CAC's private
+  key). The field is placed by computed geometry, not a text search, and
+  follows its block onto the continuation page so it can never be stranded away
+  from the name it belongs to.
+
+### Fixed
+
+- The AA form's "Proposed/Recommended Action" is no longer silently dropped
+  from the PDF. The field was collected and saved but never rendered — the
+  printed form has no box for it (its fields run 1–12) — so anything typed
+  there vanished on export. It now closes block 12 as its own labeled
+  paragraph.
+- Removed a phantom "13." from that field's label (the printed form has no
+  field 13) and a never-rendered, never-collected signature field from the
+  6105 generator (the printed NAVMC 118(11) carries its own signature lines).
+
 ## [1.2.106] — 2026-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,29 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
   signing/print order, so a counselor added after the fact no longer has to be
   deleted and re-added to sit above the Marine's acknowledgement — and on the
   AA form the block dragged to the top becomes the originator automatically.
+- Signature presets now arrive with the typed name already filled where the app
+  knows it: the counselor/originator from the active profile, and — on the
+  118(11) — the Marine's acknowledgement from the Marine Identification fields
+  the form already collects ("J. M. DOE"), instead of asking you to retype a
+  name that's two sections up. Witness stays blank; the app can't guess who
+  witnessed. All fills are editable.
+- An empty Signatures section offers the standard counseling setup in one
+  click — "Add originator/counselor + Marine acknowledgement" — which, with a
+  profile and the Marine's name on file, produces a ready-to-export pair
+  without typing.
+- After adding a signature block, focus lands in the new block's first field —
+  a preset pick flows straight into editing instead of leaving you to click
+  into the card (the add-menu suppresses its own focus-return to make room).
+
+### Changed
+
+- Removing a signature block that holds a statement, name, or uploaded
+  signature image now asks first — the same rule References and Enclosures
+  follow — and on the AA form warns that the next block becomes the
+  originator. An empty block still removes in one click.
+- Signature drag handles grew a padded hit area for touch, and a small drag
+  threshold keeps a touch-scroll that starts on a handle from becoming an
+  accidental reorder.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,18 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
 - Under the hood, both forms now share one signature model and one set of
   pdf-lib primitives, so the AA form and the 118(11) can't drift apart as
   signing grows.
+- Adding a signature block is now role-aware on both forms: **Add signature…**
+  offers Originator/Counselor, Marine acknowledgement, and Witness, each seeded
+  with the right starting statement so the boilerplate is one click away instead
+  of retyped. The wording stays fully editable — it's a starting point, not a
+  locked value.
+- On the AA form, signatures now live in their own **Signatures** section in the
+  editor outline rather than buried at the bottom of Counseling Content, so the
+  originator's block is where you'd look for it. (The 118(11) already had one.)
+- Digital (CAC-signable) signature fields now carry the signer's name — a block
+  for "R. L. SMITH" produces a field named for them instead of an anonymous
+  "Signature 1", so Acrobat's signature panel and any downstream tooling can
+  tell the counselor's field from the Marine's.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,9 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
   A counseling entry is authenticated by the counselor and the counseled Marine
   (MCO 1610.7 / IRAM); DonDocs appends signature blocks — typed, image, or
   digital — to the end of the remarks, with the acknowledgement wording yours to
-  set. The form's three pre-printed "(Signature)" cells (Art 137, SBP) are left
-  alone; these close the entry text, where a 6105's signatures actually go.
+  set and the counselor's name a one-click fill from your profile (as on the AA
+  form). The form's three pre-printed "(Signature)" cells (Art 137, SBP) are
+  left alone; these close the entry text, where a 6105's signatures actually go.
 - Under the hood, both forms now share one signature model and one set of
   pdf-lib primitives, so the AA form and the 118(11) can't drift apart as
   signing grows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
   for "R. L. SMITH" produces a field named for them instead of an anonymous
   "Signature 1", so Acrobat's signature panel and any downstream tooling can
   tell the counselor's field from the Marine's.
+- Signature blocks on both forms can be **dragged to reorder** (grip handle,
+  keyboard-operable like the References list). Order is the top-to-bottom
+  signing/print order, so a counselor added after the fact no longer has to be
+  deleted and re-added to sit above the Marine's acknowledgement — and on the
+  AA form the block dragged to the top becomes the originator automatically.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,26 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
 - After adding a signature block, focus lands in the new block's first field —
   a preset pick flows straight into editing instead of leaving you to click
   into the card (the add-menu suppresses its own focus-return to make room).
+- The 118(11) editor now shows how the entry **fits the printed page**: a live
+  "≈ N of 37 printed lines" readout under each remarks column and a warning
+  the moment text (or the closing date/signature blocks) runs past what the
+  column can hold. The form is a single physical page — there is no
+  continuation sheet — and previously anything past the cap was silently left
+  off the exported PDF. The counts come from the generator's own font metrics
+  and wrapping, so the warning and the printout can't disagree.
+- The AA form's **From** and **Organization/Station** gained one-click "Use
+  profile" fills — the originator's rank and name, and your own unit's
+  name/address, straight from the active profile (the fields users retype most
+  often). Both fills are explicit buttons, never written silently.
+
+### Fixed
+
+- The 118(11) remarks columns' line cap is now calibrated to the printed form:
+  a rendered probe showed the old 40-line cap letting the last three lines
+  print **on top of the NAME/EDIPI identification strip** at the bottom of the
+  page. Each column now stops at 37 lines — the last line that clears the
+  strip — and the new fit warning surfaces what didn't make it instead of
+  dropping it silently.
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dondocs",
-  "version": "1.2.106",
+  "version": "1.2.107",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dondocs",
-      "version": "1.2.106",
+      "version": "1.2.107",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.106",
+  "version": "1.2.107",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/src/components/editor/AddSignatureBlockMenu.tsx
+++ b/src/components/editor/AddSignatureBlockMenu.tsx
@@ -1,0 +1,42 @@
+import { Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { signaturePresets, type SignatureFormKind } from '@/lib/signaturePresets';
+import type { FormSignatureBlock } from '@/types/signature';
+
+/**
+ * "Add signature…" split into role presets (Counselor/Originator, Marine
+ * acknowledgement, Witness) so a properly-worded block is one click away.
+ * Shared by both NAVMC form sections.
+ */
+export function AddSignatureBlockMenu({
+  form,
+  onAdd,
+  disabled,
+}: {
+  form: SignatureFormKind;
+  onAdd: (block: FormSignatureBlock) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="outline" size="sm" disabled={disabled}>
+          <Plus className="mr-1.5 h-3.5 w-3.5" /> Add signature…
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {signaturePresets(form).map((preset) => (
+          <DropdownMenuItem key={preset.id} onSelect={() => onAdd(preset.make())}>
+            {preset.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/editor/AddSignatureBlockMenu.tsx
+++ b/src/components/editor/AddSignatureBlockMenu.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -6,23 +7,41 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { signaturePresets, type SignatureFormKind } from '@/lib/signaturePresets';
+import {
+  signaturePresets,
+  type SignatureFormKind,
+  type SignaturePresetNames,
+} from '@/lib/signaturePresets';
 import type { FormSignatureBlock } from '@/types/signature';
 
 /**
  * "Add signature…" split into role presets (Counselor/Originator, Marine
  * acknowledgement, Witness) so a properly-worded block is one click away.
- * Shared by both NAVMC form sections.
+ * Shared by both NAVMC form sections. `names` pre-fills typed names the app
+ * already knows (profile signer, the 118(11)'s Marine) — editable, never
+ * locked.
  */
 export function AddSignatureBlockMenu({
   form,
   onAdd,
   disabled,
+  names,
 }: {
   form: SignatureFormKind;
-  onAdd: (block: FormSignatureBlock) => void;
+  /**
+   * Called with the new block. May return a focus callback (e.g. "focus the
+   * new block's first input") — the menu runs it when it closes, at the exact
+   * moment Radix would otherwise return focus to the trigger. Timing matters:
+   * the menu's exit animation means close cleanup outlives any fixed-frame
+   * deferral a caller could schedule, so the menu must own this hand-off.
+   */
+  onAdd: (block: FormSignatureBlock) => void | (() => void);
   disabled?: boolean;
+  names?: SignaturePresetNames;
 }) {
+  // Set only when a preset was chosen; an Escape dismissal leaves it null and
+  // keeps Radix's normal focus-return to the trigger.
+  const focusAfterClose = useRef<(() => void) | null>(null);
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -30,9 +49,24 @@ export function AddSignatureBlockMenu({
           <Plus className="mr-1.5 h-3.5 w-3.5" /> Add signature…
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
-        {signaturePresets(form).map((preset) => (
-          <DropdownMenuItem key={preset.id} onSelect={() => onAdd(preset.make())}>
+      <DropdownMenuContent
+        align="start"
+        onCloseAutoFocus={(e) => {
+          if (focusAfterClose.current) {
+            e.preventDefault();
+            focusAfterClose.current();
+            focusAfterClose.current = null;
+          }
+        }}
+      >
+        {signaturePresets(form, names).map((preset) => (
+          <DropdownMenuItem
+            key={preset.id}
+            onSelect={() => {
+              const focus = onAdd(preset.make());
+              focusAfterClose.current = typeof focus === 'function' ? focus : null;
+            }}
+          >
             {preset.label}
           </DropdownMenuItem>
         ))}

--- a/src/components/editor/Form11811Section.tsx
+++ b/src/components/editor/Form11811Section.tsx
@@ -27,6 +27,8 @@ import { arrayMove } from '@dnd-kit/sortable';
 import type { FormSignatureBlock } from '@/types/signature';
 import { useProfileStore } from '@/stores/profileStore';
 import { abbreviatedSignatoryName } from '@/lib/signatoryName';
+import { standardSignaturePair } from '@/lib/signaturePresets';
+import { showAppConfirm } from '@/stores/alertStore';
 
 // Names to sort first in the @ autocomplete. This only reorders entries that
 // exist in `placeholders` (NAVMC_118_11_PLACEHOLDERS = NAME, DATE), so any name
@@ -58,8 +60,43 @@ export function Form11811Section() {
       'signatureBlocks',
       signatureBlocks.map((b, i) => (i === index ? { ...b, ...patch } : b))
     );
-  const removeSignatureBlock = (index: number) =>
+  // The counseled Marine's name in the same abbreviated form, derived from the
+  // Marine Identification fields this form already collects — so the
+  // acknowledgement preset arrives pre-filled instead of asking the user to
+  // retype a name that's two sections up.
+  const marineAckName = abbreviatedSignatoryName(
+    navmc11811.firstName,
+    navmc11811.middleName,
+    navmc11811.lastName
+  );
+  // Deleting a filled block loses a statement, a typed name, and possibly an
+  // uploaded signature image. Confirm first, same rule as References /
+  // Enclosures: an empty block still removes in a single click.
+  const removeSignatureBlock = async (index: number) => {
+    const b = signatureBlocks[index];
+    const hasContent =
+      (b?.statement ?? '').trim() !== '' || (b?.name ?? '').trim() !== '' || !!b?.image;
+    if (hasContent) {
+      const confirmed = await showAppConfirm({
+        title: 'Remove signature block?',
+        message: `Signature ${index + 1} and its contents will be removed.`,
+        confirmLabel: 'Remove',
+        destructive: true,
+      });
+      if (!confirmed) return;
+    }
     setNavmc11811Field('signatureBlocks', signatureBlocks.filter((_, i) => i !== index));
+  };
+  // Move focus into a block's first input after it's added, so a preset pick
+  // flows straight into editing. Double-rAF: the first frame lets React commit
+  // the new card, the second runs after the dropdown's close cleanup so its
+  // focus handling can't land after ours.
+  const focusStatement = (index: number) =>
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() =>
+        document.getElementById(`p11-sig-${index}-statement`)?.focus()
+      )
+    );
   const activeId = useEditorOutlineStore((s) => s.activeId);
 
   return (
@@ -258,6 +295,7 @@ export function Form11811Section() {
                         </Button>
                       </div>
                       <InputWithVariables
+                        id={`p11-sig-${index}-statement`}
                         value={block.statement}
                         onValueChange={(v) => setSignatureBlock(index, { statement: v })}
                         placeholder="Statement above the signing line (e.g. I have been counseled…)"
@@ -295,10 +333,40 @@ export function Form11811Section() {
                   </SortableSignatureItem>
                 ))}
               </SortableSignatureList>
-              <AddSignatureBlockMenu
-                form="navmc_118_11"
-                onAdd={(b) => setNavmc11811Field('signatureBlocks', [...signatureBlocks, b])}
-              />
+              <div className="flex flex-wrap gap-2">
+                <AddSignatureBlockMenu
+                  form="navmc_118_11"
+                  names={{ signer: profileSignatoryName, marine: marineAckName }}
+                  onAdd={(b) => {
+                    const index = signatureBlocks.length;
+                    setNavmc11811Field('signatureBlocks', [...signatureBlocks, b]);
+                    // Returned to the menu: it runs this on close, after its
+                    // exit animation, so the focus can't be clobbered.
+                    return () => focusStatement(index);
+                  }}
+                />
+                {signatureBlocks.length === 0 && (
+                  /* One click sets up the standard pair — counselor from the
+                     profile, the Marine from the identification fields above. */
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setNavmc11811Field(
+                        'signatureBlocks',
+                        standardSignaturePair('navmc_118_11', {
+                          signer: profileSignatoryName,
+                          marine: marineAckName,
+                        })
+                      );
+                      focusStatement(0);
+                    }}
+                  >
+                    Add counselor + Marine acknowledgement
+                  </Button>
+                )}
+              </div>
             </div>
           </AccordionContent>
         </AccordionItem>

--- a/src/components/editor/Form11811Section.tsx
+++ b/src/components/editor/Form11811Section.tsx
@@ -20,6 +20,8 @@ import { useFormStore } from '@/stores/formStore';
 import { useEditorOutlineStore } from '@/stores/editorOutlineStore';
 import { cn } from '@/lib/utils';
 import { NAVMC_118_11_PLACEHOLDERS } from '@/lib/constants';
+import { SignatureStylePicker } from './SignatureStylePicker';
+import type { FormSignatureBlock } from '@/types/signature';
 
 // Names to sort first in the @ autocomplete. This only reorders entries that
 // exist in `placeholders` (NAVMC_118_11_PLACEHOLDERS = NAME, DATE), so any name
@@ -38,6 +40,16 @@ function sectionRule(active: boolean): string {
 
 export function Form11811Section() {
   const { navmc11811, setNavmc11811Field, resetNavmc11811, clearNavmc11811 } = useFormStore();
+  const signatureBlocks = navmc11811.signatureBlocks;
+  const setSignatureBlock = (index: number, patch: Partial<FormSignatureBlock>) =>
+    setNavmc11811Field(
+      'signatureBlocks',
+      signatureBlocks.map((b, i) => (i === index ? { ...b, ...patch } : b))
+    );
+  const addSignatureBlock = () =>
+    setNavmc11811Field('signatureBlocks', [...signatureBlocks, { statement: '', name: '', style: 'typed' }]);
+  const removeSignatureBlock = (index: number) =>
+    setNavmc11811Field('signatureBlocks', signatureBlocks.filter((_, i) => i !== index));
   const activeId = useEditorOutlineStore((s) => s.activeId);
 
   return (
@@ -191,6 +203,61 @@ export function Form11811Section() {
               Include: incident description, date/location, standards violated, prior counseling (if any),
               expected corrective actions, and consequences of continued deficiency.
             </p>
+          </AccordionContent>
+        </AccordionItem>
+
+        {/* Signatures — close the 6105 entry (counselor + counseled Marine) */}
+        <AccordionItem value="signatures" id="sec-signatures" data-section="signatures" className={sectionRule(activeId === 'signatures')}>
+          <AccordionTrigger>Signatures</AccordionTrigger>
+          <AccordionContent>
+            <div className="space-y-4 pt-1">
+              <p className="text-xs text-muted-foreground">
+                A Page 11 entry is authenticated by the counselor and the
+                counseled Marine (MCO 1610.7 / IRAM). Each block prints at the
+                end of the entry text; type the acknowledgement wording your
+                command uses.
+              </p>
+              {signatureBlocks.map((block, index) => (
+                <div key={index} className="space-y-2 rounded-md border border-border p-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      Signature {index + 1}
+                    </span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Remove signature block ${index + 1}`}
+                      onClick={() => removeSignatureBlock(index)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  <InputWithVariables
+                    value={block.statement}
+                    onValueChange={(v) => setSignatureBlock(index, { statement: v })}
+                    placeholder="Statement above the signing line (e.g. I have been counseled…)"
+                    placeholders={NAVMC_118_11_PLACEHOLDERS}
+                    commonVariables={COMMON_FORM_VARS}
+                  />
+                  <InputWithVariables
+                    value={block.name}
+                    onValueChange={(v) => setSignatureBlock(index, { name: v })}
+                    placeholder="Typed name (e.g. A. B. SMITH)"
+                    placeholders={NAVMC_118_11_PLACEHOLDERS}
+                    commonVariables={COMMON_FORM_VARS}
+                  />
+                  <SignatureStylePicker
+                    block={block}
+                    index={index}
+                    onChange={(patch) => setSignatureBlock(index, patch)}
+                  />
+                </div>
+              ))}
+              <Button type="button" variant="outline" size="sm" onClick={addSignatureBlock}>
+                Add signature block
+              </Button>
+            </div>
           </AccordionContent>
         </AccordionItem>
       </Accordion>

--- a/src/components/editor/Form11811Section.tsx
+++ b/src/components/editor/Form11811Section.tsx
@@ -21,6 +21,7 @@ import { useEditorOutlineStore } from '@/stores/editorOutlineStore';
 import { cn } from '@/lib/utils';
 import { NAVMC_118_11_PLACEHOLDERS } from '@/lib/constants';
 import { SignatureStylePicker } from './SignatureStylePicker';
+import { AddSignatureBlockMenu } from './AddSignatureBlockMenu';
 import type { FormSignatureBlock } from '@/types/signature';
 import { useProfileStore } from '@/stores/profileStore';
 import { abbreviatedSignatoryName } from '@/lib/signatoryName';
@@ -55,8 +56,6 @@ export function Form11811Section() {
       'signatureBlocks',
       signatureBlocks.map((b, i) => (i === index ? { ...b, ...patch } : b))
     );
-  const addSignatureBlock = () =>
-    setNavmc11811Field('signatureBlocks', [...signatureBlocks, { statement: '', name: '', style: 'typed' }]);
   const removeSignatureBlock = (index: number) =>
     setNavmc11811Field('signatureBlocks', signatureBlocks.filter((_, i) => i !== index));
   const activeId = useEditorOutlineStore((s) => s.activeId);
@@ -278,9 +277,10 @@ export function Form11811Section() {
                   />
                 </div>
               ))}
-              <Button type="button" variant="outline" size="sm" onClick={addSignatureBlock}>
-                Add signature block
-              </Button>
+              <AddSignatureBlockMenu
+                form="navmc_118_11"
+                onAdd={(b) => setNavmc11811Field('signatureBlocks', [...signatureBlocks, b])}
+              />
             </div>
           </AccordionContent>
         </AccordionItem>

--- a/src/components/editor/Form11811Section.tsx
+++ b/src/components/editor/Form11811Section.tsx
@@ -22,6 +22,8 @@ import { cn } from '@/lib/utils';
 import { NAVMC_118_11_PLACEHOLDERS } from '@/lib/constants';
 import { SignatureStylePicker } from './SignatureStylePicker';
 import type { FormSignatureBlock } from '@/types/signature';
+import { useProfileStore } from '@/stores/profileStore';
+import { abbreviatedSignatoryName } from '@/lib/signatoryName';
 
 // Names to sort first in the @ autocomplete. This only reorders entries that
 // exist in `placeholders` (NAVMC_118_11_PLACEHOLDERS = NAME, DATE), so any name
@@ -40,6 +42,13 @@ function sectionRule(active: boolean): string {
 
 export function Form11811Section() {
   const { navmc11811, setNavmc11811Field, resetNavmc11811, clearNavmc11811 } = useFormStore();
+  // The counselor's initials + SURNAME from the active profile — the counselor
+  // is usually the person at the app, so offer their name as a one-click fill
+  // (never written silently), the same as the AA form's originator.
+  const profileSignatoryName = useProfileStore((s) => {
+    const p = s.selectedProfile ? s.profiles[s.selectedProfile] : undefined;
+    return p ? abbreviatedSignatoryName(p.sigFirst, p.sigMiddle, p.sigLast) : '';
+  });
   const signatureBlocks = navmc11811.signatureBlocks;
   const setSignatureBlock = (index: number, patch: Partial<FormSignatureBlock>) =>
     setNavmc11811Field(
@@ -240,13 +249,28 @@ export function Form11811Section() {
                     placeholders={NAVMC_118_11_PLACEHOLDERS}
                     commonVariables={COMMON_FORM_VARS}
                   />
-                  <InputWithVariables
-                    value={block.name}
-                    onValueChange={(v) => setSignatureBlock(index, { name: v })}
-                    placeholder="Typed name (e.g. A. B. SMITH)"
-                    placeholders={NAVMC_118_11_PLACEHOLDERS}
-                    commonVariables={COMMON_FORM_VARS}
-                  />
+                  <div className="flex items-center gap-2">
+                    <div className="min-w-0 flex-1">
+                      <InputWithVariables
+                        value={block.name}
+                        onValueChange={(v) => setSignatureBlock(index, { name: v })}
+                        placeholder="Typed name (e.g. A. B. SMITH)"
+                        placeholders={NAVMC_118_11_PLACEHOLDERS}
+                        commonVariables={COMMON_FORM_VARS}
+                      />
+                    </div>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="shrink-0"
+                      disabled={!profileSignatoryName}
+                      onClick={() => setSignatureBlock(index, { name: profileSignatoryName })}
+                      title={profileSignatoryName ? `Use ${profileSignatoryName}` : 'No profile signature to use'}
+                    >
+                      Use profile
+                    </Button>
+                  </div>
                   <SignatureStylePicker
                     block={block}
                     index={index}

--- a/src/components/editor/Form11811Section.tsx
+++ b/src/components/editor/Form11811Section.tsx
@@ -22,6 +22,8 @@ import { cn } from '@/lib/utils';
 import { NAVMC_118_11_PLACEHOLDERS } from '@/lib/constants';
 import { SignatureStylePicker } from './SignatureStylePicker';
 import { AddSignatureBlockMenu } from './AddSignatureBlockMenu';
+import { SortableSignatureList, SortableSignatureItem } from './SortableSignatureBlocks';
+import { arrayMove } from '@dnd-kit/sortable';
 import type { FormSignatureBlock } from '@/types/signature';
 import { useProfileStore } from '@/stores/profileStore';
 import { abbreviatedSignatoryName } from '@/lib/signatoryName';
@@ -222,61 +224,77 @@ export function Form11811Section() {
               <p className="text-xs text-muted-foreground">
                 A Page 11 entry is authenticated by the counselor and the
                 counseled Marine (MCO 1610.7 / IRAM). Each block prints at the
-                end of the entry text; type the acknowledgement wording your
-                command uses.
+                end of the entry text, top-to-bottom in the order below; drag a
+                block&apos;s handle to rearrange. Type the acknowledgement
+                wording your command uses.
               </p>
-              {signatureBlocks.map((block, index) => (
-                <div key={index} className="space-y-2 rounded-md border border-border p-3">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-medium text-muted-foreground">
-                      Signature {index + 1}
-                    </span>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`Remove signature block ${index + 1}`}
-                      onClick={() => removeSignatureBlock(index)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                  <InputWithVariables
-                    value={block.statement}
-                    onValueChange={(v) => setSignatureBlock(index, { statement: v })}
-                    placeholder="Statement above the signing line (e.g. I have been counseled…)"
-                    placeholders={NAVMC_118_11_PLACEHOLDERS}
-                    commonVariables={COMMON_FORM_VARS}
-                  />
-                  <div className="flex items-center gap-2">
-                    <div className="min-w-0 flex-1">
+              <SortableSignatureList
+                count={signatureBlocks.length}
+                className="space-y-4"
+                onReorder={(oldIndex, newIndex) =>
+                  setNavmc11811Field('signatureBlocks', arrayMove(signatureBlocks, oldIndex, newIndex))
+                }
+              >
+                {signatureBlocks.map((block, index) => (
+                  <SortableSignatureItem
+                    key={index}
+                    index={index}
+                    label={`signature block ${index + 1}`}
+                    showHandle={signatureBlocks.length > 1}
+                  >
+                    <div className="space-y-2 rounded-md border border-border p-3">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-muted-foreground">
+                          Signature {index + 1}
+                        </span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          aria-label={`Remove signature block ${index + 1}`}
+                          onClick={() => removeSignatureBlock(index)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </div>
                       <InputWithVariables
-                        value={block.name}
-                        onValueChange={(v) => setSignatureBlock(index, { name: v })}
-                        placeholder="Typed name (e.g. A. B. SMITH)"
+                        value={block.statement}
+                        onValueChange={(v) => setSignatureBlock(index, { statement: v })}
+                        placeholder="Statement above the signing line (e.g. I have been counseled…)"
                         placeholders={NAVMC_118_11_PLACEHOLDERS}
                         commonVariables={COMMON_FORM_VARS}
                       />
+                      <div className="flex items-center gap-2">
+                        <div className="min-w-0 flex-1">
+                          <InputWithVariables
+                            value={block.name}
+                            onValueChange={(v) => setSignatureBlock(index, { name: v })}
+                            placeholder="Typed name (e.g. A. B. SMITH)"
+                            placeholders={NAVMC_118_11_PLACEHOLDERS}
+                            commonVariables={COMMON_FORM_VARS}
+                          />
+                        </div>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="shrink-0"
+                          disabled={!profileSignatoryName}
+                          onClick={() => setSignatureBlock(index, { name: profileSignatoryName })}
+                          title={profileSignatoryName ? `Use ${profileSignatoryName}` : 'No profile signature to use'}
+                        >
+                          Use profile
+                        </Button>
+                      </div>
+                      <SignatureStylePicker
+                        block={block}
+                        index={index}
+                        onChange={(patch) => setSignatureBlock(index, patch)}
+                      />
                     </div>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="shrink-0"
-                      disabled={!profileSignatoryName}
-                      onClick={() => setSignatureBlock(index, { name: profileSignatoryName })}
-                      title={profileSignatoryName ? `Use ${profileSignatoryName}` : 'No profile signature to use'}
-                    >
-                      Use profile
-                    </Button>
-                  </div>
-                  <SignatureStylePicker
-                    block={block}
-                    index={index}
-                    onChange={(patch) => setSignatureBlock(index, patch)}
-                  />
-                </div>
-              ))}
+                  </SortableSignatureItem>
+                ))}
+              </SortableSignatureList>
               <AddSignatureBlockMenu
                 form="navmc_118_11"
                 onAdd={(b) => setNavmc11811Field('signatureBlocks', [...signatureBlocks, b])}

--- a/src/components/editor/Form11811Section.tsx
+++ b/src/components/editor/Form11811Section.tsx
@@ -1,4 +1,5 @@
-import { ClipboardList, RotateCcw, ChevronDown, Trash2, FileText } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { ClipboardList, RotateCcw, ChevronDown, Trash2, FileText, AlertTriangle } from 'lucide-react';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import {
@@ -29,6 +30,26 @@ import { useProfileStore } from '@/stores/profileStore';
 import { abbreviatedSignatoryName } from '@/lib/signatoryName';
 import { standardSignaturePair } from '@/lib/signaturePresets';
 import { showAppConfirm } from '@/stores/alertStore';
+import {
+  computeNavmc11811Fit,
+  type Navmc11811Fit,
+} from '@/services/pdf/navmc11811Generator';
+
+/**
+ * Per-column "≈ lines used / capacity" readout under a remarks editor. The
+ * counts come from the generator's own wrap metrics (computeNavmc11811Fit),
+ * so what this says matches what actually prints.
+ */
+function ColumnFitLine({ fit }: { fit: Navmc11811Fit['left'] | undefined }) {
+  if (!fit) return null;
+  const over = fit.truncated > 0;
+  return (
+    <p className={`text-xs ${over ? 'text-destructive' : 'text-muted-foreground'}`}>
+      ≈ {fit.lines} of {fit.capacity} printed lines
+      {over && ` — ${fit.truncated} won't fit`}
+    </p>
+  );
+}
 
 // Names to sort first in the @ autocomplete. This only reorders entries that
 // exist in `placeholders` (NAVMC_118_11_PLACEHOLDERS = NAME, DATE), so any name
@@ -98,6 +119,44 @@ export function Form11811Section() {
       )
     );
   const activeId = useEditorOutlineStore((s) => s.activeId);
+
+  // Fit report from the generator's own metrics, debounced behind typing. The
+  // columns are one physical page — text past a column's capacity is NOT
+  // printed, so this is the only thing standing between the user and silent
+  // truncation on export.
+  const [fit, setFit] = useState<Navmc11811Fit | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    const t = setTimeout(() => {
+      computeNavmc11811Fit(navmc11811).then(
+        (f) => !cancelled && setFit(f),
+        () => !cancelled && setFit(null)
+      );
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [navmc11811]);
+  const overflowMessages: string[] = [];
+  if (fit) {
+    if (fit.left.truncated > 0)
+      overflowMessages.push(
+        `Left column is full — ${fit.left.truncated} line${fit.left.truncated === 1 ? '' : 's'} won't print. Continue in the right column.`
+      );
+    if (fit.right.truncated > 0)
+      overflowMessages.push(
+        `Right column is full — ${fit.right.truncated} line${fit.right.truncated === 1 ? '' : 's'} won't print. Shorten the entry or start a second Page 11.`
+      );
+    if (fit.left.spillover > 0 && fit.left.truncated === 0)
+      overflowMessages.push(
+        'The entry date/signature blocks run past the bottom of the left column — shorten the entry or continue it in the right column.'
+      );
+    if (fit.right.spillover > 0 && fit.right.truncated === 0)
+      overflowMessages.push(
+        'The signature blocks run past the bottom of the right column — shorten the entry.'
+      );
+  }
 
   return (
     <div className="space-y-4">
@@ -234,6 +293,7 @@ export function Form11811Section() {
                   rows={16}
                   tabInsertsSpaces
                 />
+                <ColumnFitLine fit={fit?.left} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="remarksTextRight">Administrative Remarks (Right)</Label>
@@ -244,11 +304,27 @@ export function Form11811Section() {
                   rows={16}
                   tabInsertsSpaces
                 />
+                <ColumnFitLine fit={fit?.right} />
               </div>
             </div>
+            {overflowMessages.length > 0 && (
+              <div
+                role="alert"
+                className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 p-3 text-sm"
+              >
+                <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-warning" />
+                <div className="space-y-1 text-warning">
+                  {overflowMessages.map((m) => (
+                    <p key={m}>{m}</p>
+                  ))}
+                </div>
+              </div>
+            )}
             <p className="text-xs text-muted-foreground">
               Include: incident description, date/location, standards violated, prior counseling (if any),
               expected corrective actions, and consequences of continued deficiency.
+              The form is a single page — text does not flow between columns, and
+              anything past a column&apos;s last printed line is left off the PDF.
             </p>
           </AccordionContent>
         </AccordionItem>

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -65,6 +65,27 @@ export function Form6105Section() {
     const p = s.selectedProfile ? s.profiles[s.selectedProfile] : undefined;
     return p ? abbreviatedSignatoryName(p.sigFirst, p.sigMiddle, p.sigLast) : '';
   });
+  // Block 4 "From" in the form's own style ("SSgt John A. Smith") — rank +
+  // full first name + middle initial + last, from the profile. The profile
+  // doesn't hold EDIPI/MOS, so the user appends those; still one click for
+  // the part the app knows. Never written silently.
+  const profileFromLine = useProfileStore((s) => {
+    const p = s.selectedProfile ? s.profiles[s.selectedProfile] : undefined;
+    if (!p) return '';
+    const first = (p.sigFirst ?? '').trim();
+    // Positional, like abbreviatedSignatoryName: no first ⇒ no middle initial.
+    const middle = first ? (p.sigMiddle ?? '').trim().charAt(0) : '';
+    const name = [first, middle && `${middle.toUpperCase()}.`, (p.sigLast ?? '').trim()]
+      .filter(Boolean)
+      .join(' ');
+    return [(p.sigRank ?? '').trim(), name].filter(Boolean).join(' ');
+  });
+  // Block 5 "Organization/Station" from the profile's unit — the same shape
+  // the unit-directory picker writes (name lines, then address).
+  const profileOrgStation = useProfileStore((s) => {
+    const p = s.selectedProfile ? s.profiles[s.selectedProfile] : undefined;
+    return p ? [p.unitLine1, p.unitLine2, p.unitAddress].map((l) => (l ?? '').trim()).filter(Boolean).join('\n') : '';
+  });
   const signatureBlocks = navmc10274.signatureBlocks;
   const setSignatureBlock = (index: number, patch: Partial<FormSignatureBlock>) => {
     setNavmc10274Field(
@@ -255,7 +276,20 @@ export function Form6105Section() {
           <AccordionContent className="space-y-4 pt-2">
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <div className="space-y-2">
-                <Label htmlFor="from">4. From (Grade, Name, EDIPI, MOS, etc.)</Label>
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="from">4. From (Grade, Name, EDIPI, MOS, etc.)</Label>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs"
+                    onClick={() => setNavmc10274Field('from', profileFromLine)}
+                    disabled={!profileFromLine}
+                    title={profileFromLine ? `Use ${profileFromLine}` : 'No profile name to use'}
+                  >
+                    Use profile
+                  </Button>
+                </div>
                 <TextareaWithVariables
                   id="from"
                   value={navmc10274.from}
@@ -267,7 +301,20 @@ export function Form6105Section() {
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="orgStation">5. Organization/Station</Label>
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="orgStation">5. Organization/Station</Label>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs"
+                    onClick={() => setNavmc10274Field('orgStation', profileOrgStation)}
+                    disabled={!profileOrgStation}
+                    title={profileOrgStation ? 'Use your profile unit' : 'No profile unit to use'}
+                  >
+                    Use profile
+                  </Button>
+                </div>
                 <div className="flex gap-1">
                   <TextareaWithVariables
                     id="orgStation"

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -32,6 +32,7 @@ import { useEditorOutlineStore } from '@/stores/editorOutlineStore';
 import { cn } from '@/lib/utils';
 import type { UnitInfo } from '@/data/unitDirectory';
 import type { FormSignatureBlock } from '@/types/signature';
+import { SignatureStylePicker } from './SignatureStylePicker';
 
 // Active-section left-rule for a form AccordionItem, matching the letter
 // sections (FormPanel's SectionShell). activeId only changes at section
@@ -399,14 +400,11 @@ export function Form6105Section() {
                       </Button>
                     )}
                   </div>
-                  <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                    <Checkbox
-                      checked={block.style === 'digital'}
-                      onCheckedChange={(v) => setSignatureBlock(index, { style: v === true ? 'digital' : 'typed' })}
-                      aria-label={`Signature block ${index + 1}: add a digital (CAC) signature field`}
-                    />
-                    Digital signature field (CAC — signed in Acrobat)
-                  </label>
+                  <SignatureStylePicker
+                    block={block}
+                    index={index}
+                    onChange={(patch) => setSignatureBlock(index, patch)}
+                  />
                 </div>
               ))}
               <p className="text-xs text-muted-foreground">

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -34,6 +34,8 @@ import type { UnitInfo } from '@/data/unitDirectory';
 import type { FormSignatureBlock } from '@/types/signature';
 import { SignatureStylePicker } from './SignatureStylePicker';
 import { AddSignatureBlockMenu } from './AddSignatureBlockMenu';
+import { SortableSignatureList, SortableSignatureItem } from './SortableSignatureBlocks';
+import { arrayMove } from '@dnd-kit/sortable';
 
 // Active-section left-rule for a form AccordionItem, matching the letter
 // sections (FormPanel's SectionShell). activeId only changes at section
@@ -358,63 +360,79 @@ export function Form6105Section() {
                   expects at least the originator&apos;s.
                 </p>
               )}
-              {signatureBlocks.map((block, index) => (
-                <div key={index} className="space-y-2 rounded-md border border-border p-3">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-medium text-muted-foreground">
-                      {index === 0 ? 'Originator' : `Signature ${index + 1}`}
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => removeSignatureBlock(index)}
-                      aria-label={`Remove signature block ${index + 1}`}
-                      className="rounded p-0.5 text-muted-foreground outline-none hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </button>
-                  </div>
-                  <Input
-                    value={block.statement}
-                    onChange={(e) => setSignatureBlock(index, { statement: e.target.value })}
-                    placeholder={
-                      index === 0
-                        ? 'Statement above the signature (optional)'
-                        : 'e.g., I acknowledge receipt and understanding of this counseling.'
-                    }
-                    aria-label={`Signature block ${index + 1} statement`}
-                  />
-                  <div className="flex gap-2">
-                    <Input
-                      value={block.name}
-                      onChange={(e) => setSignatureBlock(index, { name: e.target.value })}
-                      placeholder="R. L. SMITH"
-                      aria-label={`Signature block ${index + 1} typed name`}
-                    />
-                    {index === 0 && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="shrink-0 self-center"
-                        onClick={fillOriginatorFromProfile}
-                        disabled={!profileOriginatorName}
-                        title={profileOriginatorName ? `Use ${profileOriginatorName}` : 'No profile signature to use'}
-                      >
-                        Use profile
-                      </Button>
-                    )}
-                  </div>
-                  <SignatureStylePicker
-                    block={block}
+              <SortableSignatureList
+                count={signatureBlocks.length}
+                className="space-y-2"
+                onReorder={(oldIndex, newIndex) =>
+                  setNavmc10274Field('signatureBlocks', arrayMove(signatureBlocks, oldIndex, newIndex))
+                }
+              >
+                {signatureBlocks.map((block, index) => (
+                  <SortableSignatureItem
+                    key={index}
                     index={index}
-                    onChange={(patch) => setSignatureBlock(index, patch)}
-                  />
-                </div>
-              ))}
+                    label={`signature block ${index + 1}`}
+                    showHandle={signatureBlocks.length > 1}
+                  >
+                    <div className="space-y-2 rounded-md border border-border p-3">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-muted-foreground">
+                          {index === 0 ? 'Originator' : `Signature ${index + 1}`}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => removeSignatureBlock(index)}
+                          aria-label={`Remove signature block ${index + 1}`}
+                          className="rounded p-0.5 text-muted-foreground outline-none hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                      <Input
+                        value={block.statement}
+                        onChange={(e) => setSignatureBlock(index, { statement: e.target.value })}
+                        placeholder={
+                          index === 0
+                            ? 'Statement above the signature (optional)'
+                            : 'e.g., I acknowledge receipt and understanding of this counseling.'
+                        }
+                        aria-label={`Signature block ${index + 1} statement`}
+                      />
+                      <div className="flex gap-2">
+                        <Input
+                          value={block.name}
+                          onChange={(e) => setSignatureBlock(index, { name: e.target.value })}
+                          placeholder="R. L. SMITH"
+                          aria-label={`Signature block ${index + 1} typed name`}
+                        />
+                        {index === 0 && (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="shrink-0 self-center"
+                            onClick={fillOriginatorFromProfile}
+                            disabled={!profileOriginatorName}
+                            title={profileOriginatorName ? `Use ${profileOriginatorName}` : 'No profile signature to use'}
+                          >
+                            Use profile
+                          </Button>
+                        )}
+                      </div>
+                      <SignatureStylePicker
+                        block={block}
+                        index={index}
+                        onChange={(patch) => setSignatureBlock(index, patch)}
+                      />
+                    </div>
+                  </SortableSignatureItem>
+                ))}
+              </SortableSignatureList>
               <p className="text-xs text-muted-foreground">
-                Each typed name prints on the third line below what precedes it
-                — the space above is where that person signs, per the
-                form&apos;s caption. Statements print as a paragraph above
+                Drag the handle to reorder — blocks print top-to-bottom in this
+                order. Each typed name prints on the third line below what
+                precedes it — the space above is where that person signs, per
+                the form&apos;s caption. Statements print as a paragraph above
                 their signature.
               </p>
             </div>

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -31,6 +31,7 @@ import { NAVMC_10274_PLACEHOLDERS } from '@/lib/constants';
 import { useEditorOutlineStore } from '@/stores/editorOutlineStore';
 import { cn } from '@/lib/utils';
 import type { UnitInfo } from '@/data/unitDirectory';
+import type { FormSignatureBlock } from '@/types/signature';
 
 // Active-section left-rule for a form AccordionItem, matching the letter
 // sections (FormPanel's SectionShell). activeId only changes at section
@@ -59,7 +60,7 @@ export function Form6105Section() {
     return p ? abbreviatedSignatoryName(p.sigFirst, p.sigMiddle, p.sigLast) : '';
   });
   const signatureBlocks = navmc10274.signatureBlocks;
-  const setSignatureBlock = (index: number, patch: Partial<{ statement: string; name: string; digital: boolean }>) => {
+  const setSignatureBlock = (index: number, patch: Partial<FormSignatureBlock>) => {
     setNavmc10274Field(
       'signatureBlocks',
       signatureBlocks.map((b, i) => (i === index ? { ...b, ...patch } : b))
@@ -400,8 +401,8 @@ export function Form6105Section() {
                   </div>
                   <label className="flex items-center gap-2 text-xs text-muted-foreground">
                     <Checkbox
-                      checked={block.digital ?? false}
-                      onCheckedChange={(v) => setSignatureBlock(index, { digital: v === true })}
+                      checked={block.style === 'digital'}
+                      onCheckedChange={(v) => setSignatureBlock(index, { style: v === true ? 'digital' : 'typed' })}
                       aria-label={`Signature block ${index + 1}: add a digital (CAC) signature field`}
                     />
                     Digital signature field (CAC — signed in Acrobat)

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -22,6 +22,8 @@ import { InputWithVariables, TextareaWithVariables } from '@/components/ui/varia
 import { VariableChipEditor } from '@/components/ui/variable-chip-editor';
 import { DatePicker } from '@/components/ui/date-picker';
 import { useFormStore } from '@/stores/formStore';
+import { useProfileStore } from '@/stores/profileStore';
+import { abbreviatedSignatoryName } from '@/lib/signatoryName';
 import { SSICLookupModal } from '@/components/modals/SSICLookupModal';
 import { UnitLookupModal } from '@/components/modals/UnitLookupModal';
 import { FormReferenceLibraryModal } from '@/components/modals/FormReferenceLibraryModal';
@@ -48,6 +50,36 @@ const COMMON_FORM_VARS = ['NAME', 'DATE'];
 export function Form6105Section() {
   const { navmc10274, setNavmc10274Field, resetNavmc10274, clearNavmc10274, includeCoverPage, setIncludeCoverPage } = useFormStore();
   const activeId = useEditorOutlineStore((s) => s.activeId);
+
+  // The active profile's signature name in the abbreviated form signature
+  // blocks use (initials + SURNAME), offered as a one-click fill for the
+  // originator — never written silently.
+  const profileOriginatorName = useProfileStore((s) => {
+    const p = s.selectedProfile ? s.profiles[s.selectedProfile] : undefined;
+    return p ? abbreviatedSignatoryName(p.sigFirst, p.sigMiddle, p.sigLast) : '';
+  });
+  const signatureBlocks = navmc10274.signatureBlocks;
+  const setSignatureBlock = (index: number, patch: Partial<{ statement: string; name: string; digital: boolean }>) => {
+    setNavmc10274Field(
+      'signatureBlocks',
+      signatureBlocks.map((b, i) => (i === index ? { ...b, ...patch } : b))
+    );
+  };
+  const addSignatureBlock = () =>
+    setNavmc10274Field('signatureBlocks', [...signatureBlocks, { statement: '', name: '' }]);
+  const removeSignatureBlock = (index: number) =>
+    setNavmc10274Field(
+      'signatureBlocks',
+      signatureBlocks.filter((_, i) => i !== index)
+    );
+  const fillOriginatorFromProfile = () => {
+    if (!profileOriginatorName) return;
+    if (signatureBlocks.length === 0) {
+      setNavmc10274Field('signatureBlocks', [{ statement: '', name: profileOriginatorName }]);
+    } else {
+      setSignatureBlock(0, { name: profileOriginatorName });
+    }
+  };
 
   // Modal states
   const [ssicModalOpen, setSSICModalOpen] = useState(false);
@@ -283,7 +315,7 @@ export function Form6105Section() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="proposedAction">13. Proposed/Recommended Action</Label>
+              <Label htmlFor="proposedAction">Proposed/Recommended Action</Label>
               <VariableChipEditor
                 value={navmc10274.proposedAction}
                 onChange={(v) => setNavmc10274Field('proposedAction', v)}
@@ -291,6 +323,97 @@ export function Form6105Section() {
                 rows={3}
                 tabInsertsSpaces
               />
+              <p className="text-xs text-muted-foreground">
+                The printed form has no box for this — it closes out block 12 as
+                its own labeled paragraph.
+              </p>
+            </div>
+
+            {/* Signature blocks close block 12: "type name of originator and
+                sign 3 lines below text" is printed on the form itself. A
+                counseling action typically adds the Marine's acknowledgement
+                as a second block, and sometimes a witness as a third. */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label>Signature blocks</Label>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={addSignatureBlock}
+                  disabled={signatureBlocks.length >= 4}
+                >
+                  Add signature
+                </Button>
+              </div>
+              {signatureBlocks.length === 0 && (
+                <p className="text-xs text-muted-foreground">
+                  No signature blocks — block 12 ends with the text. The form
+                  expects at least the originator&apos;s.
+                </p>
+              )}
+              {signatureBlocks.map((block, index) => (
+                <div key={index} className="space-y-2 rounded-md border border-border p-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      {index === 0 ? 'Originator' : `Signature ${index + 1}`}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => removeSignatureBlock(index)}
+                      aria-label={`Remove signature block ${index + 1}`}
+                      className="rounded p-0.5 text-muted-foreground outline-none hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                  <Input
+                    value={block.statement}
+                    onChange={(e) => setSignatureBlock(index, { statement: e.target.value })}
+                    placeholder={
+                      index === 0
+                        ? 'Statement above the signature (optional)'
+                        : 'e.g., I acknowledge receipt and understanding of this counseling.'
+                    }
+                    aria-label={`Signature block ${index + 1} statement`}
+                  />
+                  <div className="flex gap-2">
+                    <Input
+                      value={block.name}
+                      onChange={(e) => setSignatureBlock(index, { name: e.target.value })}
+                      placeholder="R. L. SMITH"
+                      aria-label={`Signature block ${index + 1} typed name`}
+                    />
+                    {index === 0 && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="shrink-0 self-center"
+                        onClick={fillOriginatorFromProfile}
+                        disabled={!profileOriginatorName}
+                        title={profileOriginatorName ? `Use ${profileOriginatorName}` : 'No profile signature to use'}
+                      >
+                        Use profile
+                      </Button>
+                    )}
+                  </div>
+                  <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Checkbox
+                      checked={block.digital ?? false}
+                      onCheckedChange={(v) => setSignatureBlock(index, { digital: v === true })}
+                      aria-label={`Signature block ${index + 1}: add a digital (CAC) signature field`}
+                    />
+                    Digital signature field (CAC — signed in Acrobat)
+                  </label>
+                </div>
+              ))}
+              <p className="text-xs text-muted-foreground">
+                Each typed name prints on the third line below what precedes it
+                — the space above is where that person signs, per the
+                form&apos;s caption. Statements print as a paragraph above
+                their signature.
+              </p>
             </div>
           </AccordionContent>
         </AccordionItem>

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -33,6 +33,7 @@ import { cn } from '@/lib/utils';
 import type { UnitInfo } from '@/data/unitDirectory';
 import type { FormSignatureBlock } from '@/types/signature';
 import { SignatureStylePicker } from './SignatureStylePicker';
+import { AddSignatureBlockMenu } from './AddSignatureBlockMenu';
 
 // Active-section left-rule for a form AccordionItem, matching the letter
 // sections (FormPanel's SectionShell). activeId only changes at section
@@ -67,8 +68,6 @@ export function Form6105Section() {
       signatureBlocks.map((b, i) => (i === index ? { ...b, ...patch } : b))
     );
   };
-  const addSignatureBlock = () =>
-    setNavmc10274Field('signatureBlocks', [...signatureBlocks, { statement: '', name: '' }]);
   const removeSignatureBlock = (index: number) =>
     setNavmc10274Field(
       'signatureBlocks',
@@ -330,23 +329,28 @@ export function Form6105Section() {
                 its own labeled paragraph.
               </p>
             </div>
+          </AccordionContent>
+        </AccordionItem>
 
-            {/* Signature blocks close block 12: "type name of originator and
-                sign 3 lines below text" is printed on the form itself. A
-                counseling action typically adds the Marine's acknowledgement
-                as a second block, and sometimes a witness as a third. */}
+        {/* Signatures Section — block 12 closes with the originator's typed
+            name signed 3 lines below the text (printed on the form itself); a
+            counseling action typically adds the Marine's acknowledgement as a
+            second block, and sometimes a witness as a third. */}
+        <AccordionItem value="signatures" id="sec-signatures" data-section="signatures" className={sectionRule(activeId === 'signatures')}>
+          <AccordionTrigger className="hover:no-underline">
+            <span className="font-medium">Signatures</span>
+          </AccordionTrigger>
+          <AccordionContent className="space-y-4 pt-2">
             <div className="space-y-2">
               <div className="flex items-center justify-between">
                 <Label>Signature blocks</Label>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={addSignatureBlock}
+                <AddSignatureBlockMenu
+                  form="navmc_10274"
                   disabled={signatureBlocks.length >= 4}
-                >
-                  Add signature
-                </Button>
+                  onAdd={(b) =>
+                    setNavmc10274Field('signatureBlocks', [...signatureBlocks, b])
+                  }
+                />
               </div>
               {signatureBlocks.length === 0 && (
                 <p className="text-xs text-muted-foreground">

--- a/src/components/editor/Form6105Section.tsx
+++ b/src/components/editor/Form6105Section.tsx
@@ -36,6 +36,8 @@ import { SignatureStylePicker } from './SignatureStylePicker';
 import { AddSignatureBlockMenu } from './AddSignatureBlockMenu';
 import { SortableSignatureList, SortableSignatureItem } from './SortableSignatureBlocks';
 import { arrayMove } from '@dnd-kit/sortable';
+import { standardSignaturePair } from '@/lib/signaturePresets';
+import { showAppConfirm } from '@/stores/alertStore';
 
 // Active-section left-rule for a form AccordionItem, matching the letter
 // sections (FormPanel's SectionShell). activeId only changes at section
@@ -70,10 +72,41 @@ export function Form6105Section() {
       signatureBlocks.map((b, i) => (i === index ? { ...b, ...patch } : b))
     );
   };
-  const removeSignatureBlock = (index: number) =>
+  // Deleting a filled block loses a statement, a typed name, and possibly an
+  // uploaded signature image — and deleting block 1 silently promotes the next
+  // block to originator. Confirm first, same rule as References/Enclosures:
+  // an empty block still removes in a single click.
+  const removeSignatureBlock = async (index: number) => {
+    const b = signatureBlocks[index];
+    const hasContent =
+      (b?.statement ?? '').trim() !== '' || (b?.name ?? '').trim() !== '' || !!b?.image;
+    if (hasContent) {
+      const promote =
+        index === 0 && signatureBlocks.length > 1
+          ? ' The next block becomes the originator.'
+          : '';
+      const confirmed = await showAppConfirm({
+        title: 'Remove signature block?',
+        message: `${index === 0 ? 'The originator block' : `Signature ${index + 1}`} and its contents will be removed.${promote}`,
+        confirmLabel: 'Remove',
+        destructive: true,
+      });
+      if (!confirmed) return;
+    }
     setNavmc10274Field(
       'signatureBlocks',
       signatureBlocks.filter((_, i) => i !== index)
+    );
+  };
+  // Move focus into a block's first input after it's added, so a preset pick
+  // flows straight into editing. Double-rAF: the first frame lets React commit
+  // the new card, the second runs after the dropdown's close cleanup so its
+  // focus handling can't land after ours.
+  const focusStatement = (index: number) =>
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() =>
+        document.getElementById(`aa-sig-${index}-statement`)?.focus()
+      )
     );
   const fillOriginatorFromProfile = () => {
     if (!profileOriginatorName) return;
@@ -349,16 +382,39 @@ export function Form6105Section() {
                 <AddSignatureBlockMenu
                   form="navmc_10274"
                   disabled={signatureBlocks.length >= 4}
-                  onAdd={(b) =>
-                    setNavmc10274Field('signatureBlocks', [...signatureBlocks, b])
-                  }
+                  names={{ signer: profileOriginatorName }}
+                  onAdd={(b) => {
+                    const index = signatureBlocks.length;
+                    setNavmc10274Field('signatureBlocks', [...signatureBlocks, b]);
+                    // Returned to the menu: it runs this on close, after its
+                    // exit animation, so the focus can't be clobbered.
+                    return () => focusStatement(index);
+                  }}
                 />
               </div>
               {signatureBlocks.length === 0 && (
-                <p className="text-xs text-muted-foreground">
-                  No signature blocks — block 12 ends with the text. The form
-                  expects at least the originator&apos;s.
-                </p>
+                <div className="space-y-2">
+                  <p className="text-xs text-muted-foreground">
+                    No signature blocks — block 12 ends with the text. The form
+                    expects at least the originator&apos;s.
+                  </p>
+                  {/* One click sets up the standard counseling pair, with the
+                      originator pre-filled from the profile when there is one. */}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setNavmc10274Field(
+                        'signatureBlocks',
+                        standardSignaturePair('navmc_10274', { signer: profileOriginatorName })
+                      );
+                      focusStatement(0);
+                    }}
+                  >
+                    Add originator + Marine acknowledgement
+                  </Button>
+                </div>
               )}
               <SortableSignatureList
                 count={signatureBlocks.length}
@@ -389,6 +445,7 @@ export function Form6105Section() {
                         </button>
                       </div>
                       <Input
+                        id={`aa-sig-${index}-statement`}
                         value={block.statement}
                         onChange={(e) => setSignatureBlock(index, { statement: e.target.value })}
                         placeholder={
@@ -430,10 +487,10 @@ export function Form6105Section() {
               </SortableSignatureList>
               <p className="text-xs text-muted-foreground">
                 Drag the handle to reorder — blocks print top-to-bottom in this
-                order. Each typed name prints on the third line below what
-                precedes it — the space above is where that person signs, per
-                the form&apos;s caption. Statements print as a paragraph above
-                their signature.
+                order, and the top block signs as the originator. Each typed
+                name prints on the third line below what precedes it — the
+                space above is where that person signs, per the form&apos;s
+                caption. Statements print as a paragraph above their signature.
               </p>
             </div>
           </AccordionContent>

--- a/src/components/editor/SignatureStylePicker.tsx
+++ b/src/components/editor/SignatureStylePicker.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useRef } from 'react';
+import { Type, PenLine, Shield, X } from 'lucide-react';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { loadSignatureAsPngBase64 } from '@/lib/signatureImage';
+import { FILE_LIMITS } from '@/lib/constants';
+import { showAppAlert } from '@/stores/alertStore';
+import { isImageFile, rejectedFilesMessage } from '@/lib/fileFilter';
+import type { FormSignatureBlock, SignatureStyle } from '@/types/signature';
+
+/**
+ * Per-signer style control shared by both NAVMC forms: choose how one signature
+ * block signs — Typed (name only), Image (a scanned signature drawn in the gap),
+ * or Digital (an empty CAC field signed later in Acrobat) — and, for Image,
+ * upload the scan. Mirrors the naval letter's three-way choice so all three
+ * document surfaces feel the same.
+ */
+export function SignatureStylePicker({
+  block,
+  index,
+  onChange,
+}: {
+  block: FormSignatureBlock;
+  index: number;
+  onChange: (patch: Partial<FormSignatureBlock>) => void;
+}) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const style: SignatureStyle = block.style ?? 'typed';
+
+  const handleUpload = useCallback(
+    async (file: File) => {
+      if (!isImageFile(file)) {
+        showAppAlert({ title: 'Image files only', message: rejectedFilesMessage([file], 'image') });
+        return;
+      }
+      // Stored base64 in the persisted form state — cap the size like the letter.
+      if (file.size > FILE_LIMITS.MAX_SIGNATURE_SIZE_MB * 1024 * 1024) {
+        showAppAlert({
+          title: 'Image too large',
+          message: `That signature image is too large (max ${FILE_LIMITS.MAX_SIGNATURE_SIZE_MB} MB). Please use a smaller file.`,
+        });
+        return;
+      }
+      try {
+        const image = await loadSignatureAsPngBase64(file);
+        onChange({ style: 'image', image });
+      } catch (err) {
+        showAppAlert({
+          title: "Couldn't read that image",
+          message: err instanceof Error ? err.message : 'Please try a different file.',
+        });
+      }
+    },
+    [onChange]
+  );
+
+  return (
+    <div className="space-y-2">
+      <Tabs value={style} onValueChange={(v) => onChange({ style: v as SignatureStyle })}>
+        <TabsList className="grid w-full grid-cols-3">
+          <TabsTrigger value="typed" aria-label={`Signature block ${index + 1}: typed name only`}>
+            <Type className="mr-1.5 h-3.5 w-3.5" /> Typed
+          </TabsTrigger>
+          <TabsTrigger value="image" aria-label={`Signature block ${index + 1}: upload a scanned signature`}>
+            <PenLine className="mr-1.5 h-3.5 w-3.5" /> Image
+          </TabsTrigger>
+          <TabsTrigger value="digital" aria-label={`Signature block ${index + 1}: add a digital CAC signature field`}>
+            <Shield className="mr-1.5 h-3.5 w-3.5" /> Digital
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {style === 'image' && (
+        <div className="flex items-center gap-2">
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) void handleUpload(file);
+              e.target.value = '';
+            }}
+          />
+          {block.image ? (
+            <>
+              <img
+                src={`data:image/png;base64,${block.image}`}
+                alt="Signature preview"
+                className="h-8 max-w-[9rem] rounded border border-border bg-white object-contain p-0.5"
+              />
+              <Button type="button" variant="ghost" size="sm" onClick={() => fileRef.current?.click()}>
+                Replace
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label="Remove signature image"
+                onClick={() => onChange({ image: undefined })}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </>
+          ) : (
+            <Button type="button" variant="outline" size="sm" onClick={() => fileRef.current?.click()}>
+              <PenLine className="mr-1.5 h-3.5 w-3.5" /> Upload signature…
+            </Button>
+          )}
+        </div>
+      )}
+
+      {style === 'digital' && (
+        <p className="text-xs text-muted-foreground">
+          An empty CAC-signable field is placed in the signing space. Sign it in
+          Adobe Acrobat — a browser can&apos;t reach a CAC&apos;s private key.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/editor/SortableSignatureBlocks.tsx
+++ b/src/components/editor/SortableSignatureBlocks.tsx
@@ -44,7 +44,9 @@ export function SortableSignatureList({
   children: ReactNode;
 }) {
   const sensors = useSensors(
-    useSensor(PointerSensor),
+    // A small distance threshold so a touch-scroll that happens to start on
+    // the handle doesn't turn into an accidental drag.
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 
@@ -99,7 +101,10 @@ export function SortableSignatureItem({
             aria-label={`Drag to reorder ${label}`}
             {...attributes}
             {...listeners}
-            className="mt-3 cursor-grab touch-none rounded-sm text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 active:cursor-grabbing"
+            // p-1 pads the hit area for touch without growing the icon; mt-2
+            // (+4px padding) keeps the glyph at the same visual height as the
+            // old mt-3.
+            className="mt-2 cursor-grab touch-none rounded-sm p-1 text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 active:cursor-grabbing"
           >
             <GripVertical className="h-4 w-4" />
           </button>

--- a/src/components/editor/SortableSignatureBlocks.tsx
+++ b/src/components/editor/SortableSignatureBlocks.tsx
@@ -1,0 +1,111 @@
+import type { ReactNode } from 'react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical } from 'lucide-react';
+
+/**
+ * Drag-to-reorder wrapper for a form's signature blocks, matching the
+ * References / Enclosures / Addressing pattern (dnd-kit + a grip handle). Order
+ * is meaningful — it's the top-to-bottom signing order the generator prints —
+ * so users can rearrange counselor / Marine / witness without deleting and
+ * re-adding. The dnd-kit KeyboardSensor makes the handle keyboard-operable
+ * (focus it, Space to lift, arrows to move), so reordering isn't mouse-only.
+ *
+ * The block card body stays per-form (the two NAVMC sections render different
+ * inputs); this only supplies the sortable shell and the handle to its left.
+ */
+
+const ID_PREFIX = 'sig-';
+
+export function SortableSignatureList({
+  count,
+  onReorder,
+  className,
+  children,
+}: {
+  count: number;
+  onReorder: (oldIndex: number, newIndex: number) => void;
+  /** Spacing class for the inner wrapper so each form keeps its own gap. */
+  className?: string;
+  children: ReactNode;
+}) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = Number(String(active.id).replace(ID_PREFIX, ''));
+    const newIndex = Number(String(over.id).replace(ID_PREFIX, ''));
+    onReorder(oldIndex, newIndex);
+  };
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext
+        items={Array.from({ length: count }, (_, i) => `${ID_PREFIX}${i}`)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className={className}>{children}</div>
+      </SortableContext>
+    </DndContext>
+  );
+}
+
+export function SortableSignatureItem({
+  index,
+  label,
+  showHandle,
+  children,
+}: {
+  index: number;
+  /** Human label for the drag handle's aria-label, e.g. "signature block 2". */
+  label: string;
+  /** Hide the handle when there's nothing to reorder (a lone block). */
+  showHandle: boolean;
+  children: ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: `${ID_PREFIX}${index}`,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className={isDragging ? 'opacity-50' : undefined}>
+      <div className="flex items-start gap-2">
+        {showHandle && (
+          <button
+            type="button"
+            aria-label={`Drag to reorder ${label}`}
+            {...attributes}
+            {...listeners}
+            className="mt-3 cursor-grab touch-none rounded-sm text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 active:cursor-grabbing"
+          >
+            <GripVertical className="h-4 w-4" />
+          </button>
+        )}
+        <div className="min-w-0 flex-1">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/editorSections.tsx
+++ b/src/components/layout/editorSections.tsx
@@ -107,6 +107,7 @@ export function getFormSections(formType: FormType): EditorSection[] {
         { id: 'header', label: 'Header information', icon: Hash },
         { id: 'addressing', label: 'Addressing', icon: Send },
         { id: 'content', label: 'Counseling content', icon: ClipboardList },
+        { id: 'signatures', label: 'Signatures', icon: PenLine },
         { id: 'references', label: 'References & distribution', icon: BookOpen },
       ];
     case 'navmc_118_11':

--- a/src/components/layout/editorSections.tsx
+++ b/src/components/layout/editorSections.tsx
@@ -113,6 +113,7 @@ export function getFormSections(formType: FormType): EditorSection[] {
       return [
         { id: 'marine', label: 'Marine identification', icon: User },
         { id: 'content', label: 'Entry content', icon: ClipboardList },
+        { id: 'signatures', label: 'Signatures', icon: PenLine },
       ];
     default:
       return [];

--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -740,8 +740,12 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
         const currentData = useFormStore.getState().navmc11811;
         if (Object.prototype.hasOwnProperty.call(currentData, targetField)) {
           const fieldKey = targetField as keyof typeof currentData;
-          setNavmc11811Field(fieldKey, appendInto(currentData[fieldKey] ?? ''));
-          inserted = true;
+          const value = currentData[fieldKey];
+          // Only text fields are batch targets — signatureBlocks is an array.
+          if (typeof value === 'string') {
+            setNavmc11811Field(fieldKey, appendInto(value));
+            inserted = true;
+          }
         }
       }
     } else {

--- a/src/components/modals/BatchModal.tsx
+++ b/src/components/modals/BatchModal.tsx
@@ -298,6 +298,12 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
         if (data.enclosures) allText.push(data.enclosures);
         if (data.supplementalInfo) allText.push(data.supplementalInfo);
         if (data.proposedAction) allText.push(data.proposedAction);
+        // Signature blocks: variables may appear in a statement or a name
+        // (e.g. an acknowledgement addressed to each Marine in the batch).
+        for (const block of data.signatureBlocks ?? []) {
+          if (block.statement) allText.push(block.statement);
+          if (block.name) allText.push(block.name);
+        }
       } else if (formType === 'navmc_118_11') {
         const data = navmc11811;
         if (data.lastName) allText.push(data.lastName);
@@ -718,8 +724,17 @@ export function BatchModal({ compile, isEngineReady, waitForReady }: BatchModalP
         const currentData = useFormStore.getState().navmc10274;
         if (Object.prototype.hasOwnProperty.call(currentData, targetField)) {
           const fieldKey = targetField as keyof typeof currentData;
-          setNavmc10274Field(fieldKey, appendInto(currentData[fieldKey] ?? ''));
-          inserted = true;
+          const fieldValue = currentData[fieldKey];
+          // signatureBlocks is structured (statement+name rows), not a text
+          // field — the target dropdown never offers it, and this guard keeps
+          // a drifted key from appending a variable into a non-string.
+          if (typeof fieldValue === 'string') {
+            setNavmc10274Field(
+              fieldKey as Exclude<keyof typeof currentData, 'signatureBlocks'>,
+              appendInto(fieldValue)
+            );
+            inserted = true;
+          }
         }
       } else if (formType === 'navmc_118_11') {
         const currentData = useFormStore.getState().navmc11811;

--- a/src/lib/appendedEndorsement.ts
+++ b/src/lib/appendedEndorsement.ts
@@ -13,6 +13,7 @@
  * can share one definition of what "has an acknowledgement" and what goes in it,
  * and can't drift into rendering different documents from the same input.
  */
+import { abbreviatedSignatoryName } from '@/lib/signatoryName';
 
 /**
  * Doc types that may carry an appended acknowledgement — letters only.
@@ -98,16 +99,9 @@ export function resolveAppendedEndorsement(
  * and surname, no rank or title.
  */
 export function appendedEndorsementSigner(data: AppendedEndorsementData): string {
-  // First and middle are positional: a middle initial without a first must not
-  // slide into the first slot and print "A. DOE" for someone who left first
-  // blank. Drop the middle when there is no first — same as the letter's own
-  // signature, which never shows a middle without a first.
-  const first = (data.endorsementSigFirst || '').trim().charAt(0).toUpperCase();
-  const middle = first ? (data.endorsementSigMiddle || '').trim().charAt(0).toUpperCase() : '';
-  const initials = [first, middle]
-    .filter(Boolean)
-    .map((initial) => `${initial}.`)
-    .join(' ');
-  const last = (data.endorsementSigLast || '').trim().toUpperCase();
-  return [initials, last].filter(Boolean).join(' ');
+  return abbreviatedSignatoryName(
+    data.endorsementSigFirst,
+    data.endorsementSigMiddle,
+    data.endorsementSigLast
+  );
 }

--- a/src/lib/placeholders.ts
+++ b/src/lib/placeholders.ts
@@ -150,5 +150,10 @@ export function applyPlaceholdersToNavmc10274(
     enclosures: replacePlaceholders(data.enclosures, values),
     supplementalInfo: replacePlaceholders(data.supplementalInfo, values),
     proposedAction: replacePlaceholders(data.proposedAction, values),
+    signatureBlocks: (data.signatureBlocks ?? []).map((block) => ({
+      ...block, // preserve `digital` and any future per-block flags
+      statement: replacePlaceholders(block.statement, values),
+      name: replacePlaceholders(block.name, values),
+    })),
   };
 }

--- a/src/lib/placeholders.ts
+++ b/src/lib/placeholders.ts
@@ -124,6 +124,11 @@ export function applyPlaceholdersToNavmc11811(
     remarksTextRight: replacePlaceholders(data.remarksTextRight ?? '', values),
     entryDate: replacePlaceholders(data.entryDate, values),
     box11: replacePlaceholders(data.box11, values),
+    signatureBlocks: (data.signatureBlocks ?? []).map((block) => ({
+      ...block, // preserve style and image
+      statement: replacePlaceholders(block.statement, values),
+      name: replacePlaceholders(block.name, values),
+    })),
   };
 }
 

--- a/src/lib/signatoryName.ts
+++ b/src/lib/signatoryName.ts
@@ -1,0 +1,30 @@
+/**
+ * The abbreviated signatory form used wherever a document is signed over a
+ * typed name: initials + SURNAME ("R. L. SMITH"), no rank or title.
+ *
+ * One definition, because it already grew two divergent copies — the appended
+ * endorsement's signer and the AA form's originator — and the second copy
+ * reintroduced a fixed bug (a middle initial sliding into the first slot when
+ * first is blank). Pure and leaf so every signer, whatever the store or form,
+ * abbreviates identically.
+ *
+ * (The letter's full signature block is a different convention — capitalized
+ * full names via the LaTeX generator — and deliberately not this function.)
+ */
+export function abbreviatedSignatoryName(
+  firstName?: string,
+  middleName?: string,
+  lastName?: string
+): string {
+  // First and middle are positional: a middle initial without a first must not
+  // slide into the first slot and print "A. DOE" for someone who left first
+  // blank. Drop the middle when there is no first.
+  const first = (firstName || '').trim().charAt(0).toUpperCase();
+  const middle = first ? (middleName || '').trim().charAt(0).toUpperCase() : '';
+  const initials = [first, middle]
+    .filter(Boolean)
+    .map((initial) => `${initial}.`)
+    .join(' ');
+  const last = (lastName || '').trim().toUpperCase();
+  return [initials, last].filter(Boolean).join(' ');
+}

--- a/src/lib/signaturePresets.ts
+++ b/src/lib/signaturePresets.ts
@@ -10,6 +10,22 @@ export interface SignaturePreset {
 }
 
 /**
+ * Names the app already knows, offered so a preset arrives pre-filled instead
+ * of demanding a second "Use profile" click. Every fill is an editable typed
+ * name, never a lock.
+ */
+export interface SignaturePresetNames {
+  /** Counselor/Originator typed name — usually the active profile's. */
+  signer?: string;
+  /**
+   * The counseled Marine's typed name — on the 118(11) it's derivable from the
+   * Marine Identification fields. The AA form's "To" is freeform (rank, name,
+   * MOS in one box), so callers there leave this unset rather than mis-parse.
+   */
+  marine?: string;
+}
+
+/**
  * Quick-add presets for a form's signature blocks — the counselor/originator,
  * the counseled Marine's acknowledgement, and a witness. Each drops a new block
  * with a sensible starting statement so users don't retype the boilerplate.
@@ -18,16 +34,43 @@ export interface SignaturePreset {
  * so every preset is an EDITABLE starting point — never a locked value; the same
  * posture as the app's demo text.
  */
-export function signaturePresets(form: SignatureFormKind): SignaturePreset[] {
+export function signaturePresets(
+  form: SignatureFormKind,
+  names: SignaturePresetNames = {}
+): SignaturePreset[] {
   const acknowledgement =
     form === 'navmc_118_11'
       ? 'I have been counseled this date and understand this entry.'
       : 'I acknowledge receipt and understanding of this counseling.';
   const signerLabel = form === 'navmc_118_11' ? 'Counselor' : 'Originator';
-  const block = (statement: string): FormSignatureBlock => ({ statement, name: '', style: 'typed' });
+  const block = (statement: string, name = ''): FormSignatureBlock => ({
+    statement,
+    name,
+    style: 'typed',
+  });
   return [
-    { id: 'signer', label: signerLabel, make: () => block('') },
-    { id: 'acknowledgement', label: 'Marine acknowledgement', make: () => block(acknowledgement) },
+    { id: 'signer', label: signerLabel, make: () => block('', names.signer ?? '') },
+    {
+      id: 'acknowledgement',
+      label: 'Marine acknowledgement',
+      make: () => block(acknowledgement, names.marine ?? ''),
+    },
+    // A witness is whoever happened to be present — never a name the app can
+    // guess, so it stays blank even when names are supplied.
     { id: 'witness', label: 'Witness', make: () => block('Witnessed:') },
   ];
+}
+
+/**
+ * The standard counseling setup — signer + Marine acknowledgement, in signing
+ * order — for the empty state's one-click start. With `names` supplied the
+ * whole pair arrives ready to export.
+ */
+export function standardSignaturePair(
+  form: SignatureFormKind,
+  names: SignaturePresetNames = {}
+): FormSignatureBlock[] {
+  const presets = signaturePresets(form, names);
+  const byId = (id: string) => presets.find((p) => p.id === id)!.make();
+  return [byId('signer'), byId('acknowledgement')];
 }

--- a/src/lib/signaturePresets.ts
+++ b/src/lib/signaturePresets.ts
@@ -1,0 +1,33 @@
+import type { FormSignatureBlock } from '@/types/signature';
+
+export type SignatureFormKind = 'navmc_10274' | 'navmc_118_11';
+
+export interface SignaturePreset {
+  id: string;
+  label: string;
+  /** A fresh block for this role. */
+  make(): FormSignatureBlock;
+}
+
+/**
+ * Quick-add presets for a form's signature blocks — the counselor/originator,
+ * the counseled Marine's acknowledgement, and a witness. Each drops a new block
+ * with a sensible starting statement so users don't retype the boilerplate.
+ *
+ * The acknowledgement wording is MCO 1610.7 / IRAM-governed and differs by form,
+ * so every preset is an EDITABLE starting point — never a locked value; the same
+ * posture as the app's demo text.
+ */
+export function signaturePresets(form: SignatureFormKind): SignaturePreset[] {
+  const acknowledgement =
+    form === 'navmc_118_11'
+      ? 'I have been counseled this date and understand this entry.'
+      : 'I acknowledge receipt and understanding of this counseling.';
+  const signerLabel = form === 'navmc_118_11' ? 'Counselor' : 'Originator';
+  const block = (statement: string): FormSignatureBlock => ({ statement, name: '', style: 'typed' });
+  return [
+    { id: 'signer', label: signerLabel, make: () => block('') },
+    { id: 'acknowledgement', label: 'Marine acknowledgement', make: () => block(acknowledgement) },
+    { id: 'witness', label: 'Witness', make: () => block('Witnessed:') },
+  ];
+}

--- a/src/services/pdf/navmc10274Generator.ts
+++ b/src/services/pdf/navmc10274Generator.ts
@@ -121,11 +121,12 @@ export interface Navmc10274Data {
   // below text"); counseling actions commonly add the counseled Marine's
   // acknowledgement and sometimes a witness — an optional statement renders as
   // a paragraph above each block's signing space.
-  signatureBlocks?: Array<{ statement?: string; name?: string; digital?: boolean }>;
+  signatureBlocks?: Array<{ statement?: string; name?: string; style?: SignatureStyle; image?: string }>;
 }
 
 import { calculateTextPosition, type BoxBoundary } from './extractFormFields';
 import { addSignatureFieldToPage } from './signatureFieldCore';
+import { isDigital, type SignatureStyle } from '@/types/signature';
 
 // A digital signature field sits in the signing gap ABOVE the typed name: 8pt
 // above the name's baseline (clearing its ascenders — a 2pt gap clipped them in
@@ -182,7 +183,7 @@ export interface SignatureFieldPlacement {
 export function composeBlockTwelveLines(parts: {
   supplementalInfo: string[];
   proposedAction: string[];
-  signatureBlocks: Array<{ statement: string[]; name: string; digital?: boolean }>;
+  signatureBlocks: Array<{ statement: string[]; name: string; style?: SignatureStyle }>;
 }): ComposedBlockTwelve {
   const lines: string[] = [...parts.supplementalInfo];
   if (parts.proposedAction.length > 0) {
@@ -214,7 +215,7 @@ export function composeBlockTwelveLines(parts: {
       nameLineIndex = lines.length;
       lines.push(name);
     }
-    groups.push({ start, end: lines.length - 1, nameLineIndex, digital: block.digital ?? false });
+    groups.push({ start, end: lines.length - 1, nameLineIndex, digital: isDigital(block) });
   }
   return { lines, groups };
 }
@@ -540,7 +541,7 @@ export async function generateNavmc10274Pdf(
         ? wrapText(block.statement.trim(), PAGE2_FIELDS.supplementalInfo.maxWidth, font, FONT_SIZE)
         : [],
       name: (block.name ?? '').trim(),
-      digital: block.digital ?? false,
+      style: block.style,
     })),
   });
   // Continuation-page field placements are held until page 3 is created below.

--- a/src/services/pdf/navmc10274Generator.ts
+++ b/src/services/pdf/navmc10274Generator.ts
@@ -112,11 +112,179 @@ export interface Navmc10274Data {
   enclosures: string;
   // Field 12: Supplemental Information
   supplementalInfo: string;
-  // Field 13: Proposed/Recommended Action
+  // Proposed/Recommended Action — the printed form has no box for it (its
+  // fields run 1-12), so it renders as a labeled closing paragraph inside
+  // block 12. It used to be collected by the UI and silently dropped here.
   proposedAction: string;
+  // Signature blocks at the end of block 12, in signing order. The form's
+  // caption mandates the first ("type name of originator and sign 3 lines
+  // below text"); counseling actions commonly add the counseled Marine's
+  // acknowledgement and sometimes a witness — an optional statement renders as
+  // a paragraph above each block's signing space.
+  signatureBlocks?: Array<{ statement?: string; name?: string; digital?: boolean }>;
 }
 
 import { calculateTextPosition, type BoxBoundary } from './extractFormFields';
+import { addSignatureFieldToPage } from './signatureFieldCore';
+
+// A digital signature field sits in the signing gap ABOVE the typed name: 8pt
+// above the name's baseline (clearing its ascenders — a 2pt gap clipped them in
+// testing) and 20pt tall, within the two blank lines the compose reserves.
+const SIG_FIELD_ABOVE = 8;
+const SIG_FIELD_HEIGHT = 20;
+const SIG_FIELD_WIDTH = 180;
+
+/** Rect for a signature field above a name drawn at (textX, block-start y minus
+ *  nameLineInPage line-heights). */
+function signatureFieldRect(
+  textX: number,
+  blockStartY: number,
+  nameLineInPage: number,
+  lineHeight: number
+): [number, number, number, number] {
+  const nameBaselineY = blockStartY - nameLineInPage * lineHeight;
+  const bottom = nameBaselineY + SIG_FIELD_ABOVE;
+  return [textX, bottom, textX + SIG_FIELD_WIDTH, bottom + SIG_FIELD_HEIGHT];
+}
+
+/** A signature block's lines, pre-wrapped: optional statement paragraph, then
+ *  the typed name. The block is atomic for pagination. */
+export interface ComposedBlockTwelve {
+  lines: string[];
+  /** [start, end] line spans (inclusive) that pagination must not split — one
+   *  per signature block: its statement, signing space, and name move as one.
+   *  `nameLineIndex` is where the typed name landed (null for a statement-only
+   *  block); `digital` marks a block that wants a CAC signature field placed in
+   *  its signing space. */
+  groups: Array<{ start: number; end: number; nameLineIndex: number | null; digital: boolean }>;
+}
+
+/** Where a digital signature field goes: which page, and the name's line index
+ *  within that page's block-12 stream (the field sits in the gap above it). */
+export interface SignatureFieldPlacement {
+  page: 'main' | 'continuation';
+  nameLineInPage: number;
+}
+
+/**
+ * Block 12's contents in order: the supplemental text, the proposed action as
+ * a labeled closing paragraph, then the signature blocks in signing order.
+ *
+ * Each name sits on the THIRD line below whatever precedes it — the form's own
+ * caption is the spec: "type name of originator and sign 3 lines below text".
+ * The two blank lines above each name are that signer's signing space. (The
+ * naval letter's fourth-line convention from Ch 7 ¶14 does not apply here; the
+ * form overrides it.) A block's optional statement ("Acknowledged:", "I have
+ * witnessed…") renders as a paragraph directly above its signing space, which
+ * is how counseling actions carry the Marine's acknowledgement and a witness
+ * below the originator. Exported for tests.
+ */
+export function composeBlockTwelveLines(parts: {
+  supplementalInfo: string[];
+  proposedAction: string[];
+  signatureBlocks: Array<{ statement: string[]; name: string; digital?: boolean }>;
+}): ComposedBlockTwelve {
+  const lines: string[] = [...parts.supplementalInfo];
+  if (parts.proposedAction.length > 0) {
+    if (lines.length > 0) lines.push('');
+    lines.push(...parts.proposedAction);
+  }
+  const groups: ComposedBlockTwelve['groups'] = [];
+  for (const block of parts.signatureBlocks) {
+    const name = block.name.trim();
+    if (!name && block.statement.length === 0) continue;
+    let start: number;
+    let nameLineIndex: number | null = null;
+    if (block.statement.length > 0) {
+      // The blank before the statement is paragraph separation (outside the
+      // group); the statement, the signing gap, and the name are the block.
+      if (lines.length > 0) lines.push('');
+      start = lines.length;
+      lines.push(...block.statement);
+      if (name) {
+        lines.push('', '');
+        nameLineIndex = lines.length;
+        lines.push(name);
+      }
+    } else {
+      // No statement: the signing-gap blanks themselves open the block — they
+      // ARE the signing space, so pagination must carry them with the name.
+      start = lines.length;
+      if (lines.length > 0) lines.push('', '');
+      nameLineIndex = lines.length;
+      lines.push(name);
+    }
+    groups.push({ start, end: lines.length - 1, nameLineIndex, digital: block.digital ?? false });
+  }
+  return { lines, groups };
+}
+
+/**
+ * Split block 12 across the form page and the continuation page without ever
+ * splitting a signature block: a typed name orphaned at the top of page 3 with
+ * its signing space left on page 2 cannot be signed. When the naive split
+ * lands inside a group, the whole group moves to the continuation page.
+ * Exported for tests.
+ */
+export function paginateBlockTwelve(
+  composed: ComposedBlockTwelve,
+  pageCapacity: number
+): {
+  pageLines: string[];
+  continuationLines: string[];
+  fieldPlacements: SignatureFieldPlacement[];
+} {
+  const { lines, groups } = composed;
+
+  // Digital blocks with a name → a field placement, computed once we know each
+  // name's final page and its line index within that page's stream.
+  const placementsFor = (split: number, continuationStart: number): SignatureFieldPlacement[] =>
+    groups
+      .filter((g) => g.digital && g.nameLineIndex !== null)
+      .map((g) => {
+        const idx = g.nameLineIndex as number;
+        return idx < split
+          ? { page: 'main' as const, nameLineInPage: idx }
+          : { page: 'continuation' as const, nameLineInPage: idx - continuationStart };
+      });
+
+  if (lines.length <= pageCapacity) {
+    // Everything on the main page: split past the end, continuation empty.
+    return { pageLines: lines, continuationLines: [], fieldPlacements: placementsFor(lines.length, 0) };
+  }
+  let split = pageCapacity;
+  for (const group of groups) {
+    // The split index is the first line of the continuation page; a group is
+    // torn when it starts before the split and ends at or past it.
+    if (group.start < split && group.end >= split) {
+      split = group.start;
+      break;
+    }
+  }
+  // Blank separators at the boundary belong to neither page — but a blank
+  // inside a group is a signing gap, not a separator, and must survive the
+  // trim or the name loses its signing space.
+  const inGroup = (index: number) => groups.some((g) => index >= g.start && index <= g.end);
+  const pageLines = lines.slice(0, split);
+  while (
+    pageLines.length > 0 &&
+    pageLines[pageLines.length - 1] === '' &&
+    !inGroup(pageLines.length - 1)
+  ) {
+    pageLines.pop();
+  }
+  const continuationLines = lines.slice(split);
+  let continuationStart = split;
+  while (
+    continuationLines.length > 0 &&
+    continuationLines[0] === '' &&
+    !inGroup(continuationStart)
+  ) {
+    continuationLines.shift();
+    continuationStart++;
+  }
+  return { pageLines, continuationLines, fieldPlacements: placementsFor(split, continuationStart) };
+}
 
 // =============================================================================
 // SMART BOX POSITIONING SYSTEM
@@ -282,6 +450,8 @@ export async function generateNavmc10274Pdf(
   // Track if we need page 3 for overflow
   let needsPage3 = false;
   let remainingSupplementalLines: string[] = [];
+  // Unique AcroForm field names across all signature fields in this document.
+  let sigFieldSeq = 1;
 
   // Fill Page 2 fields (with placeholder highlighting)
 
@@ -348,14 +518,41 @@ export async function generateNavmc10274Pdf(
     drawMultilineText(page2, lines, PAGE2_FIELDS.enclosures.x, PAGE2_FIELDS.enclosures.y, PAGE2_FIELDS.enclosures.lineHeight, font, FONT_SIZE);
   }
 
-  // Field 12: Supplemental Information (may span pages)
-  if (data.supplementalInfo) {
-    const allLines = wrapText(data.supplementalInfo, PAGE2_FIELDS.supplementalInfo.maxWidth, font, FONT_SIZE);
-
-    // Draw on page 2
-    const { remainingLines } = drawMultilineText(
+  // Field 12: Supplemental Information (may span pages). One line stream
+  // carries the text, the proposed action, and the signature blocks, so
+  // pagination moves them to the continuation page together — and a signature
+  // block moves whole (paginateBlockTwelve), never leaving a typed name
+  // stranded without its signing space.
+  const blockTwelve = composeBlockTwelveLines({
+    supplementalInfo: data.supplementalInfo
+      ? wrapText(data.supplementalInfo, PAGE2_FIELDS.supplementalInfo.maxWidth, font, FONT_SIZE)
+      : [],
+    proposedAction: data.proposedAction
+      ? wrapText(
+          `Proposed/recommended action: ${data.proposedAction}`,
+          PAGE2_FIELDS.supplementalInfo.maxWidth,
+          font,
+          FONT_SIZE
+        )
+      : [],
+    signatureBlocks: (data.signatureBlocks ?? []).map((block) => ({
+      statement: block.statement?.trim()
+        ? wrapText(block.statement.trim(), PAGE2_FIELDS.supplementalInfo.maxWidth, font, FONT_SIZE)
+        : [],
+      name: (block.name ?? '').trim(),
+      digital: block.digital ?? false,
+    })),
+  });
+  // Continuation-page field placements are held until page 3 is created below.
+  let continuationFieldPlacements: SignatureFieldPlacement[] = [];
+  if (blockTwelve.lines.length > 0) {
+    const { pageLines, continuationLines, fieldPlacements } = paginateBlockTwelve(
+      blockTwelve,
+      PAGE2_FIELDS.supplementalInfo.maxLines
+    );
+    drawMultilineText(
       page2,
-      allLines,
+      pageLines,
       PAGE2_FIELDS.supplementalInfo.x,
       PAGE2_FIELDS.supplementalInfo.y,
       PAGE2_FIELDS.supplementalInfo.lineHeight,
@@ -363,11 +560,24 @@ export async function generateNavmc10274Pdf(
       FONT_SIZE,
       PAGE2_FIELDS.supplementalInfo.maxLines
     );
-
-    // Track if we need page 3
-    if (remainingLines.length > 0) {
+    // Digital signature fields whose name landed on the main page.
+    for (const p of fieldPlacements.filter((f) => f.page === 'main')) {
+      addSignatureFieldToPage(
+        pdfDoc,
+        page2,
+        signatureFieldRect(
+          PAGE2_FIELDS.supplementalInfo.x,
+          PAGE2_FIELDS.supplementalInfo.y,
+          p.nameLineInPage,
+          PAGE2_FIELDS.supplementalInfo.lineHeight
+        ),
+        `Signature_${sigFieldSeq++}`
+      );
+    }
+    continuationFieldPlacements = fieldPlacements.filter((f) => f.page === 'continuation');
+    if (continuationLines.length > 0) {
       needsPage3 = true;
-      remainingSupplementalLines = remainingLines;
+      remainingSupplementalLines = continuationLines;
     }
   }
 
@@ -392,6 +602,20 @@ export async function generateNavmc10274Pdf(
       FONT_SIZE,
       PAGE3_FIELDS.supplementalInfo.maxLines
     );
+    // Digital signature fields for blocks that overflowed onto page 3.
+    for (const p of continuationFieldPlacements) {
+      addSignatureFieldToPage(
+        pdfDoc,
+        page3,
+        signatureFieldRect(
+          PAGE3_FIELDS.supplementalInfo.x,
+          PAGE3_FIELDS.supplementalInfo.y,
+          p.nameLineInPage,
+          PAGE3_FIELDS.supplementalInfo.lineHeight
+        ),
+        `Signature_${sigFieldSeq++}`
+      );
+    }
   }
 
   return pdfDoc.save();

--- a/src/services/pdf/navmc10274Generator.ts
+++ b/src/services/pdf/navmc10274Generator.ts
@@ -126,7 +126,9 @@ export interface Navmc10274Data {
 
 import { calculateTextPosition, type BoxBoundary } from './extractFormFields';
 import { addSignatureFieldToPage } from './signatureFieldCore';
-import { isDigital, type SignatureStyle } from '@/types/signature';
+import { base64ToUint8Array } from '@/lib/encoding';
+import type { SignatureStyle } from '@/types/signature';
+import type { PDFImage, PDFPage } from 'pdf-lib';
 
 // A digital signature field sits in the signing gap ABOVE the typed name: 8pt
 // above the name's baseline (clearing its ascenders — a 2pt gap clipped them in
@@ -148,6 +150,48 @@ function signatureFieldRect(
   return [textX, bottom, textX + SIG_FIELD_WIDTH, bottom + SIG_FIELD_HEIGHT];
 }
 
+// A scanned signature fills the same signing gap as a digital field but can be
+// taller — it uses the two blank signing lines above the name.
+const SIG_IMAGE_MAX_WIDTH = SIG_FIELD_WIDTH;
+
+/** Decode a base64 data URL to a pdf-lib image, or null if it can't be read
+ *  (a bad upload must never abort the whole export). */
+async function embedSignatureImage(
+  pdfDoc: PDFDocument,
+  dataUrl: string
+): Promise<PDFImage | null> {
+  try {
+    const comma = dataUrl.indexOf(',');
+    const header = comma >= 0 ? dataUrl.slice(0, comma) : '';
+    const bytes = base64ToUint8Array(comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl);
+    return /jpe?g/i.test(header) ? await pdfDoc.embedJpg(bytes) : await pdfDoc.embedPng(bytes);
+  } catch {
+    return null;
+  }
+}
+
+/** Draw a scanned signature into the signing gap above a name, scaled to fit
+ *  the two blank lines and never wider than the field width; bottom-left
+ *  anchored at the field rect so it sits where a CAC field would. */
+function drawSignatureImage(
+  page: PDFPage,
+  image: PDFImage,
+  textX: number,
+  blockStartY: number,
+  nameLineInPage: number,
+  lineHeight: number
+): void {
+  const [x, y] = signatureFieldRect(textX, blockStartY, nameLineInPage, lineHeight);
+  const boxHeight = 2 * lineHeight; // the two blank signing lines
+  const scale = Math.min(SIG_IMAGE_MAX_WIDTH / image.width, boxHeight / image.height);
+  page.drawImage(image, {
+    x,
+    y,
+    width: image.width * scale,
+    height: image.height * scale,
+  });
+}
+
 /** A signature block's lines, pre-wrapped: optional statement paragraph, then
  *  the typed name. The block is atomic for pagination. */
 export interface ComposedBlockTwelve {
@@ -155,16 +199,25 @@ export interface ComposedBlockTwelve {
   /** [start, end] line spans (inclusive) that pagination must not split — one
    *  per signature block: its statement, signing space, and name move as one.
    *  `nameLineIndex` is where the typed name landed (null for a statement-only
-   *  block); `digital` marks a block that wants a CAC signature field placed in
-   *  its signing space. */
-  groups: Array<{ start: number; end: number; nameLineIndex: number | null; digital: boolean }>;
+   *  block); `style`/`image` say what (if anything) goes in the signing gap. */
+  groups: Array<{
+    start: number;
+    end: number;
+    nameLineIndex: number | null;
+    style: SignatureStyle;
+    image?: string;
+  }>;
 }
 
-/** Where a digital signature field goes: which page, and the name's line index
- *  within that page's block-12 stream (the field sits in the gap above it). */
+/** Where a signature mark goes in the signing gap: which page, the name's line
+ *  index within that page's block-12 stream (the mark sits above it), and what
+ *  to draw there — a CAC field ('digital') or a scanned image ('image'). Typed
+ *  blocks produce no placement. */
 export interface SignatureFieldPlacement {
   page: 'main' | 'continuation';
   nameLineInPage: number;
+  style: 'image' | 'digital';
+  image?: string;
 }
 
 /**
@@ -183,7 +236,7 @@ export interface SignatureFieldPlacement {
 export function composeBlockTwelveLines(parts: {
   supplementalInfo: string[];
   proposedAction: string[];
-  signatureBlocks: Array<{ statement: string[]; name: string; style?: SignatureStyle }>;
+  signatureBlocks: Array<{ statement: string[]; name: string; style?: SignatureStyle; image?: string }>;
 }): ComposedBlockTwelve {
   const lines: string[] = [...parts.supplementalInfo];
   if (parts.proposedAction.length > 0) {
@@ -215,7 +268,13 @@ export function composeBlockTwelveLines(parts: {
       nameLineIndex = lines.length;
       lines.push(name);
     }
-    groups.push({ start, end: lines.length - 1, nameLineIndex, digital: isDigital(block) });
+    groups.push({
+      start,
+      end: lines.length - 1,
+      nameLineIndex,
+      style: block.style ?? 'typed',
+      image: block.image,
+    });
   }
   return { lines, groups };
 }
@@ -237,16 +296,22 @@ export function paginateBlockTwelve(
 } {
   const { lines, groups } = composed;
 
-  // Digital blocks with a name → a field placement, computed once we know each
-  // name's final page and its line index within that page's stream.
+  // Blocks with a name and a signing mark (a CAC field, or an image with data)
+  // → a placement, computed once we know each name's final page and its line
+  // index within that page's stream.
   const placementsFor = (split: number, continuationStart: number): SignatureFieldPlacement[] =>
     groups
-      .filter((g) => g.digital && g.nameLineIndex !== null)
+      .filter(
+        (g) =>
+          g.nameLineIndex !== null &&
+          (g.style === 'digital' || (g.style === 'image' && !!g.image))
+      )
       .map((g) => {
         const idx = g.nameLineIndex as number;
+        const mark = { style: g.style as 'image' | 'digital', image: g.image };
         return idx < split
-          ? { page: 'main' as const, nameLineInPage: idx }
-          : { page: 'continuation' as const, nameLineInPage: idx - continuationStart };
+          ? { page: 'main' as const, nameLineInPage: idx, ...mark }
+          : { page: 'continuation' as const, nameLineInPage: idx - continuationStart, ...mark };
       });
 
   if (lines.length <= pageCapacity) {
@@ -542,8 +607,28 @@ export async function generateNavmc10274Pdf(
         : [],
       name: (block.name ?? '').trim(),
       style: block.style,
+      image: block.image,
     })),
   });
+
+  // Place a signing mark (CAC field or scanned image) in the gap above a name.
+  const placeSignatureMark = async (
+    page: PDFPage,
+    p: SignatureFieldPlacement,
+    box: { x: number; y: number; lineHeight: number }
+  ): Promise<void> => {
+    if (p.style === 'digital') {
+      addSignatureFieldToPage(
+        pdfDoc,
+        page,
+        signatureFieldRect(box.x, box.y, p.nameLineInPage, box.lineHeight),
+        `Signature_${sigFieldSeq++}`
+      );
+    } else if (p.style === 'image' && p.image) {
+      const img = await embedSignatureImage(pdfDoc, p.image);
+      if (img) drawSignatureImage(page, img, box.x, box.y, p.nameLineInPage, box.lineHeight);
+    }
+  };
   // Continuation-page field placements are held until page 3 is created below.
   let continuationFieldPlacements: SignatureFieldPlacement[] = [];
   if (blockTwelve.lines.length > 0) {
@@ -561,19 +646,9 @@ export async function generateNavmc10274Pdf(
       FONT_SIZE,
       PAGE2_FIELDS.supplementalInfo.maxLines
     );
-    // Digital signature fields whose name landed on the main page.
+    // Signing marks whose name landed on the main page.
     for (const p of fieldPlacements.filter((f) => f.page === 'main')) {
-      addSignatureFieldToPage(
-        pdfDoc,
-        page2,
-        signatureFieldRect(
-          PAGE2_FIELDS.supplementalInfo.x,
-          PAGE2_FIELDS.supplementalInfo.y,
-          p.nameLineInPage,
-          PAGE2_FIELDS.supplementalInfo.lineHeight
-        ),
-        `Signature_${sigFieldSeq++}`
-      );
+      await placeSignatureMark(page2, p, PAGE2_FIELDS.supplementalInfo);
     }
     continuationFieldPlacements = fieldPlacements.filter((f) => f.page === 'continuation');
     if (continuationLines.length > 0) {
@@ -603,19 +678,9 @@ export async function generateNavmc10274Pdf(
       FONT_SIZE,
       PAGE3_FIELDS.supplementalInfo.maxLines
     );
-    // Digital signature fields for blocks that overflowed onto page 3.
+    // Signing marks for blocks that overflowed onto page 3.
     for (const p of continuationFieldPlacements) {
-      addSignatureFieldToPage(
-        pdfDoc,
-        page3,
-        signatureFieldRect(
-          PAGE3_FIELDS.supplementalInfo.x,
-          PAGE3_FIELDS.supplementalInfo.y,
-          p.nameLineInPage,
-          PAGE3_FIELDS.supplementalInfo.lineHeight
-        ),
-        `Signature_${sigFieldSeq++}`
-      );
+      await placeSignatureMark(page3, p, PAGE3_FIELDS.supplementalInfo);
     }
   }
 

--- a/src/services/pdf/navmc10274Generator.ts
+++ b/src/services/pdf/navmc10274Generator.ts
@@ -125,7 +125,7 @@ export interface Navmc10274Data {
 }
 
 import { calculateTextPosition, type BoxBoundary } from './extractFormFields';
-import { addSignatureFieldToPage } from './signatureFieldCore';
+import { addSignatureFieldToPage, signatureFieldName } from './signatureFieldCore';
 import { base64ToUint8Array } from '@/lib/encoding';
 import type { SignatureStyle } from '@/types/signature';
 import type { PDFImage, PDFPage } from 'pdf-lib';
@@ -206,6 +206,7 @@ export interface ComposedBlockTwelve {
     nameLineIndex: number | null;
     style: SignatureStyle;
     image?: string;
+    name: string;
   }>;
 }
 
@@ -218,6 +219,7 @@ export interface SignatureFieldPlacement {
   nameLineInPage: number;
   style: 'image' | 'digital';
   image?: string;
+  name: string;
 }
 
 /**
@@ -274,6 +276,7 @@ export function composeBlockTwelveLines(parts: {
       nameLineIndex,
       style: block.style ?? 'typed',
       image: block.image,
+      name,
     });
   }
   return { lines, groups };
@@ -308,7 +311,7 @@ export function paginateBlockTwelve(
       )
       .map((g) => {
         const idx = g.nameLineIndex as number;
-        const mark = { style: g.style as 'image' | 'digital', image: g.image };
+        const mark = { style: g.style as 'image' | 'digital', image: g.image, name: g.name };
         return idx < split
           ? { page: 'main' as const, nameLineInPage: idx, ...mark }
           : { page: 'continuation' as const, nameLineInPage: idx - continuationStart, ...mark };
@@ -622,7 +625,7 @@ export async function generateNavmc10274Pdf(
         pdfDoc,
         page,
         signatureFieldRect(box.x, box.y, p.nameLineInPage, box.lineHeight),
-        `Signature_${sigFieldSeq++}`
+        signatureFieldName(p.name, sigFieldSeq++)
       );
     } else if (p.style === 'image' && p.image) {
       const img = await embedSignatureImage(pdfDoc, p.image);

--- a/src/services/pdf/navmc11811Generator.ts
+++ b/src/services/pdf/navmc11811Generator.ts
@@ -105,12 +105,22 @@ export interface Navmc11811Data {
   // Box 11 - SRB (Service Record Book) page number, 5 chars max
   box11: string;
 
-  // No typed-signature field: the printed NAVMC 118(11) carries its own
-  // "(Signature)" lines, which are signed by hand. (A `signatureName` was
-  // declared here for years, never rendered and never collected by any UI.)
+  // Signature blocks appended to the end of the 6105 entry, in signing order.
+  // A Page 11 counseling entry is authenticated by the counselor and the
+  // counseled Marine (MCO 1610.7 / IRAM); the form's three pre-printed
+  // "(Signature)" cells at the top are for standing entries (Art 137, SBP), not
+  // this one, so these blocks close the entry text itself. Each block's optional
+  // statement ("I have been counseled…") prints above its signing space; `style`
+  // selects typed name / scanned image / empty CAC field, as on the AA form.
+  signatureBlocks: FormSignatureBlock[];
 }
 
 import { calculateTextPosition, type BoxBoundary } from './extractFormFields';
+import { addSignatureFieldToPage } from './signatureFieldCore';
+import { base64ToUint8Array } from '@/lib/encoding';
+import { isDigital, isImage } from '@/types/signature';
+import type { FormSignatureBlock } from '@/types/signature';
+import type { PDFDocument as PDFDocumentType, PDFImage, PDFPage } from 'pdf-lib';
 
 // =============================================================================
 // SMART BOX POSITIONING SYSTEM
@@ -176,6 +186,84 @@ const FIELDS = {
 // SECNAV-style hanging indent on continuation lines.
 const wrapText = wrapTextForForm;
 
+// Signing-gap geometry (mirrors the AA form): a mark sits 8pt above the name
+// baseline, up to 180pt wide and two blank lines tall.
+const SIG_ABOVE = 8;
+const SIG_FIELD_W = 180;
+const SIG_FIELD_H = 20;
+
+/** Decode a base64 (data-URL or raw) image to a pdf-lib image, or null. */
+async function embedSignatureImage(
+  pdfDoc: PDFDocumentType,
+  dataUrl: string
+): Promise<PDFImage | null> {
+  try {
+    const comma = dataUrl.indexOf(',');
+    const header = comma >= 0 ? dataUrl.slice(0, comma) : '';
+    const bytes = base64ToUint8Array(comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl);
+    return /jpe?g/i.test(header) ? await pdfDoc.embedJpg(bytes) : await pdfDoc.embedPng(bytes);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Draw the signature blocks that close a 6105 entry into a remarks column,
+ * starting below `startY`. Each block prints its statement (if any), leaves two
+ * blank signing lines, then the typed name — placing a CAC field or a scanned
+ * image in the gap above the name per the block's style. Returns nothing; the
+ * column is capped by its own height like the entry text above it.
+ */
+async function appendSignatureBlocks(
+  pdfDoc: PDFDocumentType,
+  page: PDFPage,
+  font: Parameters<typeof drawTextWithHighlights>[4],
+  fontSize: number,
+  blocks: FormSignatureBlock[],
+  col: { x: number; maxWidth: number; lineHeight: number },
+  startY: number,
+  seq: { n: number }
+): Promise<void> {
+  let y = startY;
+  for (const block of blocks) {
+    const name = (block.name ?? '').trim();
+    const statement = (block.statement ?? '').trim();
+    if (!name && !statement) continue;
+    y -= col.lineHeight; // paragraph gap before the block
+    if (statement) {
+      for (const line of wrapText(statement, col.maxWidth, font, fontSize)) {
+        drawTextWithHighlights(page, line, col.x, y, font, fontSize);
+        y -= col.lineHeight;
+      }
+    }
+    y -= 2 * col.lineHeight; // the two blank signing lines
+    if (!name) continue;
+    if (isDigital(block)) {
+      const bottom = y + SIG_ABOVE;
+      addSignatureFieldToPage(
+        pdfDoc,
+        page,
+        [col.x, bottom, col.x + SIG_FIELD_W, bottom + SIG_FIELD_H],
+        `Signature_${seq.n++}`
+      );
+    } else if (isImage(block) && block.image) {
+      const img = await embedSignatureImage(pdfDoc, block.image);
+      if (img) {
+        const boxH = 2 * col.lineHeight;
+        const scale = Math.min(SIG_FIELD_W / img.width, boxH / img.height);
+        page.drawImage(img, {
+          x: col.x,
+          y: y + SIG_ABOVE,
+          width: img.width * scale,
+          height: img.height * scale,
+        });
+      }
+    }
+    drawTextWithHighlights(page, name, col.x, y, font, fontSize);
+    y -= col.lineHeight;
+  }
+}
+
 /**
  * Generate a filled NAVMC 118(11) form
  * @param data - Form data to fill in
@@ -213,6 +301,7 @@ export async function generateNavmc11811Pdf(
   }
 
   // Fill in left remarks area (with placeholder highlighting)
+  let leftEndY = FIELDS.remarks.y;
   if (data.remarksText) {
     const lines = wrapText(data.remarksText, FIELDS.remarks.maxWidth, font, FONT_SIZE);
     let y = FIELDS.remarks.y;
@@ -226,10 +315,14 @@ export async function generateNavmc11811Pdf(
     if (data.entryDate) {
       y -= FIELDS.remarks.lineHeight; // Extra space
       drawTextWithHighlights(page, data.entryDate, FIELDS.remarks.x, y, font, FONT_SIZE);
+      y -= FIELDS.remarks.lineHeight;
     }
+    leftEndY = y;
   }
 
   // Fill in right remarks area (continuation) (with placeholder highlighting)
+  let rightEndY = FIELDS.remarksRight.y;
+  const hasRight = !!data.remarksTextRight;
   if (data.remarksTextRight) {
     const lines = wrapText(data.remarksTextRight, FIELDS.remarksRight.maxWidth, font, FONT_SIZE);
     let y = FIELDS.remarksRight.y;
@@ -238,6 +331,16 @@ export async function generateNavmc11811Pdf(
       drawTextWithHighlights(page, lines[i], FIELDS.remarksRight.x, y, font, FONT_SIZE);
       y -= FIELDS.remarksRight.lineHeight;
     }
+    rightEndY = y;
+  }
+
+  // Close the entry with its signature blocks — in the column the entry ends in
+  // (the right column when the entry spilled into it, else the left).
+  const sigBlocks = data.signatureBlocks ?? [];
+  if (sigBlocks.length > 0) {
+    const col = hasRight ? FIELDS.remarksRight : FIELDS.remarks;
+    const startY = hasRight ? rightEndY : leftEndY;
+    await appendSignatureBlocks(pdfDoc, page, font, FONT_SIZE, sigBlocks, col, startY, { n: 1 });
   }
 
   return pdfDoc.save();

--- a/src/services/pdf/navmc11811Generator.ts
+++ b/src/services/pdf/navmc11811Generator.ts
@@ -120,7 +120,7 @@ import { addSignatureFieldToPage, signatureFieldName } from './signatureFieldCor
 import { base64ToUint8Array } from '@/lib/encoding';
 import { isDigital, isImage } from '@/types/signature';
 import type { FormSignatureBlock } from '@/types/signature';
-import type { PDFDocument as PDFDocumentType, PDFImage, PDFPage } from 'pdf-lib';
+import type { PDFDocument as PDFDocumentType, PDFFont, PDFImage, PDFPage } from 'pdf-lib';
 
 // =============================================================================
 // SMART BOX POSITIONING SYSTEM
@@ -167,16 +167,23 @@ const FIELDS = {
     boxWidth: PAGE_BOXES.box11.width
   },
 
-  // Remarks boxes with additional properties
+  // Remarks boxes with additional properties.
+  //
+  // maxLines is calibrated by rendering, not derived from the box height: a
+  // 45-numbered-line probe showed lines 38+ printing over the NAME/EDIPI
+  // identification strip at the bottom of the form (the old cap of 40 let the
+  // last three lines corrupt the strip). 37 is the last line that stays above
+  // it. Content beyond the cap is truncated — computeNavmc11811Fit() reports
+  // that so the editor can warn instead of dropping text silently.
   remarks: {
     ...getFieldPosition('remarks'),
     lineHeight: 11,
-    maxLines: 40,
+    maxLines: 37,
   },
   remarksRight: {
     ...getFieldPosition('remarksRight'),
     lineHeight: 11,
-    maxLines: 40,
+    maxLines: 37,
   },
 };
 
@@ -208,11 +215,38 @@ async function embedSignatureImage(
 }
 
 /**
+ * Line count the signature blocks consume in a column — the measurement twin
+ * of appendSignatureBlocks below. Keep the two in lockstep: per non-empty
+ * block, 1 paragraph gap + the wrapped statement lines + 2 blank signing
+ * lines + 1 name line (when named). computeNavmc11811Fit uses this so the
+ * editor can warn when the close-out runs past the column bottom.
+ */
+function signatureBlockLineCount(
+  blocks: FormSignatureBlock[],
+  font: PDFFont,
+  fontSize: number,
+  maxWidth: number
+): number {
+  let n = 0;
+  for (const block of blocks) {
+    const name = (block.name ?? '').trim();
+    const statement = (block.statement ?? '').trim();
+    if (!name && !statement) continue;
+    n += 1; // paragraph gap before the block
+    if (statement) n += wrapText(statement, maxWidth, font, fontSize).length;
+    n += 2; // the two blank signing lines
+    if (name) n += 1;
+  }
+  return n;
+}
+
+/**
  * Draw the signature blocks that close a 6105 entry into a remarks column,
  * starting below `startY`. Each block prints its statement (if any), leaves two
  * blank signing lines, then the typed name — placing a CAC field or a scanned
  * image in the gap above the name per the block's style. Returns nothing; the
  * column is capped by its own height like the entry text above it.
+ * (Line accounting mirrored in signatureBlockLineCount above.)
  */
 async function appendSignatureBlocks(
   pdfDoc: PDFDocumentType,
@@ -344,6 +378,92 @@ export async function generateNavmc11811Pdf(
   }
 
   return pdfDoc.save();
+}
+
+// =============================================================================
+// FIT REPORT — how much of the entry actually prints
+// =============================================================================
+
+export interface Navmc11811ColumnFit {
+  /** Wrapped entry-text lines this column's content produces. */
+  lines: number;
+  /** Entry-text lines the column can print before truncation. */
+  capacity: number;
+  /** Entry-text lines that will NOT print. */
+  truncated: number;
+  /**
+   * Lines the column's close-out (entry date and/or signature blocks, when
+   * they land in this column) runs past the bottom of the column.
+   */
+  spillover: number;
+}
+
+export interface Navmc11811Fit {
+  left: Navmc11811ColumnFit;
+  right: Navmc11811ColumnFit;
+}
+
+// A cached measurement font. wrapText needs real Times Roman metrics — the
+// same font generateNavmc11811Pdf embeds — but a fit check must not load the
+// form template or build a full document per keystroke. One throwaway
+// document's font is reused for every measurement.
+let measurementFontPromise: Promise<PDFFont> | null = null;
+function measurementFont(): Promise<PDFFont> {
+  measurementFontPromise ??= PDFDocument.create().then((doc) =>
+    doc.embedFont(StandardFonts.TimesRoman)
+  );
+  return measurementFontPromise;
+}
+
+/**
+ * Report how the entry fits the form's two fixed columns, using the same
+ * wrapping, font metrics, and line caps the generator draws with. The editor
+ * shows this so over-long text warns instead of silently truncating (the
+ * columns are a single physical page — there is no continuation sheet; a
+ * longer entry continues in the right column or on a second Page 11).
+ */
+export async function computeNavmc11811Fit(data: Navmc11811Data): Promise<Navmc11811Fit> {
+  const font = await measurementFont();
+
+  const leftLines = data.remarksText
+    ? wrapText(data.remarksText, FIELDS.remarks.maxWidth, font, FONT_SIZE).length
+    : 0;
+  const rightLines = data.remarksTextRight
+    ? wrapText(data.remarksTextRight, FIELDS.remarksRight.maxWidth, font, FONT_SIZE).length
+    : 0;
+
+  const leftPrinted = Math.min(leftLines, FIELDS.remarks.maxLines);
+  const rightPrinted = Math.min(rightLines, FIELDS.remarksRight.maxLines);
+
+  // Close-out placement mirrors the generator: the date follows the left
+  // column's text (2 lines: gap + date); the signature blocks land in the
+  // right column when it has text, else the left.
+  const dateLines = data.remarksText && data.entryDate ? 2 : 0;
+  const sigInRight = !!data.remarksTextRight;
+  const sigLines = signatureBlockLineCount(
+    data.signatureBlocks ?? [],
+    font,
+    FONT_SIZE,
+    (sigInRight ? FIELDS.remarksRight : FIELDS.remarks).maxWidth
+  );
+
+  const leftUsed = leftPrinted + dateLines + (sigInRight ? 0 : sigLines);
+  const rightUsed = rightPrinted + (sigInRight ? sigLines : 0);
+
+  return {
+    left: {
+      lines: leftLines,
+      capacity: FIELDS.remarks.maxLines,
+      truncated: leftLines - leftPrinted,
+      spillover: Math.max(0, leftUsed - FIELDS.remarks.maxLines),
+    },
+    right: {
+      lines: rightLines,
+      capacity: FIELDS.remarksRight.maxLines,
+      truncated: rightLines - rightPrinted,
+      spillover: Math.max(0, rightUsed - FIELDS.remarksRight.maxLines),
+    },
+  };
 }
 
 /**

--- a/src/services/pdf/navmc11811Generator.ts
+++ b/src/services/pdf/navmc11811Generator.ts
@@ -116,7 +116,7 @@ export interface Navmc11811Data {
 }
 
 import { calculateTextPosition, type BoxBoundary } from './extractFormFields';
-import { addSignatureFieldToPage } from './signatureFieldCore';
+import { addSignatureFieldToPage, signatureFieldName } from './signatureFieldCore';
 import { base64ToUint8Array } from '@/lib/encoding';
 import { isDigital, isImage } from '@/types/signature';
 import type { FormSignatureBlock } from '@/types/signature';
@@ -244,7 +244,7 @@ async function appendSignatureBlocks(
         pdfDoc,
         page,
         [col.x, bottom, col.x + SIG_FIELD_W, bottom + SIG_FIELD_H],
-        `Signature_${seq.n++}`
+        signatureFieldName(name, seq.n++)
       );
     } else if (isImage(block) && block.image) {
       const img = await embedSignatureImage(pdfDoc, block.image);

--- a/src/services/pdf/navmc11811Generator.ts
+++ b/src/services/pdf/navmc11811Generator.ts
@@ -105,8 +105,9 @@ export interface Navmc11811Data {
   // Box 11 - SRB (Service Record Book) page number, 5 chars max
   box11: string;
 
-  // Signature info (for the counseling signature line)
-  signatureName?: string;
+  // No typed-signature field: the printed NAVMC 118(11) carries its own
+  // "(Signature)" lines, which are signed by hand. (A `signatureName` was
+  // declared here for years, never rendered and never collected by any UI.)
 }
 
 import { calculateTextPosition, type BoxBoundary } from './extractFormFields';

--- a/src/services/pdf/signatureFieldCore.ts
+++ b/src/services/pdf/signatureFieldCore.ts
@@ -26,6 +26,17 @@ import {
  * @param rect [x, y, x2, y2] in PDF points, origin bottom-left.
  * @param name unique AcroForm field name (must be unique in the document).
  */
+/**
+ * A human-readable, unique AcroForm field name for a signer, so Acrobat shows
+ * the signer *which* field is theirs (e.g. "R L SMITH signature 1") instead of
+ * an opaque "Signature_1". Periods are stripped — they denote field hierarchy
+ * in AcroForm names — and `seq` guarantees uniqueness within the document.
+ */
+export function signatureFieldName(rawName: string | undefined, seq: number): string {
+  const clean = (rawName ?? '').replace(/\./g, '').replace(/\s+/g, ' ').trim();
+  return clean ? `${clean} signature ${seq}` : `Signature ${seq}`;
+}
+
 export function addSignatureFieldToPage(
   pdfDoc: PDFDocument,
   page: PDFPage,

--- a/src/services/pdf/signatureFieldCore.ts
+++ b/src/services/pdf/signatureFieldCore.ts
@@ -1,0 +1,87 @@
+import {
+  PDFDocument,
+  PDFName,
+  PDFDict,
+  PDFArray,
+  PDFString,
+  PDFNumber,
+  type PDFPage,
+} from 'pdf-lib';
+
+/**
+ * Add one empty AcroForm signature field (`/FT /Sig`) at an explicit rectangle
+ * on a page of an already-open document. This is the coordinate-driven core:
+ * the caller supplies where the field goes, so no text search is involved.
+ *
+ * The field is exactly what Adobe Acrobat + CAC middleware recognize as an
+ * empty, signable signature field — DonDocs embeds the field, the signer
+ * applies the cryptographic CAC signature later in Acrobat. This function does
+ * NOT sign anything; a browser cannot reach a CAC's private key, and embedding
+ * an empty field is benign PDF structure.
+ *
+ * (The letter path in addSignatureField.ts creates the same structure but
+ * positions it by searching the rendered text for the signatory's name — it
+ * predates this primitive and could adopt it later.)
+ *
+ * @param rect [x, y, x2, y2] in PDF points, origin bottom-left.
+ * @param name unique AcroForm field name (must be unique in the document).
+ */
+export function addSignatureFieldToPage(
+  pdfDoc: PDFDocument,
+  page: PDFPage,
+  rect: [number, number, number, number],
+  name: string
+): void {
+  const catalog = pdfDoc.catalog;
+
+  // AcroForm with the signature flags (3 = SignaturesExist | AppendOnly).
+  let acroForm = catalog.lookup(PDFName.of('AcroForm')) as PDFDict | undefined;
+  if (!acroForm) {
+    acroForm = pdfDoc.context.obj({ Fields: [], SigFlags: 3 }) as PDFDict;
+    catalog.set(PDFName.of('AcroForm'), acroForm);
+  }
+  acroForm.set(PDFName.of('SigFlags'), PDFNumber.of(3));
+
+  let fields = acroForm.lookup(PDFName.of('Fields')) as PDFArray | undefined;
+  if (!fields) {
+    fields = pdfDoc.context.obj([]) as PDFArray;
+    acroForm.set(PDFName.of('Fields'), fields);
+  }
+
+  const pageRef =
+    pdfDoc.context.getObjectRef(page.node) ?? pdfDoc.context.register(page.node);
+
+  // Empty appearance stream so viewers draw a clean, unfilled field box.
+  const width = rect[2] - rect[0];
+  const height = rect[3] - rect[1];
+  const appearance = pdfDoc.context.register(
+    pdfDoc.context.stream('q Q', {
+      Type: PDFName.of('XObject'),
+      Subtype: PDFName.of('Form'),
+      FormType: 1,
+      BBox: [0, 0, width, height],
+    })
+  );
+
+  const sigField = pdfDoc.context.obj({
+    Type: PDFName.of('Annot'),
+    Subtype: PDFName.of('Widget'),
+    FT: PDFName.of('Sig'),
+    T: PDFString.of(name),
+    Rect: rect,
+    F: 4, // Print
+    P: pageRef,
+    Border: [0, 0, 0],
+    AP: pdfDoc.context.obj({ N: appearance }),
+  }) as PDFDict;
+
+  const sigRef = pdfDoc.context.register(sigField);
+  fields.push(sigRef);
+
+  let annots = page.node.lookup(PDFName.of('Annots')) as PDFArray | undefined;
+  if (!annots) {
+    annots = pdfDoc.context.obj([]) as PDFArray;
+    page.node.set(PDFName.of('Annots'), annots);
+  }
+  annots.push(sigRef);
+}

--- a/src/stores/formStore.ts
+++ b/src/stores/formStore.ts
@@ -62,8 +62,19 @@ export interface NavmcForm10274Data {
   enclosures: string;
   // Field 12: Supplemental Information (main counseling text)
   supplementalInfo: string;
-  // Field 13: Proposed/Recommended Action
+  // Proposed/Recommended Action. The printed NAVMC 10274 has no box for this
+  // (its fields run 1-12), so it renders as a labeled closing paragraph inside
+  // block 12 rather than into a box of its own.
   proposedAction: string;
+  // Signature blocks at the end of block 12, in signing order. The first is
+  // the originator's, per the form's own caption ("type name of originator and
+  // sign 3 lines below text"); counseling actions add the counseled Marine's
+  // acknowledgement and sometimes a witness. Each block's optional statement
+  // ("Acknowledged:", "I have witnessed…") prints as a paragraph above that
+  // signer's signing space; the typed name goes on the third line below it.
+  // `digital` places an empty CAC-signable AcroForm field in the signing gap
+  // above the name (the signer applies the cryptographic signature in Acrobat).
+  signatureBlocks: Array<{ statement: string; name: string; digital?: boolean }>;
 }
 
 interface FormStore {
@@ -97,6 +108,7 @@ const EMPTY_NAVMC_10274: NavmcForm10274Data = {
   enclosures: '',
   supplementalInfo: '',
   proposedAction: '',
+  signatureBlocks: [],
 };
 
 const EMPTY_NAVMC_11811: Navmc11811Data = {
@@ -169,6 +181,16 @@ Despite these counseling efforts and remedial PT opportunities, you have failed 
 
 10. Your signature below acknowledges receipt of this counseling and indicates that you understand the requirements and potential consequences outlined herein. Your signature does not constitute agreement with the contents of this counseling. You have the right to submit a written rebuttal within 10 working days of the date of this counseling.`,
   proposedAction: 'Request entry of adverse Page 11 (6105) entry per MCO 1610.7A. Recommend assignment to Remedial PT Program and monthly progress evaluations.',
+  // Two blocks — the shape most counseling actions need: the originator signs
+  // first, then the Marine acknowledges (fulfilling the demo text's own
+  // "Your signature below acknowledges receipt" in paragraph 10).
+  signatureBlocks: [
+    { statement: '', name: 'R. L. SMITH' },
+    {
+      statement: 'I acknowledge receipt and understanding of this counseling.',
+      name: 'J. A. DOE',
+    },
+  ],
 };
 
 const DEFAULT_NAVMC_11811: Navmc11811Data = {
@@ -236,6 +258,24 @@ export const useFormStore = create<FormStore>()(
         navmc11811: s.navmc11811,
         includeCoverPage: s.includeCoverPage,
       }),
+      // Persisted sessions predating signatureBlocks (every user before
+      // 1.2.105) hydrate a navmc10274 without the array — the default merge is
+      // shallow, so the stored object would replace the default wholesale and
+      // leave signatureBlocks undefined, crashing the Forms tab on .map.
+      merge: (persisted, current) => {
+        const p = (persisted ?? {}) as Partial<FormStore>;
+        const merged = { ...current, ...p };
+        if (p.navmc10274) {
+          merged.navmc10274 = {
+            ...current.navmc10274,
+            ...p.navmc10274,
+            signatureBlocks: Array.isArray(p.navmc10274.signatureBlocks)
+              ? p.navmc10274.signatureBlocks
+              : [],
+          };
+        }
+        return merged;
+      },
     }
   )
 );

--- a/src/stores/formStore.ts
+++ b/src/stores/formStore.ts
@@ -51,6 +51,10 @@ export interface Navmc11811Data {
 
   // Box 11 - SRB (Service Record Book) page number, 5 chars max
   box11: string;
+
+  // Signature blocks closing the 6105 entry (counselor + counseled Marine),
+  // appended to the remarks body. Same shape/styles as the AA form.
+  signatureBlocks: FormSignatureBlock[];
 }
 
 export interface NavmcForm10274Data {
@@ -133,6 +137,7 @@ const EMPTY_NAVMC_11811: Navmc11811Data = {
   firstName: '',
   middleName: '',
   edipi: '',
+  signatureBlocks: [],
   remarksText: '',
   remarksTextRight: '',
   entryDate: '',
@@ -228,6 +233,16 @@ J. A. SMITH, SSgt, USMC`,
   remarksTextRight: '',
   entryDate: formatMilitaryDate(new Date()),
   box11: '01',
+  // A 6105 is authenticated by the counselor and the counseled Marine; the
+  // acknowledgement wording is the user's to set (MCO 1610.7 / IRAM).
+  signatureBlocks: [
+    { statement: '', name: 'J. A. SMITH', style: 'typed' },
+    {
+      statement: 'I have been counseled this date and understand this entry.',
+      name: 'J. M. DOE',
+      style: 'typed',
+    },
+  ],
 };
 
 export const useFormStore = create<FormStore>()(
@@ -289,6 +304,15 @@ export const useFormStore = create<FormStore>()(
             ...p.navmc10274,
             signatureBlocks: Array.isArray(p.navmc10274.signatureBlocks)
               ? p.navmc10274.signatureBlocks.map(migrateSignatureBlock)
+              : [],
+          };
+        }
+        if (p.navmc11811) {
+          merged.navmc11811 = {
+            ...current.navmc11811,
+            ...p.navmc11811,
+            signatureBlocks: Array.isArray(p.navmc11811.signatureBlocks)
+              ? p.navmc11811.signatureBlocks.map(migrateSignatureBlock)
               : [],
           };
         }

--- a/src/stores/formStore.ts
+++ b/src/stores/formStore.ts
@@ -2,6 +2,22 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { safeLocalStorage } from '@/lib/compressedStorage';
 import { format } from 'date-fns';
+import type { FormSignatureBlock, SignatureStyle } from '@/types/signature';
+
+/** Upgrade a persisted signature block from the pre-1.2.107 `digital` boolean
+ *  to the `style` field, dropping the legacy key. Idempotent. */
+function migrateSignatureBlock(
+  block: FormSignatureBlock & { digital?: boolean }
+): FormSignatureBlock {
+  if (block.style) {
+    const { digital: _d, ...rest } = block;
+    void _d;
+    return rest;
+  }
+  const { digital, ...rest } = block;
+  const style: SignatureStyle = digital ? 'digital' : 'typed';
+  return { ...rest, style };
+}
 
 // The persist key for NAVMC form data. Exported so the "Saved" indicator can
 // verify the latest write actually landed (safeLocalStorage.lastWriteFailed).
@@ -72,9 +88,10 @@ export interface NavmcForm10274Data {
   // acknowledgement and sometimes a witness. Each block's optional statement
   // ("Acknowledged:", "I have witnessed…") prints as a paragraph above that
   // signer's signing space; the typed name goes on the third line below it.
-  // `digital` places an empty CAC-signable AcroForm field in the signing gap
-  // above the name (the signer applies the cryptographic signature in Acrobat).
-  signatureBlocks: Array<{ statement: string; name: string; digital?: boolean }>;
+  // `style` selects how each block signs: 'typed' (name only, the default),
+  // 'image' (a scanned signature drawn in the gap), or 'digital' (an empty
+  // CAC-signable AcroForm field placed there for signing later in Acrobat).
+  signatureBlocks: FormSignatureBlock[];
 }
 
 interface FormStore {
@@ -258,10 +275,11 @@ export const useFormStore = create<FormStore>()(
         navmc11811: s.navmc11811,
         includeCoverPage: s.includeCoverPage,
       }),
-      // Persisted sessions predating signatureBlocks (every user before
-      // 1.2.105) hydrate a navmc10274 without the array — the default merge is
-      // shallow, so the stored object would replace the default wholesale and
-      // leave signatureBlocks undefined, crashing the Forms tab on .map.
+      // Persisted sessions predating signatureBlocks hydrate a navmc10274
+      // without the array — the default merge is shallow, so the stored object
+      // would replace the default wholesale and leave signatureBlocks undefined,
+      // crashing the Forms tab on .map. Also upgrade any block still carrying the
+      // pre-1.2.107 `digital: boolean` flag to the `style` field.
       merge: (persisted, current) => {
         const p = (persisted ?? {}) as Partial<FormStore>;
         const merged = { ...current, ...p };
@@ -270,7 +288,7 @@ export const useFormStore = create<FormStore>()(
             ...current.navmc10274,
             ...p.navmc10274,
             signatureBlocks: Array.isArray(p.navmc10274.signatureBlocks)
-              ? p.navmc10274.signatureBlocks
+              ? p.navmc10274.signatureBlocks.map(migrateSignatureBlock)
               : [],
           };
         }

--- a/src/types/signature.ts
+++ b/src/types/signature.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared signature model for the NAVMC forms (NAVMC 10274 and 118(11)).
+ *
+ * Both forms render through pdf-lib and place a signer's block the same way: an
+ * optional statement above a signing gap, the typed name below it, and — per
+ * the chosen style — a scanned signature image drawn into the gap or an empty
+ * CAC-signable AcroForm field placed there. Keeping one shape (and one set of
+ * pdf-lib primitives) for both forms stops the two from drifting apart.
+ *
+ * The naval letter renders through LaTeX, a different engine, so it keeps its
+ * own `SignatureType`/`signatureImage` fields — but speaks the same vocabulary:
+ * `SignatureStyle` here mirrors the letter's `'typed' | 'image' | 'digital'`
+ * choice (the letter historically spells "typed" as `'none'`).
+ */
+
+export type SignatureStyle = 'typed' | 'image' | 'digital';
+
+export interface FormSignatureBlock {
+  /** Typed name printed on the signing line (initials + SURNAME). */
+  name: string;
+  /** Optional statement printed above the signing space ("Acknowledged:"). */
+  statement: string;
+  /**
+   * How the signature is produced. Defaults to `'typed'` (name only).
+   * `'image'` draws `image` into the signing gap; `'digital'` places an empty
+   * CAC-signable AcroForm field there for signing later in Acrobat.
+   */
+  style?: SignatureStyle;
+  /** Base64 data URL of the scanned signature, used only when style === 'image'. */
+  image?: string;
+}
+
+/** True when a block wants a digital (CAC) AcroForm field placed in its gap. */
+export function isDigital(block: { style?: SignatureStyle }): boolean {
+  return block.style === 'digital';
+}
+
+/** True when a block wants a scanned image drawn in its gap. */
+export function isImage(block: { style?: SignatureStyle; image?: string }): boolean {
+  return block.style === 'image' && !!block.image;
+}

--- a/tests/integration/navmc10274-digital-sig.test.ts
+++ b/tests/integration/navmc10274-digital-sig.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Digital signature fields on the NAVMC 10274.
+ *
+ * A signature block marked `digital` gets a real, empty AcroForm `/FT /Sig`
+ * field placed in its signing gap — exactly what Acrobat + CAC middleware
+ * recognize as signable (DonDocs embeds the field; the CAC signature is applied
+ * later in Acrobat). This reads the fields back off the compiled PDF with
+ * pdf-lib and asserts: the field is a real /Sig widget, it sits ABOVE the right
+ * name, and it lands on the SAME page as the name — including when the block
+ * overflows onto the continuation page, where a field left behind on page 2
+ * would be unsignable.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { PDFDocument, PDFName, PDFDict, PDFArray, PDFRef } from 'pdf-lib';
+import { generateNavmc10274Pdf } from '@/services/pdf/navmc10274Generator';
+import { hasPdfToolchain, describeToolchainRequirement } from '../_helpers/pdfToolchain';
+
+const toolchain = hasPdfToolchain;
+const TDIR = join(process.cwd(), 'public/templates/NAVMC10274 - Administrative Action');
+
+const base = {
+  actionNo: '001-25', ssicFileNo: '1610', date: '16 Jul 26', from: 'Sgt J. A. DOE',
+  via: '', orgStation: '1st Bn', to: 'CO', natureOfAction: 'Counseling', copyTo: '',
+  references: '(a) MCO 1610.7A', enclosures: '',
+  supplementalInfo: 'You are counseled for the reasons in reference (a).',
+  proposedAction: '',
+};
+
+async function generate(data: Record<string, unknown>): Promise<Uint8Array> {
+  const [p1, p2, p3] = await Promise.all([
+    readFile(join(TDIR, 'page1.pdf')), readFile(join(TDIR, 'page2.pdf')), readFile(join(TDIR, 'page3.pdf')),
+  ]);
+  return generateNavmc10274Pdf(data as never, p1, p2, p3, { includeCoverPage: false });
+}
+
+/** Every /FT /Sig widget in the doc: its page index and rect. */
+async function sigFields(bytes: Uint8Array) {
+  const doc = await PDFDocument.load(bytes);
+  const acro = doc.catalog.lookup(PDFName.of('AcroForm')) as PDFDict | undefined;
+  if (!acro) return [];
+  const fields = acro.lookup(PDFName.of('Fields')) as PDFArray | undefined;
+  if (!fields) return [];
+  const pageRefs = doc.getPages().map((p) => doc.context.getObjectRef(p.node)?.toString());
+  const out: Array<{ pageIndex: number; rect: number[] }> = [];
+  for (let i = 0; i < fields.size(); i++) {
+    const f = fields.lookup(i) as PDFDict;
+    if ((f.lookup(PDFName.of('FT')) as PDFName | undefined)?.toString() !== '/Sig') continue;
+    const rect = (f.lookup(PDFName.of('Rect')) as PDFArray).asArray().map((n) => (n as { asNumber(): number }).asNumber());
+    const pRef = f.get(PDFName.of('P')) as PDFRef | undefined;
+    out.push({ pageIndex: pageRefs.indexOf(pRef?.toString()), rect });
+  }
+  return out;
+}
+
+/** Page index (0-based) each search string's text lands on, via pdftotext. */
+function pageOfText(bytes: Uint8Array, needles: RegExp[]): number[] {
+  const dir = mkdtempSync(join(tmpdir(), 'aa-ds-'));
+  const p = join(dir, 'o.pdf');
+  writeFileSync(p, Buffer.from(bytes));
+  const pages = spawnSync('pdftotext', [p, '-'], { encoding: 'utf-8' }).stdout.split('\f');
+  return needles.map((re) => pages.findIndex((pg) => re.test(pg)));
+}
+
+describe('NAVMC 10274 digital signature fields', () => {
+  describeToolchainRequirement('navmc10274-digital-sig');
+
+  it.skipIf(!toolchain)('places a real /Sig field above the digital signer on the same page', async () => {
+    const bytes = await generate({
+      ...base,
+      signatureBlocks: [
+        { statement: '', name: 'R. L. SMITH', digital: true },
+        { statement: 'I acknowledge receipt.', name: 'T. R. OAKES' }, // not digital
+      ],
+    });
+    const fields = await sigFields(bytes);
+    // Exactly one field — only the digital block gets one.
+    expect(fields).toHaveLength(1);
+    const [f] = fields;
+
+    const [smithPage] = pageOfText(bytes, [/R\. L\. SMITH/]);
+    expect(f.pageIndex).toBe(smithPage); // field on the signer's page
+
+    expect(f.rect[0]).toBeGreaterThanOrEqual(30); // block-12 left margin
+    expect(f.rect[3] - f.rect[1]).toBeCloseTo(20, 0); // configured height
+
+    // The field must sit ABOVE the typed name — the signing gap between the
+    // text and the name, per the form's caption — not overlap or fall below it.
+    // pdftotext -bbox is top-left origin; convert the name's glyph top to the
+    // PDF's bottom-left origin and require the field's bottom to clear it.
+    const pageHeight = 792;
+    const bp = join(mkdtempSync(join(tmpdir(), 'aa-bb-')), 'o.pdf');
+    writeFileSync(bp, Buffer.from(bytes));
+    const bbox = spawnSync('pdftotext', ['-bbox', bp, '-'], { encoding: 'utf-8' }).stdout;
+    const smith = [...bbox.matchAll(/yMin="([\d.]+)"[^>]*yMax="[\d.]+">([^<]+)</g)].find((w) => w[2] === 'SMITH');
+    expect(smith).toBeTruthy();
+    const nameTopPdf = pageHeight - Number(smith![1]);
+    expect(f.rect[1]).toBeGreaterThanOrEqual(nameTopPdf); // field bottom clears the name
+  });
+
+  it.skipIf(!toolchain)('emits no field when no block is digital', async () => {
+    const bytes = await generate({
+      ...base,
+      signatureBlocks: [{ statement: '', name: 'R. L. SMITH' }],
+    });
+    expect(await sigFields(bytes)).toHaveLength(0);
+  });
+
+  it.skipIf(!toolchain)('follows a digital block onto the continuation page', async () => {
+    // Long enough to push the second (digital) block to page 3.
+    const filler = Array.from({ length: 26 }, (_, i) => `${i + 1}. Paragraph.`).join('\n');
+    const bytes = await generate({
+      ...base,
+      supplementalInfo: filler,
+      signatureBlocks: [
+        { statement: '', name: 'R. L. SMITH', digital: true },
+        { statement: 'I acknowledge receipt.', name: 'T. R. OAKES', digital: true },
+      ],
+    });
+    const fields = await sigFields(bytes);
+    expect(fields).toHaveLength(2);
+
+    const [smithPage, oakesPage] = pageOfText(bytes, [/R\. L\. SMITH/, /T\. R\. OAKES/]);
+    // The two signers ended up on different pages (overflow happened).
+    expect(oakesPage).toBeGreaterThan(smithPage);
+
+    // Each field is on the SAME page as its signer — the field followed the
+    // block. A field stranded on page 2 while its name moved to page 3 would
+    // fail here.
+    const pages = fields.map((f) => f.pageIndex).sort();
+    expect(pages).toEqual([smithPage, oakesPage].sort());
+  });
+});

--- a/tests/integration/navmc10274-digital-sig.test.ts
+++ b/tests/integration/navmc10274-digital-sig.test.ts
@@ -73,7 +73,7 @@ describe('NAVMC 10274 digital signature fields', () => {
     const bytes = await generate({
       ...base,
       signatureBlocks: [
-        { statement: '', name: 'R. L. SMITH', digital: true },
+        { statement: '', name: 'R. L. SMITH', style: 'digital' },
         { statement: 'I acknowledge receipt.', name: 'T. R. OAKES' }, // not digital
       ],
     });
@@ -117,8 +117,8 @@ describe('NAVMC 10274 digital signature fields', () => {
       ...base,
       supplementalInfo: filler,
       signatureBlocks: [
-        { statement: '', name: 'R. L. SMITH', digital: true },
-        { statement: 'I acknowledge receipt.', name: 'T. R. OAKES', digital: true },
+        { statement: '', name: 'R. L. SMITH', style: 'digital' },
+        { statement: 'I acknowledge receipt.', name: 'T. R. OAKES', style: 'digital' },
       ],
     });
     const fields = await sigFields(bytes);

--- a/tests/integration/navmc10274-digital-sig.test.ts
+++ b/tests/integration/navmc10274-digital-sig.test.ts
@@ -46,13 +46,14 @@ async function sigFields(bytes: Uint8Array) {
   const fields = acro.lookup(PDFName.of('Fields')) as PDFArray | undefined;
   if (!fields) return [];
   const pageRefs = doc.getPages().map((p) => doc.context.getObjectRef(p.node)?.toString());
-  const out: Array<{ pageIndex: number; rect: number[] }> = [];
+  const out: Array<{ pageIndex: number; rect: number[]; name: string }> = [];
   for (let i = 0; i < fields.size(); i++) {
     const f = fields.lookup(i) as PDFDict;
     if ((f.lookup(PDFName.of('FT')) as PDFName | undefined)?.toString() !== '/Sig') continue;
     const rect = (f.lookup(PDFName.of('Rect')) as PDFArray).asArray().map((n) => (n as { asNumber(): number }).asNumber());
     const pRef = f.get(PDFName.of('P')) as PDFRef | undefined;
-    out.push({ pageIndex: pageRefs.indexOf(pRef?.toString()), rect });
+    const name = (f.lookup(PDFName.of('T')) as { asString?(): string } | undefined)?.asString?.() ?? '';
+    out.push({ pageIndex: pageRefs.indexOf(pRef?.toString()), rect, name });
   }
   return out;
 }
@@ -108,6 +109,10 @@ describe('NAVMC 10274 digital signature fields', () => {
 
     const [smithPage] = pageOfText(bytes, [/R\. L\. SMITH/]);
     expect(f.pageIndex).toBe(smithPage); // field on the signer's page
+
+    // The field is named for its signer (not an anonymous "Signature N"), so
+    // Acrobat's signature panel can tell whose field is whose.
+    expect(f.name).toMatch(/^R L SMITH signature \d+$/);
 
     expect(f.rect[0]).toBeGreaterThanOrEqual(30); // block-12 left margin
     expect(f.rect[3] - f.rect[1]).toBeCloseTo(20, 0); // configured height

--- a/tests/integration/navmc10274-digital-sig.test.ts
+++ b/tests/integration/navmc10274-digital-sig.test.ts
@@ -66,6 +66,30 @@ function pageOfText(bytes: Uint8Array, needles: RegExp[]): number[] {
   return needles.map((re) => pages.findIndex((pg) => re.test(pg)));
 }
 
+/** Page indices (0-based) that carry at least one image XObject. */
+async function imagePages(bytes: Uint8Array): Promise<number[]> {
+  const doc = await PDFDocument.load(bytes);
+  const out: number[] = [];
+  doc.getPages().forEach((pg, i) => {
+    const res = pg.node.lookup(PDFName.of('Resources')) as PDFDict | undefined;
+    const xo = res?.lookup(PDFName.of('XObject')) as PDFDict | undefined;
+    if (!xo) return;
+    for (const [, ref] of xo.entries()) {
+      const stream = doc.context.lookup(ref) as { dict?: PDFDict } | undefined;
+      const sub = stream?.dict?.lookup(PDFName.of('Subtype')) as PDFName | undefined;
+      if (sub?.toString() === '/Image') {
+        out.push(i);
+        return;
+      }
+    }
+  });
+  return out;
+}
+
+// A 1×1 red PNG — enough to prove an image is embedded and placed.
+const RED_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
 describe('NAVMC 10274 digital signature fields', () => {
   describeToolchainRequirement('navmc10274-digital-sig');
 
@@ -133,5 +157,43 @@ describe('NAVMC 10274 digital signature fields', () => {
     // fail here.
     const pages = fields.map((f) => f.pageIndex).sort();
     expect(pages).toEqual([smithPage, oakesPage].sort());
+  });
+});
+
+describe('NAVMC 10274 image signature blocks', () => {
+  describeToolchainRequirement('navmc10274-image-sig');
+
+  it.skipIf(!toolchain)('embeds a scanned signature on the signer\'s page, and only when style is image', async () => {
+    const withImage = await generate({
+      ...base,
+      signatureBlocks: [{ statement: '', name: 'R. L. SMITH', style: 'image', image: RED_PNG }],
+    });
+    const [smithPage] = pageOfText(withImage, [/R\. L\. SMITH/]);
+    expect(await imagePages(withImage)).toContain(smithPage); // image landed on the signer's page
+
+    // Differential: the same doc typed (no image) has no image on that page, so
+    // the one above is ours — not a template graphic.
+    const typed = await generate({
+      ...base,
+      signatureBlocks: [{ statement: '', name: 'R. L. SMITH', style: 'typed' }],
+    });
+    expect(await imagePages(typed)).not.toContain(smithPage);
+  });
+
+  it.skipIf(!toolchain)('follows an image block onto the continuation page', async () => {
+    const filler = Array.from({ length: 26 }, (_, i) => `${i + 1}. Paragraph.`).join('\n');
+    const bytes = await generate({
+      ...base,
+      supplementalInfo: filler,
+      signatureBlocks: [
+        { statement: '', name: 'R. L. SMITH', style: 'image', image: RED_PNG },
+        { statement: 'I acknowledge receipt.', name: 'T. R. OAKES', style: 'image', image: RED_PNG },
+      ],
+    });
+    const [smithPage, oakesPage] = pageOfText(bytes, [/R\. L\. SMITH/, /T\. R\. OAKES/]);
+    expect(oakesPage).toBeGreaterThan(smithPage); // overflow happened
+    const imgs = await imagePages(bytes);
+    expect(imgs).toContain(smithPage);
+    expect(imgs).toContain(oakesPage); // the image followed its block to page 3
   });
 });

--- a/tests/integration/navmc10274-render.test.ts
+++ b/tests/integration/navmc10274-render.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Rendered-output checks for NAVMC 10274 block 12 — proved on the generated
+ * PDF, not the line arrays.
+ *
+ * Two of these assert fixes for real defects:
+ *  - the proposed/recommended action was collected by the UI and silently
+ *    dropped from the PDF (the printed form has no box for it; it now closes
+ *    block 12), so its presence here fails on the old generator;
+ *  - the originator's typed name (the form's caption: "type name of
+ *    originator and sign 3 lines below text") did not exist at all — users
+ *    hand-typed it and tab-aligned, which textWrap's tab→spaces normalization
+ *    makes impossible to position. The bbox check pins the name exactly three
+ *    line-heights below the last text line, and the pagination check keeps it
+ *    attached to the text across the page-3 overflow.
+ *
+ * Requires pdftotext; fails rather than skips in CI.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { readFile, writeFile, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  generateNavmc10274Pdf,
+  type Navmc10274Data,
+} from '@/services/pdf/navmc10274Generator';
+import { hasPdfToolchain, describeToolchainRequirement } from '../_helpers/pdfToolchain';
+
+const toolchain = hasPdfToolchain;
+
+const TEMPLATE_DIR = join(
+  process.cwd(),
+  'public/templates/NAVMC10274 - Administrative Action'
+);
+
+const LINE_HEIGHT = 12; // PAGE2_FIELDS.supplementalInfo.lineHeight
+
+const baseData: Navmc10274Data = {
+  actionNo: '1',
+  ssicFileNo: '1610',
+  date: '16 Jul 26',
+  from: 'Sergeant J. A. DOE 1234567890/0111 USMC',
+  via: '',
+  orgStation: '1st Battalion, 6th Marines',
+  to: 'Commanding Officer',
+  natureOfAction: 'Formal Counseling',
+  copyTo: '',
+  references: '(a) MCO 1610.7A',
+  enclosures: '',
+  supplementalInfo: 'You are counseled for the reasons stated in reference (a).',
+  proposedAction: 'Request entry of adverse Page 11 entry per MCO 1610.7A.',
+  // The three-signature counseling shape: originator, the Marine's
+  // acknowledgement, and a witness.
+  signatureBlocks: [
+    { statement: '', name: 'R. L. SMITH' },
+    { statement: 'I acknowledge receipt and understanding of this counseling.', name: 'T. R. OAKES' },
+    { statement: 'Witnessed:', name: 'M. B. JONES' },
+  ],
+};
+
+async function generate(data: Navmc10274Data) {
+  const [page1, page2, page3] = await Promise.all([
+    readFile(join(TEMPLATE_DIR, 'page1.pdf')),
+    readFile(join(TEMPLATE_DIR, 'page2.pdf')),
+    readFile(join(TEMPLATE_DIR, 'page3.pdf')),
+  ]);
+  const bytes = await generateNavmc10274Pdf(data, page1, page2, page3, {
+    includeCoverPage: false,
+  });
+  const dir = await mkdtemp(join(tmpdir(), 'dondocs-aa-'));
+  const pdfPath = join(dir, 'out.pdf');
+  await writeFile(pdfPath, bytes);
+  return pdfPath;
+}
+
+function textOf(pdfPath: string): string {
+  const { stdout } = spawnSync('pdftotext', [pdfPath, '-'], { encoding: 'utf-8' });
+  return stdout;
+}
+
+describe('NAVMC 10274 block 12 — rendered PDF', () => {
+  describeToolchainRequirement('navmc10274-render');
+
+  it.skipIf(!toolchain)('renders the proposed action instead of dropping it', async () => {
+    const pdfPath = await generate(baseData);
+    const text = textOf(pdfPath);
+    expect(text.trim().length).toBeGreaterThan(0);
+    expect(text).toMatch(/Proposed\/recommended action: Request entry of adverse Page 11/);
+  });
+
+  it.skipIf(!toolchain)('stacks the three signatures in signing order', async () => {
+    const pdfPath = await generate(baseData);
+    const text = textOf(pdfPath);
+    const order = ['R. L. SMITH', 'I acknowledge receipt', 'T. R. OAKES', 'Witnessed:', 'M. B. JONES']
+      .map((needle) => text.indexOf(needle));
+    expect(order.every((i) => i >= 0)).toBe(true);
+    expect([...order].sort((a, b) => a - b)).toEqual(order);
+  });
+
+  it.skipIf(!toolchain)('types the originator exactly three lines below the text', async () => {
+    const pdfPath = await generate(baseData);
+    const { stdout } = spawnSync('pdftotext', ['-bbox', pdfPath, '-'], { encoding: 'utf-8' });
+    const words = [...stdout.matchAll(/<word xMin="([\d.]+)" yMin="([\d.]+)"[^>]*>([^<]+)<\/word>/g)]
+      .map((m) => ({ x: Number(m[1]), y: Number(m[2]), text: m[3] }));
+    expect(words.length).toBeGreaterThan(0);
+
+    // The last line of block-12 text is the proposed action; the name sits
+    // below it. Blank lines draw nothing, so the y-gap IS the signing space:
+    // third line below = exactly 3 line-heights.
+    const lastTextY = Math.max(
+      ...words.filter((w) => w.text === '1610.7A.').map((w) => w.y)
+    );
+    const nameY = Math.min(...words.filter((w) => w.text === 'SMITH').map((w) => w.y));
+    expect(Number.isFinite(lastTextY)).toBe(true);
+    expect(Number.isFinite(nameY)).toBe(true);
+    expect(nameY - lastTextY).toBeCloseTo(3 * LINE_HEIGHT, 0);
+  });
+
+  it.skipIf(!toolchain)('keeps the signature with the text across the page-3 overflow', async () => {
+    // 40 short paragraphs wrap to >29 lines, pushing past page 2's capacity.
+    const long = Array.from({ length: 40 }, (_, i) => `${i + 1}. Paragraph.`).join('\n');
+    const pdfPath = await generate({ ...baseData, supplementalInfo: long });
+    const pages = textOf(pdfPath).split('\f');
+    const pageOf = (re: RegExp) => pages.findIndex((p) => re.test(p));
+    const lastParaPage = pageOf(/40\. Paragraph\./);
+    expect(lastParaPage).toBeGreaterThan(0);
+    // Every signature travels with the overflowing text instead of staying
+    // behind — and each block stays whole: the Marine's acknowledgement
+    // statement is on the same page as the Marine's name.
+    for (const name of [/R\. L\. SMITH/, /T\. R\. OAKES/, /M\. B\. JONES/]) {
+      expect(pageOf(name)).toBe(lastParaPage);
+    }
+    expect(pageOf(/I acknowledge receipt/)).toBe(pageOf(/T\. R\. OAKES/));
+  });
+
+  it.skipIf(!toolchain)('moves a straddling block whole instead of tearing it', async () => {
+    // 23 filler lines put the naive page-2 split (capacity 29) INSIDE the
+    // acknowledgement block: statement on one side, name on the other. The
+    // group-aware pagination must move the whole block to page 3 — the
+    // originator, fitting fully, stays behind on page 2 with the text.
+    const filler = Array.from({ length: 23 }, (_, i) => `${i + 1}. Paragraph.`).join('\n');
+    const pdfPath = await generate({
+      ...baseData,
+      supplementalInfo: filler,
+      proposedAction: '',
+    });
+    const pages = textOf(pdfPath).split('\f');
+    const pageOf = (re: RegExp) => pages.findIndex((p) => re.test(p));
+
+    expect(pageOf(/R\. L\. SMITH/)).toBe(pageOf(/23\. Paragraph\./));
+    // The acknowledgement statement and the Marine's name are inseparable —
+    // a name at the top of page 3 with its statement and signing space left
+    // on page 2 cannot be signed.
+    expect(pageOf(/I acknowledge receipt/)).toBe(pageOf(/T\. R\. OAKES/));
+    expect(pageOf(/T\. R\. OAKES/)).toBeGreaterThan(pageOf(/R\. L\. SMITH/));
+  });
+
+  it.skipIf(!toolchain)('omits the signature area when there are no blocks', async () => {
+    const pdfPath = await generate({ ...baseData, signatureBlocks: [] });
+    const text = textOf(pdfPath);
+    expect(text).not.toMatch(/R\. L\. SMITH/);
+    // The rest of block 12 still renders.
+    expect(text).toMatch(/counseled for the reasons/);
+  });
+});

--- a/tests/integration/navmc11811-fit.test.ts
+++ b/tests/integration/navmc11811-fit.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Column-fit behavior on the NAVMC 118(11).
+ *
+ * The form is a single physical page: each remarks column prints at most
+ * `maxLines` wrapped lines and silently drops the rest. Two things are under
+ * test, both against the RENDERED PDF (verify-by-rendering):
+ *
+ * 1. Calibration — the cap stops at line 37. A rendered probe showed lines
+ *    38+ printing over the NAME/EDIPI identification strip at the bottom of
+ *    the form, so the cap is a correctness bound, not a style choice.
+ * 2. Parity — computeNavmc11811Fit() (what the editor's warning shows) agrees
+ *    with what the generator actually printed. If the two ever drift, the
+ *    warning lies and silent truncation returns.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import {
+  generateNavmc11811Pdf,
+  computeNavmc11811Fit,
+  type Navmc11811Data,
+} from '@/services/pdf/navmc11811Generator';
+import { hasPdfToolchain, describeToolchainRequirement } from '../_helpers/pdfToolchain';
+
+const toolchain = hasPdfToolchain;
+
+const TEMPLATE = 'public/templates/NAVMC11811 - Administrative Remarks/page1.pdf';
+
+const base: Navmc11811Data = {
+  lastName: 'DOE',
+  firstName: 'JOHN',
+  middleName: 'M',
+  edipi: '1234567890',
+  remarksText: '',
+  remarksTextRight: '',
+  entryDate: '',
+  box11: '',
+  signatureBlocks: [],
+};
+
+/** N short numbered lines, each guaranteed to wrap to exactly one line. */
+const numberedLines = (n: number) =>
+  Array.from({ length: n }, (_, i) => `LINE ${String(i + 1).padStart(2, '0')} xxxxxxxxxx`).join('\n');
+
+function pdfText(bytes: Uint8Array): string {
+  const p = join(mkdtempSync(join(tmpdir(), 'p11-fit-')), 'o.pdf');
+  writeFileSync(p, Buffer.from(bytes));
+  return spawnSync('pdftotext', [p, '-'], { encoding: 'utf-8' }).stdout;
+}
+
+describe('NAVMC 118(11) column fit', () => {
+  describeToolchainRequirement('navmc11811-fit');
+
+  it.skipIf(!toolchain)('caps a column at 37 lines — below the identification strip', async () => {
+    const tmpl = readFileSync(TEMPLATE);
+    const bytes = await generateNavmc11811Pdf({ ...base, remarksText: numberedLines(45) }, tmpl);
+    const text = pdfText(bytes);
+    expect(text).toContain('LINE 37');
+    // Truncated, not overlapped: 38+ must not appear anywhere on the page.
+    expect(text).not.toContain('LINE 38');
+    expect(text).not.toContain('LINE 45');
+  });
+
+  it.skipIf(!toolchain)('fit report matches the rendered truncation', async () => {
+    const data = { ...base, remarksText: numberedLines(45) };
+    const fit = await computeNavmc11811Fit(data);
+    expect(fit.left.capacity).toBe(37);
+    expect(fit.left.lines).toBe(45);
+    expect(fit.left.truncated).toBe(8);
+
+    // The rendered PDF drops exactly the lines the report claims: the last
+    // printed line is capacity, the first missing one is capacity + 1.
+    const tmpl = readFileSync(TEMPLATE);
+    const text = pdfText(await generateNavmc11811Pdf(data, tmpl));
+    expect(text).toContain(`LINE ${fit.left.capacity}`);
+    expect(text).not.toContain(`LINE ${fit.left.capacity + 1}`);
+  });
+
+  it('reports a clean fit for a short entry', async () => {
+    const fit = await computeNavmc11811Fit({
+      ...base,
+      remarksText: numberedLines(10),
+      entryDate: '15 Dec 24',
+      signatureBlocks: [
+        { statement: '', name: 'R. L. SMITH' },
+        { statement: 'I have been counseled this date and understand this entry.', name: 'J. M. DOE' },
+      ],
+    });
+    expect(fit.left.truncated).toBe(0);
+    expect(fit.left.spillover).toBe(0);
+    expect(fit.right.lines).toBe(0);
+  });
+
+  it('reports close-out spillover when text + date + signatures exceed the left column', async () => {
+    // 35 text lines print (≤37), but date (2) + two signature blocks (4 lines
+    // each: gap + statement + 2 signing + name ≈) push past the bottom.
+    const fit = await computeNavmc11811Fit({
+      ...base,
+      remarksText: numberedLines(35),
+      entryDate: '15 Dec 24',
+      signatureBlocks: [
+        { statement: 'Statement.', name: 'R. L. SMITH' },
+        { statement: 'Ack.', name: 'J. M. DOE' },
+      ],
+    });
+    expect(fit.left.truncated).toBe(0);
+    expect(fit.left.spillover).toBeGreaterThan(0);
+  });
+
+  it('places the signature blocks in the right column when it has text', async () => {
+    // Right column full to the brim; the signatures land there and spill.
+    const fit = await computeNavmc11811Fit({
+      ...base,
+      remarksText: numberedLines(5),
+      remarksTextRight: numberedLines(37),
+      signatureBlocks: [{ statement: '', name: 'R. L. SMITH' }],
+    });
+    expect(fit.right.truncated).toBe(0);
+    expect(fit.right.spillover).toBeGreaterThan(0);
+    // The left column is untouched by the close-out (no date set).
+    expect(fit.left.spillover).toBe(0);
+  });
+
+  it('empty blocks add no lines to the close-out', async () => {
+    const withEmpty = await computeNavmc11811Fit({
+      ...base,
+      remarksText: numberedLines(37),
+      signatureBlocks: [{ statement: '', name: '' }],
+    });
+    expect(withEmpty.left.spillover).toBe(0);
+  });
+});

--- a/tests/integration/navmc11811-signatures.test.ts
+++ b/tests/integration/navmc11811-signatures.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Signature blocks closing a NAVMC 118(11) / Page 11 (6105) entry.
+ *
+ * A Page 11 counseling entry is authenticated by the counselor and the
+ * counseled Marine (MCO 1610.7 / IRAM). DonDocs appends the signature blocks to
+ * the end of the remarks body — typed name, a scanned image, or an empty CAC
+ * field — the same model the AA form uses. This reads the compiled PDF back and
+ * asserts each style actually lands.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { PDFDocument, PDFName, PDFDict, PDFArray } from 'pdf-lib';
+import { generateNavmc11811Pdf } from '@/services/pdf/navmc11811Generator';
+import { hasPdfToolchain, describeToolchainRequirement } from '../_helpers/pdfToolchain';
+
+const toolchain = hasPdfToolchain;
+const TPL = join(process.cwd(), 'public/templates/NAVMC11811 - Administrative Remarks/page1.pdf');
+const RED_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+const base = {
+  lastName: 'DOE', firstName: 'JOHN', middleName: 'M', edipi: '1234567890',
+  remarksText: '6105 counseling entry text.', remarksTextRight: '',
+  entryDate: '18 Jul 26', box11: '01',
+};
+
+async function generate(data: Record<string, unknown>): Promise<Uint8Array> {
+  return generateNavmc11811Pdf(data as never, await readFile(TPL));
+}
+
+function sigFieldCount(doc: PDFDocument): number {
+  const acro = doc.catalog.lookup(PDFName.of('AcroForm')) as PDFDict | undefined;
+  const fields = acro?.lookup(PDFName.of('Fields')) as PDFArray | undefined;
+  if (!fields) return 0;
+  let n = 0;
+  for (let i = 0; i < fields.size(); i++) {
+    const f = fields.lookup(i) as PDFDict;
+    if ((f.lookup(PDFName.of('FT')) as PDFName | undefined)?.toString() === '/Sig') n++;
+  }
+  return n;
+}
+
+function imageCount(doc: PDFDocument): number {
+  let n = 0;
+  for (const pg of doc.getPages()) {
+    const res = pg.node.lookup(PDFName.of('Resources')) as PDFDict | undefined;
+    const xo = res?.lookup(PDFName.of('XObject')) as PDFDict | undefined;
+    if (!xo) continue;
+    for (const [, ref] of xo.entries()) {
+      const s = doc.context.lookup(ref) as { dict?: PDFDict } | undefined;
+      if ((s?.dict?.lookup(PDFName.of('Subtype')) as PDFName | undefined)?.toString() === '/Image') n++;
+    }
+  }
+  return n;
+}
+
+function text(bytes: Uint8Array): string {
+  const p = join(mkdtempSync(join(tmpdir(), 'aa-11811-')), 'o.pdf');
+  writeFileSync(p, Buffer.from(bytes));
+  return spawnSync('pdftotext', [p, '-'], { encoding: 'utf-8' }).stdout;
+}
+
+describe('NAVMC 118(11) signature blocks', () => {
+  describeToolchainRequirement('navmc11811-signatures');
+
+  it.skipIf(!toolchain)('renders typed, image, and digital signatures closing the entry', async () => {
+    const bytes = await generate({
+      ...base,
+      signatureBlocks: [
+        { statement: '', name: 'A. B. COUNSELOR', style: 'typed' },
+        {
+          statement: 'I have been counseled this date and understand this entry.',
+          name: 'J. M. DOE',
+          style: 'image',
+          image: RED_PNG,
+        },
+        { statement: '', name: 'C. D. WITNESS', style: 'digital' },
+      ],
+    });
+    const doc = await PDFDocument.load(bytes);
+    const t = text(bytes);
+
+    expect(t).toMatch(/A\. B\. COUNSELOR/); // typed name printed
+    expect(t).toMatch(/J\. M\. DOE/);
+    expect(t).toMatch(/I have been counseled this date/); // acknowledgement statement
+    expect(sigFieldCount(doc)).toBe(1); // one CAC field, from the digital block
+    expect(imageCount(doc)).toBe(1); // one scanned signature, from the image block
+  });
+
+  it.skipIf(!toolchain)('adds no signature marks when there are no blocks', async () => {
+    const bytes = await generate({ ...base, signatureBlocks: [] });
+    const doc = await PDFDocument.load(bytes);
+    expect(sigFieldCount(doc)).toBe(0);
+    expect(imageCount(doc)).toBe(0);
+  });
+});

--- a/tests/unit/formStoreMigration.test.ts
+++ b/tests/unit/formStoreMigration.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Every user who saved NAVMC form data before 1.2.105 has a persisted
+ * navmc10274 without `signatureBlocks`. zustand's default persist merge is
+ * shallow — the stored object replaces the default wholesale — so without the
+ * store's custom merge the field hydrates undefined and the Forms tab crashes
+ * on .map. This pins the guard.
+ */
+import { describe, it, expect } from 'vitest';
+import { useFormStore, FORMS_PERSIST_KEY } from '@/stores/formStore';
+
+describe('formStore hydration of pre-signatureBlocks sessions', () => {
+  it('fills signatureBlocks with an empty list and keeps the saved fields', async () => {
+    localStorage.setItem(
+      FORMS_PERSIST_KEY,
+      JSON.stringify({
+        state: {
+          navmc10274: {
+            actionNo: '007-24',
+            supplementalInfo: 'Saved before signature blocks existed.',
+            proposedAction: 'Keep me.',
+            // no signatureBlocks key — the pre-1.2.105 shape
+          },
+        },
+        version: 0,
+      })
+    );
+    await useFormStore.persist.rehydrate();
+    const data = useFormStore.getState().navmc10274;
+    expect(data.actionNo).toBe('007-24');
+    expect(data.proposedAction).toBe('Keep me.');
+    expect(Array.isArray(data.signatureBlocks)).toBe(true);
+    expect(data.signatureBlocks).toEqual([]);
+  });
+
+  it('keeps saved signature blocks when they exist', async () => {
+    localStorage.setItem(
+      FORMS_PERSIST_KEY,
+      JSON.stringify({
+        state: {
+          navmc10274: {
+            signatureBlocks: [{ statement: 'Acknowledged:', name: 'T. R. OAKES' }],
+          },
+        },
+        version: 0,
+      })
+    );
+    await useFormStore.persist.rehydrate();
+    expect(useFormStore.getState().navmc10274.signatureBlocks).toEqual([
+      { statement: 'Acknowledged:', name: 'T. R. OAKES' },
+    ]);
+  });
+});

--- a/tests/unit/formStoreMigration.test.ts
+++ b/tests/unit/formStoreMigration.test.ts
@@ -45,8 +45,32 @@ describe('formStore hydration of pre-signatureBlocks sessions', () => {
       })
     );
     await useFormStore.persist.rehydrate();
+    // Migration normalizes each block to carry an explicit `style` (a block
+    // saved before the style field defaults to 'typed').
     expect(useFormStore.getState().navmc10274.signatureBlocks).toEqual([
-      { statement: 'Acknowledged:', name: 'T. R. OAKES' },
+      { statement: 'Acknowledged:', name: 'T. R. OAKES', style: 'typed' },
+    ]);
+  });
+
+  it('upgrades a pre-1.2.107 digital flag to style', async () => {
+    localStorage.setItem(
+      FORMS_PERSIST_KEY,
+      JSON.stringify({
+        state: {
+          navmc10274: {
+            signatureBlocks: [
+              { statement: '', name: 'R. L. SMITH', digital: true },
+              { statement: '', name: 'J. A. DOE', digital: false },
+            ],
+          },
+        },
+        version: 0,
+      })
+    );
+    await useFormStore.persist.rehydrate();
+    expect(useFormStore.getState().navmc10274.signatureBlocks).toEqual([
+      { statement: '', name: 'R. L. SMITH', style: 'digital' },
+      { statement: '', name: 'J. A. DOE', style: 'typed' },
     ]);
   });
 });

--- a/tests/unit/formStoreMigration.test.ts
+++ b/tests/unit/formStoreMigration.test.ts
@@ -73,4 +73,43 @@ describe('formStore hydration of pre-signatureBlocks sessions', () => {
       { statement: '', name: 'J. A. DOE', style: 'typed' },
     ]);
   });
+
+  it('gives a pre-signatures navmc11811 an empty signatureBlocks list', async () => {
+    localStorage.setItem(
+      FORMS_PERSIST_KEY,
+      JSON.stringify({
+        state: {
+          navmc11811: {
+            lastName: 'DOE',
+            remarksText: 'Saved before the 118(11) had signatures.',
+            // no signatureBlocks key
+          },
+        },
+        version: 0,
+      })
+    );
+    await useFormStore.persist.rehydrate();
+    const data = useFormStore.getState().navmc11811;
+    expect(data.lastName).toBe('DOE');
+    expect(data.remarksText).toBe('Saved before the 118(11) had signatures.');
+    expect(data.signatureBlocks).toEqual([]); // never undefined — the Forms tab .maps it
+  });
+
+  it('upgrades a 118(11) block from the digital flag to style', async () => {
+    localStorage.setItem(
+      FORMS_PERSIST_KEY,
+      JSON.stringify({
+        state: {
+          navmc11811: {
+            signatureBlocks: [{ statement: '', name: 'A. B. COUNSELOR', digital: true }],
+          },
+        },
+        version: 0,
+      })
+    );
+    await useFormStore.persist.rehydrate();
+    expect(useFormStore.getState().navmc11811.signatureBlocks).toEqual([
+      { statement: '', name: 'A. B. COUNSELOR', style: 'digital' },
+    ]);
+  });
 });

--- a/tests/unit/navmc10274BlockTwelve.test.ts
+++ b/tests/unit/navmc10274BlockTwelve.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Block 12 of the NAVMC 10274 carries the counseling text, the proposed
+ * action (the printed form has no box for it — fields run 1-12), and the
+ * signature blocks in one paginating line stream. The form's own caption is
+ * the layout spec: "type name of originator and sign 3 lines below text" —
+ * each typed name sits on the third line below what precedes it, and the two
+ * blank lines above it are that signer's signing space.
+ *
+ * Counseling actions routinely carry two or three signatures (originator, the
+ * counseled Marine's acknowledgement, sometimes a witness), so the compose
+ * model is a list — and pagination must never tear a signature block: a typed
+ * name at the top of the continuation page with its signing space left behind
+ * on the previous page cannot be signed.
+ *
+ * These pin composition and pagination; the rendered geometry is proved in
+ * tests/integration/navmc10274-render.test.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  composeBlockTwelveLines,
+  paginateBlockTwelve,
+} from '@/services/pdf/navmc10274Generator';
+
+const noSignatures: Array<{ statement: string[]; name: string }> = [];
+
+describe('composeBlockTwelveLines', () => {
+  it('places a lone signature name on the third line below the text', () => {
+    const { lines } = composeBlockTwelveLines({
+      supplementalInfo: ['Paragraph one.', 'Paragraph two.'],
+      proposedAction: [],
+      signatureBlocks: [{ statement: [], name: 'R. L. SMITH' }],
+    });
+    expect(lines).toEqual(['Paragraph one.', 'Paragraph two.', '', '', 'R. L. SMITH']);
+  });
+
+  it('appends the proposed action as a separated paragraph before signatures', () => {
+    const { lines } = composeBlockTwelveLines({
+      supplementalInfo: ['Text.'],
+      proposedAction: ['Proposed/recommended action: NJP.'],
+      signatureBlocks: [{ statement: [], name: 'R. L. SMITH' }],
+    });
+    expect(lines).toEqual([
+      'Text.',
+      '',
+      'Proposed/recommended action: NJP.',
+      '',
+      '',
+      'R. L. SMITH',
+    ]);
+  });
+
+  it('stacks three signature blocks with statements in signing order', () => {
+    const { lines, groups } = composeBlockTwelveLines({
+      supplementalInfo: ['Counseling text.'],
+      proposedAction: [],
+      signatureBlocks: [
+        { statement: [], name: 'R. L. SMITH' },
+        { statement: ['I acknowledge receipt of this counseling.'], name: 'J. A. DOE' },
+        { statement: ['Witnessed:'], name: 'M. B. JONES' },
+      ],
+    });
+    expect(lines).toEqual([
+      'Counseling text.',
+      '',
+      '',
+      'R. L. SMITH',
+      '',
+      'I acknowledge receipt of this counseling.',
+      '',
+      '',
+      'J. A. DOE',
+      '',
+      'Witnessed:',
+      '',
+      '',
+      'M. B. JONES',
+    ]);
+    // Each group ends on its own typed name.
+    expect(groups).toHaveLength(3);
+    expect(lines[groups[0].end]).toBe('R. L. SMITH');
+    expect(lines[groups[1].end]).toBe('J. A. DOE');
+    expect(lines[groups[2].end]).toBe('M. B. JONES');
+  });
+
+  it('skips blocks that carry neither statement nor name', () => {
+    const { lines, groups } = composeBlockTwelveLines({
+      supplementalInfo: ['Text.'],
+      proposedAction: [],
+      signatureBlocks: [
+        { statement: [], name: '' },
+        { statement: [], name: 'R. L. SMITH' },
+      ],
+    });
+    expect(lines).toEqual(['Text.', '', '', 'R. L. SMITH']);
+    expect(groups).toHaveLength(1);
+  });
+
+  it('renders nothing extra when there are no signatures', () => {
+    const { lines, groups } = composeBlockTwelveLines({
+      supplementalInfo: ['Text.'],
+      proposedAction: [],
+      signatureBlocks: noSignatures,
+    });
+    expect(lines).toEqual(['Text.']);
+    expect(groups).toHaveLength(0);
+  });
+
+  it('starts at the top when there is no text above the signature', () => {
+    const { lines } = composeBlockTwelveLines({
+      supplementalInfo: [],
+      proposedAction: [],
+      signatureBlocks: [{ statement: [], name: 'R. L. SMITH' }],
+    });
+    expect(lines).toEqual(['R. L. SMITH']);
+  });
+});
+
+describe('paginateBlockTwelve', () => {
+  const compose = (fillerLines: number) =>
+    composeBlockTwelveLines({
+      supplementalInfo: Array.from({ length: fillerLines }, (_, i) => `Line ${i + 1}.`),
+      proposedAction: [],
+      signatureBlocks: [
+        { statement: [], name: 'R. L. SMITH' },
+        { statement: ['I acknowledge receipt.'], name: 'J. A. DOE' },
+      ],
+    });
+
+  it('leaves everything on the page when it fits', () => {
+    const result = paginateBlockTwelve(compose(3), 29);
+    expect(result.continuationLines).toEqual([]);
+  });
+
+  it('never tears a signature block across the boundary', () => {
+    // Sweep filler so the naive split lands on every line of both signature
+    // blocks at least once; whichever block straddles must move whole.
+    for (let filler = 15; filler <= 29; filler++) {
+      const composed = compose(filler);
+      const { pageLines, continuationLines } = paginateBlockTwelve(composed, 29);
+      const tornAck =
+        pageLines.includes('I acknowledge receipt.') !== pageLines.includes('J. A. DOE');
+      expect(tornAck, `filler=${filler}: statement and name split apart`).toBe(false);
+      // A moved name always brings its signing gap: it is never the first
+      // line of the continuation page.
+      if (continuationLines.length > 0) {
+        expect(continuationLines[continuationLines.length - 1]).not.toBe('');
+      }
+      for (const name of ['R. L. SMITH', 'J. A. DOE']) {
+        if (continuationLines[0] === name) {
+          throw new Error(`filler=${filler}: ${name} orphaned at top of continuation`);
+        }
+      }
+      // Nothing lost or duplicated across the split.
+      const joined = [...pageLines, ...continuationLines].filter((l) => l !== '');
+      const original = composed.lines.filter((l) => l !== '');
+      expect(joined).toEqual(original);
+    }
+  });
+
+  it('splits plain text at capacity when no group straddles', () => {
+    const composed = composeBlockTwelveLines({
+      supplementalInfo: Array.from({ length: 40 }, (_, i) => `Line ${i + 1}.`),
+      proposedAction: [],
+      signatureBlocks: noSignatures,
+    });
+    const { pageLines, continuationLines } = paginateBlockTwelve(composed, 29);
+    expect(pageLines).toHaveLength(29);
+    expect(continuationLines[0]).toBe('Line 30.');
+  });
+});
+
+describe('digital signature field placements', () => {
+  it('places a main-page field at the name line index within the page', () => {
+    // lines: [text, '', '', SMITH]  → SMITH at index 3, on the main page.
+    const composed = composeBlockTwelveLines({
+      supplementalInfo: ['Counseling text.'],
+      proposedAction: [],
+      signatureBlocks: [{ statement: [], name: 'R. L. SMITH', digital: true }],
+    });
+    const { fieldPlacements, pageLines } = paginateBlockTwelve(composed, 29);
+    expect(fieldPlacements).toHaveLength(1);
+    expect(fieldPlacements[0].page).toBe('main');
+    // The placement's line index must point at the name in the page stream.
+    expect(pageLines[fieldPlacements[0].nameLineInPage]).toBe('R. L. SMITH');
+  });
+
+  it('emits no field for a non-digital block', () => {
+    const composed = composeBlockTwelveLines({
+      supplementalInfo: ['Text.'],
+      proposedAction: [],
+      signatureBlocks: [{ statement: [], name: 'R. L. SMITH' }],
+    });
+    expect(paginateBlockTwelve(composed, 29).fieldPlacements).toEqual([]);
+  });
+
+  it('follows a block onto the continuation page — index resolves there, not on the main page', () => {
+    // 23 filler lines force the second (digital) block to straddle → it moves
+    // whole to the continuation page, and its field must resolve THERE.
+    const composed = composeBlockTwelveLines({
+      supplementalInfo: Array.from({ length: 23 }, (_, i) => `Line ${i + 1}.`),
+      proposedAction: [],
+      signatureBlocks: [
+        { statement: [], name: 'R. L. SMITH', digital: true },
+        { statement: ['I acknowledge receipt.'], name: 'T. R. OAKES', digital: true },
+      ],
+    });
+    const { fieldPlacements, pageLines, continuationLines } = paginateBlockTwelve(composed, 29);
+    const byName = (page: string[], p: { nameLineInPage: number }) => page[p.nameLineInPage];
+
+    const main = fieldPlacements.filter((f) => f.page === 'main');
+    const cont = fieldPlacements.filter((f) => f.page === 'continuation');
+    expect(main).toHaveLength(1);
+    expect(cont).toHaveLength(1);
+    // Each placement indexes the correct name in its own page's stream — the
+    // regression that would strand a field on the wrong page fails here.
+    expect(byName(pageLines, main[0])).toBe('R. L. SMITH');
+    expect(byName(continuationLines, cont[0])).toBe('T. R. OAKES');
+  });
+});

--- a/tests/unit/navmc10274BlockTwelve.test.ts
+++ b/tests/unit/navmc10274BlockTwelve.test.ts
@@ -175,7 +175,7 @@ describe('digital signature field placements', () => {
     const composed = composeBlockTwelveLines({
       supplementalInfo: ['Counseling text.'],
       proposedAction: [],
-      signatureBlocks: [{ statement: [], name: 'R. L. SMITH', digital: true }],
+      signatureBlocks: [{ statement: [], name: 'R. L. SMITH', style: 'digital' }],
     });
     const { fieldPlacements, pageLines } = paginateBlockTwelve(composed, 29);
     expect(fieldPlacements).toHaveLength(1);
@@ -200,8 +200,8 @@ describe('digital signature field placements', () => {
       supplementalInfo: Array.from({ length: 23 }, (_, i) => `Line ${i + 1}.`),
       proposedAction: [],
       signatureBlocks: [
-        { statement: [], name: 'R. L. SMITH', digital: true },
-        { statement: ['I acknowledge receipt.'], name: 'T. R. OAKES', digital: true },
+        { statement: [], name: 'R. L. SMITH', style: 'digital' },
+        { statement: ['I acknowledge receipt.'], name: 'T. R. OAKES', style: 'digital' },
       ],
     });
     const { fieldPlacements, pageLines, continuationLines } = paginateBlockTwelve(composed, 29);

--- a/tests/unit/placeholders.property.test.ts
+++ b/tests/unit/placeholders.property.test.ts
@@ -156,6 +156,7 @@ const SAMPLE_11811: Navmc11811Data = {
   remarksTextRight: '',
   entryDate: '15 Jan 26',
   box11: 'PFM',
+  signatureBlocks: [],
 };
 
 describe('buildNavmc11811DefaultValues', () => {
@@ -253,6 +254,22 @@ describe('applyPlaceholdersToNavmc11811', () => {
     const values = buildNavmc11811DefaultValues(SAMPLE_11811);
     const filled = applyPlaceholdersToNavmc11811(SAMPLE_11811, values);
     expect(filled.remarksText).toBe('Counseled on 15 Jan 26 re: DOE, JOHN, MICHAEL');
+  });
+
+  it('substitutes signature-block text but preserves style and image', () => {
+    const data: Navmc11811Data = {
+      ...SAMPLE_11811,
+      signatureBlocks: [
+        { statement: 'Counseled {{NAME}}.', name: '{{NAME}}', style: 'digital' },
+        { statement: '', name: 'J. DOE', style: 'image', image: 'iVBORw0KGgo=' },
+      ],
+    };
+    const result = applyPlaceholdersToNavmc11811(data, { NAME: 'CPL SMITH' });
+    expect(result.signatureBlocks[0].statement).toBe('Counseled CPL SMITH.');
+    expect(result.signatureBlocks[0].name).toBe('CPL SMITH');
+    expect(result.signatureBlocks[0].style).toBe('digital'); // style survives a batch run
+    expect(result.signatureBlocks[1].style).toBe('image');
+    expect(result.signatureBlocks[1].image).toBe('iVBORw0KGgo='); // image survives too
   });
 });
 

--- a/tests/unit/placeholders.property.test.ts
+++ b/tests/unit/placeholders.property.test.ts
@@ -273,7 +273,7 @@ const SAMPLE_10274: NavmcForm10274Data = {
   supplementalInfo: 'Re: {{NAME}}',
   proposedAction: 'Approve',
   signatureBlocks: [
-    { statement: 'Acknowledged by {{NAME}}.', name: '{{ORIGINATOR}}', digital: true },
+    { statement: 'Acknowledged by {{NAME}}.', name: '{{ORIGINATOR}}', style: 'digital' },
   ],
 };
 
@@ -292,7 +292,7 @@ describe('applyPlaceholdersToNavmc10274', () => {
     expect(result.signatureBlocks[0].name).toBe('{{ORIGINATOR}}');
     // The digital-field flag survives substitution — a batch run must not
     // silently drop the CAC field the user asked for.
-    expect(result.signatureBlocks[0].digital).toBe(true);
+    expect(result.signatureBlocks[0].style).toBe('digital');
   });
 
   it('substitutes signature-block names when the variable is supplied', () => {

--- a/tests/unit/placeholders.property.test.ts
+++ b/tests/unit/placeholders.property.test.ts
@@ -272,6 +272,9 @@ const SAMPLE_10274: NavmcForm10274Data = {
   enclosures: '',
   supplementalInfo: 'Re: {{NAME}}',
   proposedAction: 'Approve',
+  signatureBlocks: [
+    { statement: 'Acknowledged by {{NAME}}.', name: '{{ORIGINATOR}}', digital: true },
+  ],
 };
 
 describe('applyPlaceholdersToNavmc10274', () => {
@@ -284,6 +287,20 @@ describe('applyPlaceholdersToNavmc10274', () => {
     expect(result.via).toBe('SMITH');
     expect(result.natureOfAction).toBe('Request transfer');
     expect(result.supplementalInfo).toBe('Re: SMITH');
+    // Signature blocks substitute in both the statement and the name.
+    expect(result.signatureBlocks[0].statement).toBe('Acknowledged by SMITH.');
+    expect(result.signatureBlocks[0].name).toBe('{{ORIGINATOR}}');
+    // The digital-field flag survives substitution — a batch run must not
+    // silently drop the CAC field the user asked for.
+    expect(result.signatureBlocks[0].digital).toBe(true);
+  });
+
+  it('substitutes signature-block names when the variable is supplied', () => {
+    const result = applyPlaceholdersToNavmc10274(SAMPLE_10274, {
+      NAME: 'SMITH',
+      ORIGINATOR: 'R. L. SMITH',
+    });
+    expect(result.signatureBlocks[0].name).toBe('R. L. SMITH');
   });
 
   it('non-placeholder fields pass through unchanged', () => {

--- a/tests/unit/signatoryName.test.ts
+++ b/tests/unit/signatoryName.test.ts
@@ -1,0 +1,36 @@
+/**
+ * One abbreviation for every typed-name signer (endorsement acknowledgement,
+ * AA form originator, profile fills). This function exists because two copies
+ * had already diverged — the second one reintroduced the middle-initial slide
+ * that the first had fixed.
+ */
+import { describe, it, expect } from 'vitest';
+import { abbreviatedSignatoryName } from '@/lib/signatoryName';
+
+describe('abbreviatedSignatoryName', () => {
+  it('abbreviates to initials and surname', () => {
+    expect(abbreviatedSignatoryName('Robert', 'Lee', 'Smith')).toBe('R. L. SMITH');
+  });
+
+  it('handles a missing middle', () => {
+    expect(abbreviatedSignatoryName('Robert', '', 'Smith')).toBe('R. SMITH');
+  });
+
+  it('never lets a middle initial slide into the first slot', () => {
+    // A middle without a first must not print "L. SMITH" as if L were the
+    // first initial — positional truth over prettiness.
+    expect(abbreviatedSignatoryName('', 'Lee', 'Smith')).toBe('SMITH');
+  });
+
+  it('surname only', () => {
+    expect(abbreviatedSignatoryName(undefined, undefined, 'Smith')).toBe('SMITH');
+  });
+
+  it('empty in, empty out', () => {
+    expect(abbreviatedSignatoryName('', '', '')).toBe('');
+  });
+
+  it('trims and uppercases', () => {
+    expect(abbreviatedSignatoryName('  robert ', ' lee ', '  smith ')).toBe('R. L. SMITH');
+  });
+});

--- a/tests/unit/signature.test.ts
+++ b/tests/unit/signature.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { isDigital, isImage, type FormSignatureBlock } from '@/types/signature';
+
+const block = (b: Partial<FormSignatureBlock>): FormSignatureBlock => ({
+  name: '',
+  statement: '',
+  ...b,
+});
+
+describe('isDigital', () => {
+  it('is true only for the digital style', () => {
+    expect(isDigital(block({ style: 'digital' }))).toBe(true);
+    expect(isDigital(block({ style: 'image' }))).toBe(false);
+    expect(isDigital(block({ style: 'typed' }))).toBe(false);
+    expect(isDigital(block({}))).toBe(false); // undefined style defaults to not-digital
+  });
+});
+
+describe('isImage', () => {
+  it('is true only for the image style WITH image data', () => {
+    expect(isImage(block({ style: 'image', image: 'iVBORw0KGgo=' }))).toBe(true);
+    // image style but no upload yet — nothing to draw, so not an image mark
+    expect(isImage(block({ style: 'image' }))).toBe(false);
+    expect(isImage(block({ style: 'image', image: '' }))).toBe(false);
+    // stale image data on a non-image style must not count
+    expect(isImage(block({ style: 'typed', image: 'iVBORw0KGgo=' }))).toBe(false);
+    expect(isImage(block({ style: 'digital', image: 'iVBORw0KGgo=' }))).toBe(false);
+    expect(isImage(block({}))).toBe(false);
+  });
+});
+
+describe('a block is at most one kind of mark', () => {
+  it('never reports both digital and image for the same block', () => {
+    for (const style of ['typed', 'image', 'digital'] as const) {
+      const b = block({ style, image: 'iVBORw0KGgo=' });
+      expect(isDigital(b) && isImage(b)).toBe(false);
+    }
+  });
+});

--- a/tests/unit/signaturePresets.test.ts
+++ b/tests/unit/signaturePresets.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { signaturePresets } from '@/lib/signaturePresets';
+import { signatureFieldName } from '@/services/pdf/signatureFieldCore';
+
+describe('signaturePresets', () => {
+  it('offers signer / acknowledgement / witness for both forms', () => {
+    for (const form of ['navmc_10274', 'navmc_118_11'] as const) {
+      const ids = signaturePresets(form).map((p) => p.id);
+      expect(ids).toEqual(['signer', 'acknowledgement', 'witness']);
+    }
+  });
+
+  it('labels the signer per form (Originator vs Counselor)', () => {
+    const signer = (form: 'navmc_10274' | 'navmc_118_11') =>
+      signaturePresets(form).find((p) => p.id === 'signer')!.label;
+    expect(signer('navmc_10274')).toBe('Originator');
+    expect(signer('navmc_118_11')).toBe('Counselor');
+  });
+
+  it('seeds a fresh typed block with an empty name', () => {
+    for (const form of ['navmc_10274', 'navmc_118_11'] as const) {
+      for (const preset of signaturePresets(form)) {
+        const block = preset.make();
+        expect(block.name).toBe('');
+        expect(block.style).toBe('typed');
+      }
+    }
+  });
+
+  it('carries form-specific acknowledgement wording as an editable start', () => {
+    const ack = (form: 'navmc_10274' | 'navmc_118_11') =>
+      signaturePresets(form).find((p) => p.id === 'acknowledgement')!.make().statement;
+    expect(ack('navmc_118_11')).toMatch(/counseled this date/i);
+    expect(ack('navmc_10274')).toMatch(/acknowledge receipt/i);
+    // The two forms must not share the same wording.
+    expect(ack('navmc_118_11')).not.toBe(ack('navmc_10274'));
+  });
+
+  it('gives the witness preset the "Witnessed:" lead-in', () => {
+    expect(signaturePresets('navmc_10274').find((p) => p.id === 'witness')!.make().statement).toBe(
+      'Witnessed:'
+    );
+  });
+
+  it('returns distinct block instances each call (no shared mutable state)', () => {
+    const [a] = signaturePresets('navmc_10274');
+    const first = a.make();
+    first.name = 'R. L. SMITH';
+    expect(a.make().name).toBe(''); // a later make() is unaffected
+  });
+});
+
+describe('signatureFieldName', () => {
+  it('derives a stable, sequenced field name from the typed name', () => {
+    expect(signatureFieldName('R. L. Smith', 0)).toBe('R L Smith signature 0');
+    expect(signatureFieldName('J.  A.   Doe', 1)).toBe('J A Doe signature 1');
+  });
+
+  it('falls back to a plain sequenced name when unnamed', () => {
+    expect(signatureFieldName('', 2)).toBe('Signature 2');
+    expect(signatureFieldName(undefined, 3)).toBe('Signature 3');
+    expect(signatureFieldName('   ', 4)).toBe('Signature 4');
+  });
+
+  it('keeps sequential fields unique even for identical names', () => {
+    expect(signatureFieldName('J. Doe', 0)).not.toBe(signatureFieldName('J. Doe', 1));
+  });
+});

--- a/tests/unit/signaturePresets.test.ts
+++ b/tests/unit/signaturePresets.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { signaturePresets } from '@/lib/signaturePresets';
+import { signaturePresets, standardSignaturePair } from '@/lib/signaturePresets';
 import { signatureFieldName } from '@/services/pdf/signatureFieldCore';
 
 describe('signaturePresets', () => {
@@ -47,6 +47,48 @@ describe('signaturePresets', () => {
     const first = a.make();
     first.name = 'R. L. SMITH';
     expect(a.make().name).toBe(''); // a later make() is unaffected
+  });
+
+  it('pre-fills names the app knows: signer ← profile, ack ← Marine; witness stays blank', () => {
+    const names = { signer: 'R. L. SMITH', marine: 'J. M. DOE' };
+    for (const form of ['navmc_10274', 'navmc_118_11'] as const) {
+      const byId = Object.fromEntries(signaturePresets(form, names).map((p) => [p.id, p.make()]));
+      expect(byId.signer.name).toBe('R. L. SMITH');
+      expect(byId.acknowledgement.name).toBe('J. M. DOE');
+      // Whoever witnessed is never guessable — no pre-fill even with names given.
+      expect(byId.witness.name).toBe('');
+    }
+  });
+
+  it('leaves names blank when the context has none (no profile, blank Marine ID)', () => {
+    for (const preset of signaturePresets('navmc_118_11', {})) {
+      expect(preset.make().name).toBe('');
+    }
+  });
+});
+
+describe('standardSignaturePair', () => {
+  it('returns signer then acknowledgement, in signing order', () => {
+    const [signer, ack] = standardSignaturePair('navmc_118_11', {
+      signer: 'R. L. SMITH',
+      marine: 'J. M. DOE',
+    });
+    expect(signer.statement).toBe(''); // counselor's block has no statement
+    expect(signer.name).toBe('R. L. SMITH');
+    expect(ack.statement).toMatch(/counseled this date/i);
+    expect(ack.name).toBe('J. M. DOE');
+    expect(standardSignaturePair('navmc_118_11')).toHaveLength(2);
+  });
+
+  it('uses the form-specific acknowledgement wording', () => {
+    const [, aaAck] = standardSignaturePair('navmc_10274');
+    expect(aaAck.statement).toMatch(/acknowledge receipt/i);
+  });
+
+  it('returns fresh instances each call', () => {
+    const a = standardSignaturePair('navmc_10274');
+    a[0].name = 'MUTATED';
+    expect(standardSignaturePair('navmc_10274')[0].name).toBe('');
   });
 });
 


### PR DESCRIPTION
Users reported having to hand-type signature blocks into the AA form's block 12 and align them with tabs — which can never work, since tabs normalize to spaces in a proportional font. The advice in the wild was "export it and add it by hand." This PR makes signatures a first-class feature of both NAVMC forms.

## What's in it

**Signature blocks on both forms** — the AA form (NAVMC 10274) and the Page 11 (NAVMC 118(11)) share one signature model: an ordered list of blocks, each with an optional statement, a typed name, and a style — **Typed**, **Image** (scanned signature drawn into the signing space), or **Digital** (an empty, named, CAC-signable AcroForm field, signed later in Acrobat). Layout follows the form's own caption: statement above, two blank signing lines, typed name on the third line — and a block never splits across a page break.

**Easy to use** — dedicated Signatures section in the editor outline on both forms; "Add signature…" role presets (Originator/Counselor, Marine acknowledgement, Witness) with names pre-filled from the profile and, on the 118(11), from the Marine Identification fields; a one-click standard pair from the empty state; drag-to-reorder (order = signing order); confirm-before-delete on filled blocks; focus follows a newly added block.

**Fit and fills** — the 118(11) now shows a live per-column line counter and warns before anything truncates (the old silent 40-line cap also overprinted the NAME strip; recalibrated to 37 by rendered probe). The AA form's From and Organization/Station fields gained one-click profile fills.

**Fixed along the way** — "Proposed/Recommended Action" was silently dropped from every AA export (now closes block 12 as a labeled paragraph); the phantom "13." label; duplicate signatory-name utilities unified; a dead never-rendered field removed.

## Compliance

Verified against the governing documents: the name prints exactly 3 line-heights below the preceding text per block 12's printed caption (measured via pdftotext -bbox: 36pt = 3 × 12pt); name style is initials + capitalized SURNAME, no rank, per SECNAV M-5216.5 ¶14a; the signature is written in the blank space above the typed name — no ruled line, per the same convention. The 118(11)'s three pre-printed Art 137/SBP cells are deliberately untouched; in-entry signatures close the remarks text per MCO 1610.7 / IRAM.

## Verification

Rendered-PDF integration tests (pdftotext/bbox assertions, pagination straddle sweeps, /Sig field and image XObject checks), unit tests for the model, presets, migration, and fit math; full suite green; 16/16 CI checks.