### PR TITLE
fix(endorsement): continue the basic letter's page sequence in both exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.102] — 2026-07-16
+
+### Fixed
+
+- Endorsement pages now genuinely continue the basic letter's sequence
+  (SECNAV M-5216.5 Ch 9, Fig 9-2: "Number each page of your endorsement and
+  continue the sequence of numbers from ... the basic letter"). "First page
+  number" was a dead field in PDF export — the generator never emitted it and
+  the template had no counter to receive it — and the Word export suppressed
+  the continued number on the endorsement's own sheet, where Fig 9-2 prints
+  it. Uploading a basic letter now also defaults the field from the letter's
+  page count instead of discarding it.
+
 ## [1.2.101] — 2026-07-16
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dondocs",
-  "version": "1.2.101",
+  "version": "1.2.102",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dondocs",
-      "version": "1.2.101",
+      "version": "1.2.102",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.101",
+  "version": "1.2.102",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/public/lib/latex-templates.js
+++ b/public/lib/latex-templates.js
@@ -129,6 +129,16 @@ const LATEX_TEMPLATES = {
 \\newcommand{\\PageNumberStyle}{xofy}
 \\newcommand{\\setPageNumberStyle}[1]{\\renewcommand{\\PageNumberStyle}{#1}}
 
+% An endorsement continues the basic letter's page sequence rather than
+% starting at 1 (Ch 9, Fig 9-2 body: "Number each page of your endorsement and
+% continue the sequence of numbers from the previous endorsement or from the
+% basic letter"). The counter is applied at \\begin{document}; with a start
+% above 1 the first sheet naturally prints its number (Fig 9-2 shows "2" on
+% the endorsement's own sheet), since the styles' suppress-page-1 checks test
+% the counter value, not the sheet index.
+\\newcommand{\\StartingPageNumber}{1}
+\\newcommand{\\setStartingPageNumber}[1]{\\renewcommand{\\StartingPageNumber}{#1}}
+
 % Smart page numbering based on style setting
 \\makeatletter
 \\newcommand{\\smartPageNumber}{%
@@ -1445,6 +1455,11 @@ const LATEX_TEMPLATES = {
 
 % Apply font settings after config is loaded
 \\applyFontSettings
+
+% Continue the basic letter's page sequence (Ch 9): applied after the config
+% inputs so \\setStartingPageNumber from document.tex has taken effect, and
+% before any content so sheet 1 carries the continued number.
+\\setcounter{page}{\\StartingPageNumber}
 
 %=============================================================================
 % LOAD FORMAT-SPECIFIC MODULE

--- a/src/components/editor/EndorsementBasicLetterSection.tsx
+++ b/src/components/editor/EndorsementBasicLetterSection.tsx
@@ -145,6 +145,19 @@ export function EndorsementBasicLetterSection() {
       );
       setField('basicLetterFile', { name: file.name, size: file.size, data });
       setField('basicLetterFileRef', fileRef);
+      // The endorsement continues the letter's page sequence (Ch 9, Fig 9-2:
+      // "Number each page of your endorsement and continue the sequence of
+      // numbers from ... the basic letter"). The page count is in hand, so
+      // default "First page number" from it — but never clobber a value the
+      // user already set. Numbering must also actually print for the
+      // continuation to exist, so a 'none' style steps up to 'simple'.
+      const fd = useDocumentStore.getState().formData;
+      if (!fd.startingPageNumber || fd.startingPageNumber <= 1) {
+        setField('startingPageNumber', check.pageCount + 1);
+        if (!fd.pageNumbering || fd.pageNumbering === 'none') {
+          setField('pageNumbering', 'simple');
+        }
+      }
     },
     [setField]
   );

--- a/src/lib/endorsement.ts
+++ b/src/lib/endorsement.ts
@@ -81,6 +81,18 @@ export function enclosureStartNumber(docType: string, startingNumber?: number): 
   return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1;
 }
 
+/**
+ * The page number the document starts at — the Ch 9 page-continuation rule
+ * (Fig 9-2 ¶1), gated exactly like its reference/enclosure siblings above: a
+ * startingPageNumber left behind after switching document type must never
+ * silently offset a basic letter's own sequence.
+ */
+export function pageStartNumber(docType: string, startingPageNumber?: number): number {
+  if (!isEndorsement(docType)) return 1;
+  const n = Number(startingPageNumber);
+  return Number.isFinite(n) && n > 1 ? Math.floor(n) : 1;
+}
+
 // Empty or a bracketed placeholder ([SSIC]) counts as absent.
 function usable(value: string | undefined): string {
   const t = (value ?? '').trim();

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -298,9 +298,13 @@ function buildPageNumbering(data: Partial<DocumentData>): string {
   const startPage = data.startingPageNumber && data.startingPageNumber > 1
     ? `\\setcounter{page}{${data.startingPageNumber}}\n`
     : '';
-  // SECNAV: no page number on first page, numbered on subsequent pages
+  // SECNAV: no page number on the FIRST page of a document — but a continued
+  // sequence is not a first page: Fig 9-2 prints the number on the
+  // endorsement's own sheet ("2"), so suppression only applies when the
+  // sequence actually starts at 1.
+  const suppressFirst = startPage ? '' : '\\thispagestyle{plain}\n';
   // Use right footer to avoid conflict with classification markings in center footer
-  return `\\fancypagestyle{plain}{\\fancyhf{}}\n\\thispagestyle{plain}\n\\fancyfoot[R]{\\thepage}\n${startPage}`;
+  return `\\fancypagestyle{plain}{\\fancyhf{}}\n${suppressFirst}\\fancyfoot[R]{\\thepage}\n${startPage}`;
 }
 
 /** Centered letterhead using tabularX (pandoc renders center alignment in DOCX) */

--- a/src/services/latex/flat-generator.ts
+++ b/src/services/latex/flat-generator.ts
@@ -17,7 +17,7 @@
 import type { DocumentData, Reference, Enclosure, Paragraph, CopyTo, Distribution, DocTypeConfig } from '@/types/document';
 import { DOC_TYPE_CONFIG } from '@/types/document';
 import { LAYOUT, TEXT_WIDTH_IN } from '@/services/docx/layout-config';
-import { enclosureStartNumber } from '@/lib/endorsement';
+import { enclosureStartNumber, pageStartNumber } from '@/lib/endorsement';
 import {
   resolveAppendedEndorsement,
   appendedEndorsementSigner,
@@ -291,13 +291,15 @@ function buildClassificationHeaders(data: Partial<DocumentData>, paragraphs: Par
 `;
 }
 
-function buildPageNumbering(data: Partial<DocumentData>): string {
+function buildPageNumbering(docType: string, data: Partial<DocumentData>): string {
   const style = data.pageNumbering || 'none';
   if (style === 'none') return '\\pagenumbering{gobble}\n';
-  // Support custom starting page number (e.g., for endorsements continuing a letter)
-  const startPage = data.startingPageNumber && data.startingPageNumber > 1
-    ? `\\setcounter{page}{${data.startingPageNumber}}\n`
-    : '';
+  // The Ch 9 page continuation, gated to endorsement types exactly like the
+  // reference/enclosure continuations — this was previously ungated, so a
+  // startingPageNumber left behind by an endorsement silently offset ANY
+  // doc type's pages in the Word export.
+  const start = pageStartNumber(docType, data.startingPageNumber);
+  const startPage = start > 1 ? `\\setcounter{page}{${start}}\n` : '';
   // SECNAV: no page number on the FIRST page of a document — but a continued
   // sequence is not a first page: Fig 9-2 prints the number on the
   // endorsement's own sheet ("2"), so suppression only applies when the
@@ -1558,7 +1560,7 @@ export function generateFlatLatex(store: DocumentStore): string {
 
   tex += buildPreamble(data);
   tex += buildClassificationHeaders(data, store.paragraphs);
-  tex += buildPageNumbering(data);
+  tex += buildPageNumbering(store.docType, data);
   tex += '\n\\begin{document}\n\n';
 
   switch (config.uiMode) {

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -2,7 +2,7 @@ import { escapeLatex, escapeLatexUrl, processBodyText, formatSubjectForLatex, fo
 import type { DocumentData, Reference, Enclosure, Paragraph, CopyTo, Distribution } from '@/types/document';
 import { DOC_TYPE_CONFIG } from '@/types/document';
 import { base64ToUint8Array } from '@/lib/encoding';
-import { enclosureStartNumber } from '@/lib/endorsement';
+import { enclosureStartNumber, pageStartNumber } from '@/lib/endorsement';
 import { safeUrl } from '@/lib/url-safety';
 import { splitAddressForLetterhead } from '@/lib/unitAddress';
 import { deriveOverallClassLevel } from '@/lib/overallClassification';
@@ -93,11 +93,12 @@ export function generateDocumentTex(store: DocumentStore): string {
 \\setFontSize{${data.fontSize || '12pt'}}
 \\setFontFamily{${data.fontFamily || 'times'}}
 \\setPageNumberStyle{${data.pageNumbering || 'none'}}
-${
-  data.startingPageNumber && data.startingPageNumber > 1
-    ? `\\setStartingPageNumber{${Math.floor(data.startingPageNumber)}}`
-    : '% Page sequence starts at 1'
-}
+${(() => {
+  // Gated to endorsement types like the reference/enclosure continuations —
+  // a leftover value must never offset another doc type's own sequence.
+  const start = pageStartNumber(store.docType, data.startingPageNumber);
+  return start > 1 ? `\\setStartingPageNumber{${start}}` : '% Page sequence starts at 1';
+})()}
 
 `;
 

--- a/src/services/latex/generator.ts
+++ b/src/services/latex/generator.ts
@@ -93,6 +93,11 @@ export function generateDocumentTex(store: DocumentStore): string {
 \\setFontSize{${data.fontSize || '12pt'}}
 \\setFontFamily{${data.fontFamily || 'times'}}
 \\setPageNumberStyle{${data.pageNumbering || 'none'}}
+${
+  data.startingPageNumber && data.startingPageNumber > 1
+    ? `\\setStartingPageNumber{${Math.floor(data.startingPageNumber)}}`
+    : '% Page sequence starts at 1'
+}
 
 `;
 

--- a/tests/integration/endorsement-page-continuation.test.ts
+++ b/tests/integration/endorsement-page-continuation.test.ts
@@ -1,0 +1,81 @@
+/**
+ * An endorsement's pages continue the basic letter's sequence, proved on a
+ * compiled PDF. Ch 9, Fig 9-2 body: "Number each page of your endorsement and
+ * continue the sequence of numbers from the previous endorsement or from the
+ * basic letter if you are the first endorser" — and the figure prints the
+ * number ("2") on the endorsement's own sheet, so a continued first sheet is
+ * NOT suppressed the way a document's true page 1 is.
+ *
+ * Before this, "First page number" was a dead field in PDF export: the
+ * generator never emitted it and main.tex had no counter to receive it.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { writeFile, mkdtemp } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { compileFixture } from '../_helpers/compileLatex';
+import { hasPdfToolchain, describeToolchainRequirement } from '../_helpers/pdfToolchain';
+
+const toolchain = hasPdfToolchain;
+
+const store = (startingPageNumber?: number) =>
+  ({
+    docType: 'new_page_endorsement',
+    formData: {
+      docType: 'new_page_endorsement',
+      fontSize: '12pt',
+      fontFamily: 'times',
+      pageNumbering: 'simple',
+      ...(startingPageNumber ? { startingPageNumber } : {}),
+      department: 'usmc',
+      unitLine1: '1ST BATTALION, 6TH MARINES',
+      unitLine2: '2D MARINE DIVISION, II MEF',
+      unitAddress: 'PSC BOX 20123, CAMP LEJEUNE, NC 28542-0123',
+      sealType: 'dow',
+      letterheadColor: 'blue',
+      ssic: '5216',
+      serial: '0456',
+      date: '20 Jan 25',
+      from: 'Commanding Officer, 1st Battalion, 6th Marines',
+      to: 'Commanding General, 2d Marine Division',
+      subject: 'PAGE CONTINUATION RENDER CHECK',
+      basicLetterId: 'NAS Meridian ltr 5216 Ser 11/273 of 22 Apr 15',
+      endorsementOrdinal: 'FIRST',
+      sigFirst: 'Robert',
+      sigLast: 'GABEL',
+      classLevel: 'unclassified',
+    },
+    references: [],
+    enclosures: [],
+    paragraphs: [{ text: 'Forwarded, recommending approval.', level: 0 }],
+    copyTos: [],
+    distributions: [],
+  }) as never;
+
+async function renderPages(startingPageNumber?: number): Promise<string[]> {
+  const result = await compileFixture(store(startingPageNumber));
+  expect(result.ok, `pdflatex failed; work dir: ${result.workDir}`).toBe(true);
+  const dir = await mkdtemp(join(tmpdir(), 'dondocs-pagecont-'));
+  const pdfPath = join(dir, 'out.pdf');
+  await writeFile(pdfPath, result.pdfBytes!);
+  const { stdout } = spawnSync('pdftotext', [pdfPath, '-'], { encoding: 'utf-8' });
+  expect(stdout.trim().length).toBeGreaterThan(0);
+  return stdout.split('\f');
+}
+
+describe('endorsement page continuation — rendered PDF', () => {
+  describeToolchainRequirement('endorsement-page-continuation');
+
+  it.skipIf(!toolchain)('a first page number of 4 prints "4" on the endorsement sheet', async () => {
+    const pages = await renderPages(4);
+    // One-sheet endorsement, its printed number continuing the letter's three.
+    expect(pages[0]).toMatch(/\b4\b\s*$/m);
+    expect(pages[0]).not.toMatch(/^\s*1\s*$/m);
+  });
+
+  it.skipIf(!toolchain)('without a continuation the sequence starts at 1', async () => {
+    const pages = await renderPages(undefined);
+    expect(pages[0]).not.toMatch(/\b4\b\s*$/m);
+  });
+});

--- a/tests/unit/pageStartNumber.test.ts
+++ b/tests/unit/pageStartNumber.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The Ch 9 page continuation is endorsements-only, exactly like its
+ * reference/enclosure siblings: "a value left behind after switching document
+ * type can never silently offset a basic letter's sequence" (the 1.2.94
+ * guarantee). The DOCX generator violated this ungated from the start, and the
+ * PDF plumbing nearly shipped with the same leak — these pin the gate in the
+ * helper and at both generators' output.
+ */
+import { describe, it, expect } from 'vitest';
+import { pageStartNumber } from '@/lib/endorsement';
+import { generateDocumentTex } from '@/services/latex/generator';
+import { generateFlatLatex } from '@/services/latex/flat-generator';
+
+const store = (docType: string) =>
+  ({
+    docType,
+    formData: {
+      docType,
+      pageNumbering: 'simple',
+      startingPageNumber: 4, // lingering from an endorsement session
+      from: 'Commanding Officer',
+      to: 'Commanding General',
+      subject: 'PAGE LEAK CHECK',
+      sigFirst: 'John',
+      sigLast: 'DOE',
+    },
+    references: [],
+    enclosures: [],
+    paragraphs: [{ text: 'Body.', level: 0 }],
+    copyTos: [],
+    distributions: [],
+  }) as never;
+
+describe('pageStartNumber', () => {
+  it('continues for endorsement types', () => {
+    expect(pageStartNumber('new_page_endorsement', 4)).toBe(4);
+    expect(pageStartNumber('same_page_endorsement', 7)).toBe(7);
+  });
+
+  it('never offsets any other doc type', () => {
+    expect(pageStartNumber('naval_letter', 4)).toBe(1);
+    expect(pageStartNumber('moa', 9)).toBe(1);
+  });
+
+  it('treats absent, 1, and junk as start-at-1', () => {
+    expect(pageStartNumber('new_page_endorsement', undefined)).toBe(1);
+    expect(pageStartNumber('new_page_endorsement', 1)).toBe(1);
+    expect(pageStartNumber('new_page_endorsement', NaN)).toBe(1);
+  });
+});
+
+describe('a lingering startingPageNumber on a non-endorsement', () => {
+  it('emits no counter in the PDF generator', () => {
+    expect(generateDocumentTex(store('naval_letter'))).not.toContain('\\setStartingPageNumber');
+    expect(generateDocumentTex(store('new_page_endorsement'))).toContain('\\setStartingPageNumber{4}');
+  });
+
+  it('emits no counter in the DOCX generator', () => {
+    expect(generateFlatLatex(store('naval_letter'))).not.toContain('\\setcounter{page}');
+    expect(generateFlatLatex(store('new_page_endorsement'))).toContain('\\setcounter{page}{4}');
+  });
+});

--- a/tex/main.tex
+++ b/tex/main.tex
@@ -116,6 +116,16 @@
 \newcommand{\PageNumberStyle}{xofy}
 \newcommand{\setPageNumberStyle}[1]{\renewcommand{\PageNumberStyle}{#1}}
 
+% An endorsement continues the basic letter's page sequence rather than
+% starting at 1 (Ch 9, Fig 9-2 body: "Number each page of your endorsement and
+% continue the sequence of numbers from the previous endorsement or from the
+% basic letter"). The counter is applied at \begin{document}; with a start
+% above 1 the first sheet naturally prints its number (Fig 9-2 shows "2" on
+% the endorsement's own sheet), since the styles' suppress-page-1 checks test
+% the counter value, not the sheet index.
+\newcommand{\StartingPageNumber}{1}
+\newcommand{\setStartingPageNumber}[1]{\renewcommand{\StartingPageNumber}{#1}}
+
 % Smart page numbering based on style setting
 \makeatletter
 \newcommand{\smartPageNumber}{%
@@ -1432,6 +1442,11 @@
 
 % Apply font settings after config is loaded
 \applyFontSettings
+
+% Continue the basic letter's page sequence (Ch 9): applied after the config
+% inputs so \setStartingPageNumber from document.tex has taken effect, and
+% before any content so sheet 1 carries the continued number.
+\setcounter{page}{\StartingPageNumber}
 
 %=============================================================================
 % LOAD FORMAT-SPECIFIC MODULE


### PR DESCRIPTION
Stacked on #213. Closes the audit's page-continuation findings: "First page number" was a dead field in PDF export (never emitted, no counter in the template), the Word export suppressed the continued number on the endorsement's own sheet (Fig 9-2 prints it — "2" on the endorsement sheet), and the uploaded letter's page count was validated then discarded.

- `\setStartingPageNumber` + `\setcounter{page}` at begin-document; the existing suppress-page-1 checks test the counter value, so a continued first sheet prints its number with no per-template edits.
- DOCX first-sheet suppression now applies only when the sequence starts at 1.
- Uploading a basic letter defaults the field to `pageCount + 1` (never clobbering a user-set value) and steps a `none` numbering style up to `simple` so the continuation actually prints.

Rendered proof: a new-page endorsement with first page 4 prints "4" on its sheet; mutating the counter out of the template fails the test. Build, lint, 1686 unit tests green; bundle regenerated.

Ch 9, Fig 9-2 body: "Number each page of your endorsement and continue the sequence of numbers from the previous endorsement or from the basic letter if you are the first endorser."

---
_Supersedes #216 (auto-closed when its stacked base branch merged; reopened as a fresh PR onto `main` with the same two commits rebased)._