### PR TITLE
fix(pwa): self-heal an unstyled shell, not just a blank one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.105] — 2026-07-17
+
+### Fixed
+
+- The boot watchdog now heals an *unstyled* shell, not just a blank one.
+  Previously it treated "the JavaScript booted" as health — but a stale
+  service worker can serve a poisoned stylesheet, so the app mounts and renders
+  with no CSS (the white/unstyled page some users were stuck on). Booting is no
+  longer sufficient: the watchdog also checks that the stylesheet actually
+  applied (our `--background` token resolved), and when it hasn't, it now
+  **unregisters the service worker** — the thing serving the bad CSS — before
+  reloading, so the healing load fetches the current assets straight from the
+  network. This runs inline in `index.html` (served fresh on every visit), so a
+  currently-stuck client self-heals on its next load with no cache-clearing or
+  DevTools needed. It still runs at most once per distinct shell (never loops),
+  never touches saved documents (IndexedDB/localStorage), and leaves offline
+  clients alone.
+
 ## [1.2.104] — 2026-07-16
 
 ### Fixed

--- a/index.html
+++ b/index.html
@@ -62,23 +62,40 @@
         }
       })();
     </script>
-    <!-- Boot watchdog: self-heal a stale app shell instead of white-screening.
-         After a deploy, a cached index.html can reference hashed bundles that
-         no longer exist (the service worker's NetworkFirst navigation fetch can
-         be satisfied by the browser's HTTP cache, and may then store that stale
-         shell in its own runtime cache — the 1.2.94 white-screen incident). The
-         app sets window.__DD_BOOTED__ as its first act; if that hasn't happened
-         shortly after load and we're online, this drops the shell caches,
-         force-revalidates the page in the HTTP cache, and reloads ONCE
-         (session-guarded so it can never loop; offline is left alone — the
-         cached shell is all an air-gapped machine has). -->
-    <script>
+    <!-- Boot watchdog: self-heal a stale/broken app shell instead of leaving a
+         white or unstyled screen. Two failure modes, one recovery:
+           1. Stale shell — a cached index.html references hashed bundles that no
+              longer exist, so the JS never boots (window.__DD_BOOTED__ stays
+              unset). The 1.2.94 white-screen incident.
+           2. Poisoned stylesheet — the JS boots but a stale service worker serves
+              a bad /assets/*.css, so the app renders UNSTYLED. Booting alone is
+              therefore NOT health: we also require our --background token to have
+              resolved, which only happens if the stylesheet actually applied.
+              Without this, the app's own "update available" prompt can't rescue
+              the user — it's a React component, invisible without CSS.
+         When neither holds shortly after load and we're online, this unregisters
+         the service worker (so the healing reload isn't intercepted and fetches
+         fresh assets straight from the network), drops the shell caches,
+         force-revalidates the page in the HTTP cache, and reloads ONCE. Guarded
+         per DISTINCT shell so it can never loop; IndexedDB/localStorage (saved
+         documents) are never touched; offline is left alone — the cached shell is
+         all an air-gapped machine has. This exact block is extracted and
+         exercised end-to-end by tests/regressions/boot-watchdog-stale-shell.ts. -->
+    <script id="boot-watchdog">
       (function () {
         try {
           var KEY = 'dondocs-boot-recovery';
+          // Our stylesheet defines --background on :root. If it resolves empty,
+          // the stylesheet never applied — the shell is unstyled/broken.
+          function stylesApplied() {
+            try {
+              return getComputedStyle(document.documentElement)
+                .getPropertyValue('--background').trim() !== '';
+            } catch (e) { return true; } // can't tell → assume fine, never nuke blindly
+          }
           setTimeout(function () {
             try {
-              if (window.__DD_BOOTED__) { sessionStorage.removeItem(KEY); return; }
+              if (window.__DD_BOOTED__ && stylesApplied()) { sessionStorage.removeItem(KEY); return; }
               if (!navigator.onLine) return;
               // One shot per DISTINCT broken shell, not per tab session: the
               // module script's hashed src fingerprints the build this shell
@@ -91,6 +108,15 @@
               if (sessionStorage.getItem(KEY) === shellId) return;
               sessionStorage.setItem(KEY, shellId);
               var reload = function () { location.reload(); };
+              // Unregister the worker: the poisoned CSS is served BY the stale SW,
+              // so the reload must not be intercepted by it. With no controller,
+              // the healing load fetches the current hashed assets from the
+              // network. Engine caches are left intact so offline compile survives.
+              var unregisterSW = ('serviceWorker' in navigator)
+                ? navigator.serviceWorker.getRegistrations().then(function (regs) {
+                    return Promise.all(regs.map(function (r) { return r.unregister(); }));
+                  }).catch(function () {})
+                : Promise.resolve();
               var dropShellCaches = ('caches' in window)
                 ? caches.keys().then(function (keys) {
                     return Promise.all(keys
@@ -102,7 +128,7 @@
               // entry with a fresh copy, so the reload below can't re-read the
               // same stale shell.
               var refreshShell = fetch(location.href, { cache: 'reload' }).catch(function () {});
-              Promise.all([dropShellCaches, refreshShell]).then(reload, reload);
+              Promise.all([unregisterSW, dropShellCaches, refreshShell]).then(reload, reload);
             } catch (e) { /* never break boot */ }
           }, 10000);
         } catch (e) { /* never break boot */ }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dondocs",
-  "version": "1.2.104",
+  "version": "1.2.105",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dondocs",
-      "version": "1.2.104",
+      "version": "1.2.105",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.104",
+  "version": "1.2.105",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/tests/regressions/boot-watchdog-stale-shell.test.ts
+++ b/tests/regressions/boot-watchdog-stale-shell.test.ts
@@ -27,12 +27,17 @@ const SHELL_CACHE_PREFIX = 'dondocs-app-shell';
 const GUARD_KEY = 'dondocs-boot-recovery';
 
 function extractWatchdogSource(): string {
-  // Case-insensitive: this only extracts a known inline script from our own
-  // index.html, but CodeQL (rightly) treats case-sensitive tag regexes as a
-  // sanitizer-bypass smell, and <SCRIPT> is valid HTML anyway.
-  const scripts = [...indexHtml.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/gi)].map((m) => m[1]);
-  const src = scripts.find((s) => s.includes(GUARD_KEY));
-  if (!src) throw new Error('boot watchdog inline script not found in index.html');
+  // Slice on the known id rather than an HTML-tag regex: parsing tags with a
+  // regex is a sanitizer-bypass smell CodeQL rightly flags (js/bad-tag-filter),
+  // and we only ever extract this one inline script from our own index.html.
+  const OPEN = '<script id="boot-watchdog">';
+  const start = indexHtml.indexOf(OPEN);
+  if (start === -1) throw new Error('boot watchdog inline script not found in index.html');
+  const bodyStart = start + OPEN.length;
+  const end = indexHtml.indexOf('</script>', bodyStart);
+  if (end === -1) throw new Error('boot watchdog script end tag not found in index.html');
+  const src = indexHtml.slice(bodyStart, end);
+  if (!src.includes(GUARD_KEY)) throw new Error('boot watchdog script missing its guard key');
   return src;
 }
 

--- a/tests/regressions/boot-watchdog-stale-shell.test.ts
+++ b/tests/regressions/boot-watchdog-stale-shell.test.ts
@@ -30,7 +30,7 @@ function extractWatchdogSource(): string {
   // Case-insensitive: this only extracts a known inline script from our own
   // index.html, but CodeQL (rightly) treats case-sensitive tag regexes as a
   // sanitizer-bypass smell, and <SCRIPT> is valid HTML anyway.
-  const scripts = [...indexHtml.matchAll(/<script>([\s\S]*?)<\/script>/gi)].map((m) => m[1]);
+  const scripts = [...indexHtml.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/gi)].map((m) => m[1]);
   const src = scripts.find((s) => s.includes(GUARD_KEY));
   if (!src) throw new Error('boot watchdog inline script not found in index.html');
   return src;
@@ -44,12 +44,17 @@ const SHELL_SRC = '/assets/main-abc123.js';
 
 interface RunOptions {
   booted: boolean;
+  /** Whether our --background token resolved (the stylesheet applied). Default
+   *  true: booting is only healthy when the CSS also loaded. */
+  stylesApplied?: boolean;
   online?: boolean;
   /** Pre-set guard value: SHELL_SRC = this shell already healed. */
   guardValue?: string;
   cacheKeys?: string[];
   /** The module script src the current shell carries (null = none found). */
   shellSrc?: string | null;
+  /** Whether a service worker controls the page (default: yes, one worker). */
+  serviceWorker?: boolean;
 }
 
 /** Run the extracted watchdog against doubles and fire its timer. */
@@ -60,6 +65,7 @@ async function runWatchdog(opts: RunOptions) {
   const deleted: string[] = [];
   const fetchCalls: { url: string; init?: RequestInit }[] = [];
   let reloads = 0;
+  let unregistered = 0;
   let timerCb: (() => void) | null = null;
 
   const cachesStub = {
@@ -69,8 +75,25 @@ async function runWatchdog(opts: RunOptions) {
       return true;
     },
   };
+  const hasSW = opts.serviceWorker ?? true;
+  const navigatorStub: Record<string, unknown> = { onLine: opts.online ?? true };
+  if (hasSW) {
+    navigatorStub.serviceWorker = {
+      getRegistrations: async () => [
+        { unregister: async () => void unregistered++ },
+        { unregister: async () => void unregistered++ },
+      ],
+    };
+  }
+  const stylesApplied = opts.stylesApplied ?? true;
   const sandbox = {
     window: { __DD_BOOTED__: opts.booted ? true : undefined, caches: cachesStub },
+    // The watchdog probes getComputedStyle(...).getPropertyValue('--background');
+    // an empty value means the stylesheet never applied (unstyled shell).
+    getComputedStyle: () => ({
+      getPropertyValue: (prop: string) =>
+        prop === '--background' && stylesApplied ? 'oklch(0.97 0.008 250)' : '',
+    }),
     document: {
       querySelector: (sel: string) => {
         if (!sel.includes('script')) return null;
@@ -78,7 +101,7 @@ async function runWatchdog(opts: RunOptions) {
         return src === null ? null : { getAttribute: () => src };
       },
     },
-    navigator: { onLine: opts.online ?? true },
+    navigator: navigatorStub,
     sessionStorage: {
       getItem: (k: string) => storage.get(k) ?? null,
       setItem: (k: string, v: string) => void storage.set(k, v),
@@ -112,7 +135,7 @@ async function runWatchdog(opts: RunOptions) {
   };
   await fireTimer();
 
-  return { deleted, fetchCalls, reloads: () => reloads, storage, fireTimer };
+  return { deleted, fetchCalls, reloads: () => reloads, unregistered: () => unregistered, storage, fireTimer };
 }
 
 describe('boot watchdog — stale shell recovery (v1.2.94 incident)', () => {
@@ -133,8 +156,27 @@ describe('boot watchdog — stale shell recovery (v1.2.94 incident)', () => {
       { url: 'https://dondocs.test/', init: { cache: 'reload' } },
     ]);
     expect(r.reloads()).toBe(1);
+    // Recovery unregisters the service worker — it is what serves the stale
+    // shell, so the healing reload must not be intercepted by it.
+    expect(r.unregistered()).toBe(2);
     // The guard records WHICH shell was healed (the hashed module src), so
     // recovery is one-shot per broken build rather than per tab session.
+    expect(r.storage.get(GUARD_KEY)).toBe(SHELL_SRC);
+  });
+
+  it('booted-but-unstyled shell (poisoned CSS) is recovered, not treated as healthy', async () => {
+    // The regression this release fixes: the JS booted (__DD_BOOTED__ set) but
+    // a stale service worker served a bad stylesheet, so --background never
+    // resolved. The old watchdog saw "booted" and stood down, leaving the user
+    // on a white/unstyled page. Health now requires the stylesheet too.
+    const r = await runWatchdog({
+      booted: true,
+      stylesApplied: false,
+      cacheKeys: [`${SHELL_CACHE_PREFIX}-deadbeef`],
+    });
+    expect(r.reloads()).toBe(1);
+    expect(r.unregistered()).toBe(2); // the poisoned worker is unregistered
+    expect(r.deleted).toEqual([`${SHELL_CACHE_PREFIX}-deadbeef`]);
     expect(r.storage.get(GUARD_KEY)).toBe(SHELL_SRC);
   });
 
@@ -173,11 +215,13 @@ describe('boot watchdog — stale shell recovery (v1.2.94 incident)', () => {
   it('healthy boot: no recovery, and the one-shot guard is cleared for next time', async () => {
     const r = await runWatchdog({
       booted: true,
+      stylesApplied: true, // booted AND styled — genuinely healthy
       guardValue: SHELL_SRC, // left over from a prior recovered session
       cacheKeys: [`${SHELL_CACHE_PREFIX}-deadbeef`],
     });
     expect(r.deleted).toEqual([]);
     expect(r.reloads()).toBe(0);
+    expect(r.unregistered()).toBe(0);
     expect(r.storage.has(GUARD_KEY)).toBe(false);
   });
 


### PR DESCRIPTION
## The bug
Some users get a **white/unstyled page** and stay stuck on it — normal refresh keeps showing it, only a hard refresh (or DevTools → Clear site data) fixes it, then it reverts.

Root cause is a stale service worker serving a poisoned `/assets/*.css`. The **origin** side is already fixed (#218 + the Cloudflare Browser-Cache-TTL change), so this can't happen to *new* visitors — but clients already in that state weren't self-healing.

## Why the existing watchdog missed it
The inline boot watchdog in `index.html` treated **`window.__DD_BOOTED__` (the JS booted)** as health. On the unstyled page the JS *did* boot (React mounts and renders the header) — only the CSS is missing — so the watchdog declared it healthy and stood down. The app's own "update available" prompt can't help either: it's a React component, invisible without CSS, so the user can never click it.

## The fix
- **Health now requires the stylesheet too.** The watchdog probes the `--background` custom property our stylesheet defines on `:root`; empty ⇒ the stylesheet never applied ⇒ broken.
- **Recovery now unregisters the service worker** (the thing serving the bad CSS) before reloading, so the healing load fetches current assets straight from the network with no interceptor.
- Lives **inline in `index.html`** (served `NetworkFirst` + `no-cache`), so a currently-stuck client receives this on its next visit and self-heals — no cache-clearing, no DevTools.

## Safety (unchanged guards)
- **Never loops** — at most once per distinct shell fingerprint.
- **Never touches saved documents** — only Cache Storage + SW registration; IndexedDB/localStorage untouched.
- **Offline-safe** — stands down when offline (the cached shell is all an air-gapped machine has).
- **Engine caches preserved** — offline LaTeX/pandoc compile still works after a heal.

## Tests
The regression suite executes the *real* extracted inline script against doubles. Added the **booted-but-unstyled** case (reproduces the bug) and the **service-worker unregister** assertion, and taught the harness to drive the stylesheet probe. Full gate green: build, lint (0), 1709 unit tests, no-CDN guard.