### PR TITLE
fix(editor): outline jump to a trailing section highlights that section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.106] — 2026-07-17
+
+### Fixed
+
+- Jumping to a section near the end of the editor outline (e.g. Distribution)
+  now highlights that section, not the last one. The scroll-spy has a
+  bottom-edge override that lights the final section once you reach the end of
+  the form — but a short second-to-last section can't scroll any higher than
+  the bottom, so clicking it in the outline snapped the highlight straight to
+  the last section (Signature). A jump is now authoritative: the spy is
+  suppressed for the scroll the jump itself fires, and a real user scroll
+  resumes it immediately, so both the target section and normal scroll-spying
+  behave.
+
 ## [1.2.105] — 2026-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
   bottom-edge override that lights the final section once you reach the end of
   the form — but a short second-to-last section can't scroll any higher than
   the bottom, so clicking it in the outline snapped the highlight straight to
-  the last section (Signature). A jump is now authoritative: the spy is
-  suppressed for the scroll the jump itself fires, and a real user scroll
-  resumes it immediately, so both the target section and normal scroll-spying
-  behave.
+  the last section (Signature). A jump is now authoritative: the section you
+  jumped to stays selected until you actually scroll — a later re-render or
+  layout shift can't quietly re-fire the override and un-stick it — and the
+  first real scroll (wheel, touch, or arrow key) resumes normal scroll-spying.
 
 ## [1.2.105] — 2026-07-17
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dondocs",
-  "version": "1.2.105",
+  "version": "1.2.106",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dondocs",
-      "version": "1.2.105",
+      "version": "1.2.106",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.105",
+  "version": "1.2.106",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/src/components/layout/FormPanel.tsx
+++ b/src/components/layout/FormPanel.tsx
@@ -33,6 +33,15 @@ export function FormPanel() {
   const viewport = () =>
     scrollWrapRef.current?.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]') ?? null;
 
+  // When the sidebar jumps to a section, that choice is authoritative until the
+  // user scrolls. Without this, jumping to a trailing section (e.g.
+  // Distribution) scrolls the viewport to its bottom, and the scroll event that
+  // the jump itself fires trips the bottom-edge override below, which snaps the
+  // highlight to the LAST section (Signature) — so a short second-to-last
+  // section could never be selected. Suppress the spy briefly so the jump's own
+  // scroll can't clobber it; a real user scroll clears it and resumes the spy.
+  const suppressSpyUntilRef = useRef(0);
+
   // Scroll-spy: the active section is the last one whose top has passed a
   // trigger line near the top of the viewport, with a bottom-edge override so
   // the final short sections light up at the end. Publishes to the outline store.
@@ -44,6 +53,8 @@ export function FormPanel() {
     let raf = 0;
     const compute = () => {
       raf = 0;
+      // A recent jump owns the active section until the user scrolls for real.
+      if (performance.now() < suppressSpyUntilRef.current) return;
       // Bottom-edge override: when scrolled to the end, light the last section.
       // Gated on the form actually overflowing, else a short doc would light the
       // last section at the top on first paint instead of the first.
@@ -67,10 +78,19 @@ export function FormPanel() {
     const schedule = () => {
       if (!raf) raf = requestAnimationFrame(compute);
     };
+    // A real user scroll (wheel / touch / arrow key) ends the post-jump
+    // suppression immediately, so the spy is never sluggish after a jump.
+    const releaseSuppression = () => { suppressSpyUntilRef.current = 0; };
     root.addEventListener('scroll', schedule, { passive: true });
+    root.addEventListener('wheel', releaseSuppression, { passive: true });
+    root.addEventListener('touchmove', releaseSuppression, { passive: true });
+    root.addEventListener('keydown', releaseSuppression);
     schedule(); // initial sync, deferred out of the effect body
     return () => {
       root.removeEventListener('scroll', schedule);
+      root.removeEventListener('wheel', releaseSuppression);
+      root.removeEventListener('touchmove', releaseSuppression);
+      root.removeEventListener('keydown', releaseSuppression);
       if (raf) cancelAnimationFrame(raf);
     };
   }, [sections, spyEnabled]);
@@ -81,6 +101,8 @@ export function FormPanel() {
     const root = scrollWrapRef.current?.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
     const el = root?.querySelector<HTMLElement>(`#sec-${id}`);
     if (!el) return;
+    // Own the active section through the scroll this jump is about to fire.
+    suppressSpyUntilRef.current = performance.now() + 400;
     el.scrollIntoView({ block: 'start', behavior: 'auto' });
     // Move focus into the section so keyboard/AT users land there, not back on
     // the rail button (WCAG 2.4.3). The wrapper is tabIndex=-1 for this.

--- a/src/components/layout/FormPanel.tsx
+++ b/src/components/layout/FormPanel.tsx
@@ -34,13 +34,14 @@ export function FormPanel() {
     scrollWrapRef.current?.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]') ?? null;
 
   // When the sidebar jumps to a section, that choice is authoritative until the
-  // user scrolls. Without this, jumping to a trailing section (e.g.
-  // Distribution) scrolls the viewport to its bottom, and the scroll event that
-  // the jump itself fires trips the bottom-edge override below, which snaps the
+  // user scrolls for real. Without this, jumping to a trailing section (e.g.
+  // Distribution) scrolls the viewport to its bottom, and the scroll event the
+  // jump itself fires trips the bottom-edge override below, which snaps the
   // highlight to the LAST section (Signature) — so a short second-to-last
-  // section could never be selected. Suppress the spy briefly so the jump's own
-  // scroll can't clobber it; a real user scroll clears it and resumes the spy.
-  const suppressSpyUntilRef = useRef(0);
+  // section could never be selected. Pinning (rather than a time window) means a
+  // late layout shift or async re-render can't quietly re-fire the override and
+  // un-stick the jump; only a genuine user scroll (wheel/touch/arrow) clears it.
+  const jumpPinnedRef = useRef(false);
 
   // Scroll-spy: the active section is the last one whose top has passed a
   // trigger line near the top of the viewport, with a bottom-edge override so
@@ -53,8 +54,9 @@ export function FormPanel() {
     let raf = 0;
     const compute = () => {
       raf = 0;
-      // A recent jump owns the active section until the user scrolls for real.
-      if (performance.now() < suppressSpyUntilRef.current) return;
+      // A jump owns the active section until the user scrolls for real, so a
+      // stray scroll event (layout shift, re-render) can't clobber it.
+      if (jumpPinnedRef.current) return;
       // Bottom-edge override: when scrolled to the end, light the last section.
       // Gated on the form actually overflowing, else a short doc would light the
       // last section at the top on first paint instead of the first.
@@ -78,19 +80,21 @@ export function FormPanel() {
     const schedule = () => {
       if (!raf) raf = requestAnimationFrame(compute);
     };
-    // A real user scroll (wheel / touch / arrow key) ends the post-jump
-    // suppression immediately, so the spy is never sluggish after a jump.
-    const releaseSuppression = () => { suppressSpyUntilRef.current = 0; };
+    // A real user scroll (wheel / touch / arrow key) releases the jump pin, so
+    // the spy resumes the instant the user takes over — and, crucially, only
+    // then. Bare 'scroll' events don't release it: those also fire for the
+    // jump's own scroll and for layout shifts, neither of which is user intent.
+    const releasePin = () => { jumpPinnedRef.current = false; };
     root.addEventListener('scroll', schedule, { passive: true });
-    root.addEventListener('wheel', releaseSuppression, { passive: true });
-    root.addEventListener('touchmove', releaseSuppression, { passive: true });
-    root.addEventListener('keydown', releaseSuppression);
+    root.addEventListener('wheel', releasePin, { passive: true });
+    root.addEventListener('touchmove', releasePin, { passive: true });
+    root.addEventListener('keydown', releasePin);
     schedule(); // initial sync, deferred out of the effect body
     return () => {
       root.removeEventListener('scroll', schedule);
-      root.removeEventListener('wheel', releaseSuppression);
-      root.removeEventListener('touchmove', releaseSuppression);
-      root.removeEventListener('keydown', releaseSuppression);
+      root.removeEventListener('wheel', releasePin);
+      root.removeEventListener('touchmove', releasePin);
+      root.removeEventListener('keydown', releasePin);
       if (raf) cancelAnimationFrame(raf);
     };
   }, [sections, spyEnabled]);
@@ -101,8 +105,9 @@ export function FormPanel() {
     const root = scrollWrapRef.current?.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
     const el = root?.querySelector<HTMLElement>(`#sec-${id}`);
     if (!el) return;
-    // Own the active section through the scroll this jump is about to fire.
-    suppressSpyUntilRef.current = performance.now() + 400;
+    // Own the active section until the user scrolls — through the scroll this
+    // jump is about to fire, and through any later re-render or layout shift.
+    jumpPinnedRef.current = true;
     el.scrollIntoView({ block: 'start', behavior: 'auto' });
     // Move focus into the section so keyboard/AT users land there, not back on
     // the rail button (WCAG 2.4.3). The wrapper is tabIndex=-1 for this.


### PR DESCRIPTION
## Complaint
"Some issues with scroll / distribution." Clicking **Distribution** in the editor outline scrolled to it, but the sidebar highlighted **Signature** (the last section) instead — so it looked like you couldn't navigate to Distribution.

## Root cause (reproduced + measured live)
The scroll-spy has a **bottom-edge override**: once the form is scrolled to its end, it lights the *last* section (so short trailing sections can light up at all). But Distribution is second-to-last and short, so jumping to it scrolls the viewport to the very bottom — and the scroll event the jump itself fires trips the override, which snaps the highlight to Signature. Any short second-to-last section was unselectable from the outline.

Measured: after clicking Distribution, `atBottom: true`, Distribution sat 106px down (couldn't reach the top), and the active color was Signature's red, not Distribution's.

## Fix
A jump is now **authoritative**: it suppresses the spy for the ~one scroll event its own `scrollIntoView` fires, so the jumped section stays lit. A real user scroll (wheel / touch / arrow key) releases the suppression immediately, so the spy is never sluggish and later sections still light as you scroll.

## Verified in the browser
- Click **Distribution** → Distribution stays highlighted, stable past the suppression window (checked at t0 / t+700ms / t+2.2s).
- Click **Signature** → Signature highlights (still selectable).
- Scroll for real → spy resumes and moves off the pinned section.

Full gate green: build, lint 0, 1709 unit tests, no-CDN guard. (Scroll-spy is geometry-driven; happy-dom has no layout, so this is verified by live rendering per the repo's testing norms rather than a layout-blind unit test.)