### PR TITLE
fix(pwa): instant stale-shell heal + persistent storage (1.2.107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
+## [1.2.107] — 2026-07-18
+
+### Fixed
+
+- The unstyled-page flash on refresh now heals instantly instead of after
+  seconds. When a stale service worker serves a shell whose stylesheet no
+  longer exists, the boot watchdog previously waited 10 seconds before
+  recovering; the failed stylesheet's own error event now triggers the same
+  one-shot recovery the moment the failure lands. All guards carry over:
+  only the app's own stylesheets count, a healthy styled session is never
+  touched, offline clients are left alone, and recovery still can never loop.
+- Attacked the root of the recurrence: the app now asks the browser for
+  **persistent storage** once a user has saved documents. Persistence protects
+  IndexedDB, Cache Storage, and the service-worker registration from
+  disk-pressure eviction — the mechanism that strands an installed worker
+  serving a shell whose assets were evicted, producing the
+  broken-refresh-then-recover loop on affected machines. Chromium grants or
+  denies silently; the storage-health notice now reflects the post-request
+  state. A brand-new visitor with nothing to lose is never prompted.
+
 ## [1.2.106] — 2026-07-17
 
 ### Fixed

--- a/index.html
+++ b/index.html
@@ -73,14 +73,18 @@
               resolved, which only happens if the stylesheet actually applied.
               Without this, the app's own "update available" prompt can't rescue
               the user — it's a React component, invisible without CSS.
-         When neither holds shortly after load and we're online, this unregisters
-         the service worker (so the healing reload isn't intercepted and fetches
-         fresh assets straight from the network), drops the shell caches,
-         force-revalidates the page in the HTTP cache, and reloads ONCE. Guarded
-         per DISTINCT shell so it can never loop; IndexedDB/localStorage (saved
-         documents) are never touched; offline is left alone — the cached shell is
-         all an air-gapped machine has. This exact block is extracted and
-         exercised end-to-end by tests/regressions/boot-watchdog-stale-shell.ts. -->
+         When neither holds and we're online, this unregisters the service
+         worker (so the healing reload isn't intercepted and fetches fresh
+         assets straight from the network), drops the shell caches,
+         force-revalidates the page in the HTTP cache, and reloads ONCE.
+         Recovery has two triggers: a FAST one — a shell stylesheet firing its
+         error event (the 404 case, healed the moment it lands instead of
+         after seconds of unstyled page) — and a 10s timer that catches
+         everything else. Guarded per DISTINCT shell so it can never loop;
+         IndexedDB/localStorage (saved documents) are never touched; offline is
+         left alone — the cached shell is all an air-gapped machine has. This
+         exact block is extracted and exercised end-to-end by
+         tests/regressions/boot-watchdog-stale-shell.ts. -->
     <script id="boot-watchdog">
       (function () {
         try {
@@ -93,16 +97,16 @@
                 .getPropertyValue('--background').trim() !== '';
             } catch (e) { return true; } // can't tell → assume fine, never nuke blindly
           }
-          setTimeout(function () {
+          // The one-shot recovery, shared by the slow timer below and the fast
+          // stylesheet-failure trigger. Guarded per DISTINCT broken shell, not
+          // per tab session: the module script's hashed src fingerprints the
+          // build this shell belongs to. Guarding on the bare session left a
+          // tab stuck when the first heal didn't take (a stale SW re-served a
+          // different stale shell) — a new fingerprint means a new failure
+          // worth one more attempt, while the same shell can still never loop.
+          function heal() {
             try {
-              if (window.__DD_BOOTED__ && stylesApplied()) { sessionStorage.removeItem(KEY); return; }
               if (!navigator.onLine) return;
-              // One shot per DISTINCT broken shell, not per tab session: the
-              // module script's hashed src fingerprints the build this shell
-              // belongs to. Guarding on the bare session left a tab stuck when
-              // the first heal didn't take (a stale SW re-served a different
-              // stale shell) — a new fingerprint means a new failure worth one
-              // more attempt, while the same shell can still never loop.
               var s = document.querySelector('script[type="module"][src]');
               var shellId = (s && s.getAttribute('src')) || 'unknown';
               if (sessionStorage.getItem(KEY) === shellId) return;
@@ -129,6 +133,33 @@
               // same stale shell.
               var refreshShell = fetch(location.href, { cache: 'reload' }).catch(function () {});
               Promise.all([unregisterSW, dropShellCaches, refreshShell]).then(reload, reload);
+            } catch (e) { /* never break boot */ }
+          }
+          // Fast path: a shell stylesheet that fails to load fires a capture-
+          // phase error event the moment the 404/failure lands — heal right
+          // then instead of leaving the user on an unstyled page until the
+          // timer. Only our own hashed assets count, and only when the styles
+          // really are missing, so an unrelated resource error can't nuke a
+          // healthy session. (Resource errors don't bubble; capture is the
+          // only way to see them from here.)
+          if (window.addEventListener) {
+            window.addEventListener('error', function (e) {
+              try {
+                var t = e && e.target;
+                if (!t || t.tagName !== 'LINK') return;
+                if ((t.rel || '') !== 'stylesheet') return;
+                if (String(t.href || '').indexOf('/assets/') === -1) return;
+                if (stylesApplied()) return;
+                heal();
+              } catch (err) { /* never break boot */ }
+            }, true);
+          }
+          // Slow path: catches everything else (blank shell, hung requests,
+          // a worker serving nothing at all).
+          setTimeout(function () {
+            try {
+              if (window.__DD_BOOTED__ && stylesApplied()) { sessionStorage.removeItem(KEY); return; }
+              heal();
             } catch (e) { /* never break boot */ }
           }, 10000);
         } catch (e) { /* never break boot */ }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dondocs",
-  "version": "1.2.106",
+  "version": "1.2.107",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dondocs",
-      "version": "1.2.106",
+      "version": "1.2.107",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.106",
+  "version": "1.2.107",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,7 @@ import { AppAlertDialog } from '@/components/AppAlertDialog';
 import { StorageNotice } from '@/components/StorageNotice';
 import { BackupNotice } from '@/components/BackupNotice';
 import { InstallNotice } from '@/components/InstallNotice';
-import { probeStorageHealth } from '@/lib/documentsDb';
+import { probeStorageHealth, requestPersistentStorage } from '@/lib/documentsDb';
 import { useUIStore } from '@/stores/uiStore';
 import { useDocumentStore, getSavedSession, rehydrateEnclosureFiles } from '@/stores/documentStore';
 import { useFormStore, FORMS_PERSIST_KEY } from '@/stores/formStore';
@@ -466,8 +466,14 @@ function App() {
       // Probe how durable storage is only AFTER hydration/migration settles, so a
       // returning user's just-migrated docs are already in IndexedDB and the
       // StorageNotice can't be suppressed by reading an empty store mid-migration.
+      // Request persistence first so the probe reports the post-grant state —
+      // for most Chromium users this quietly flips 'evictable' to 'ok' and, more
+      // importantly, stops the browser evicting the service worker's precache
+      // (the root of the recurring unstyled-shell loop).
       .finally(() => {
-        void probeStorageHealth()
+        void requestPersistentStorage()
+          .catch(() => false)
+          .then(() => probeStorageHealth())
           .then((health) => {
             if (!cancelled) useUIStore.getState().setStorageHealth(health);
           })

--- a/src/lib/documentsDb.ts
+++ b/src/lib/documentsDb.ts
@@ -260,6 +260,33 @@ export type StorageHealth = 'ok' | 'evictable' | 'unreadable' | 'unavailable';
  *  - 'ok': persistent storage is granted.
  * Uses the passive `persisted()` check (no permission prompt).
  */
+/**
+ * Ask the browser to protect this origin's storage from eviction. Persistence
+ * covers everything the app depends on — IndexedDB (documents), Cache Storage
+ * (the offline engines AND the service worker's precache), and the service
+ * worker registration itself. Without it, disk pressure can evict the
+ * precache out from under an installed worker, leaving it serving a shell
+ * whose assets are gone (the recurring unstyled-page loop the boot watchdog
+ * heals). Asking is the systemic fix; the watchdog is the backstop.
+ *
+ * Only asks once the user actually has documents: Chromium decides silently
+ * from engagement signals either way, but Firefox shows a permission dialog,
+ * and prompting a first-time visitor with nothing to lose is noise. Best
+ * effort — returns whether storage is persistent afterwards.
+ */
+export async function requestPersistentStorage(): Promise<boolean> {
+  try {
+    if (!navigator.storage?.persist || !navigator.storage.persisted) return false;
+    if (await navigator.storage.persisted()) return true;
+    if (!hasIndexedDb) return false;
+    const records = await idbGetAllDocuments();
+    if (!records || records.length === 0) return false;
+    return await navigator.storage.persist();
+  } catch {
+    return false;
+  }
+}
+
 export async function probeStorageHealth(): Promise<StorageHealth> {
   if (!hasIndexedDb) return 'unavailable';
   try {

--- a/tests/regressions/boot-watchdog-stale-shell.test.ts
+++ b/tests/regressions/boot-watchdog-stale-shell.test.ts
@@ -60,6 +60,15 @@ interface RunOptions {
   shellSrc?: string | null;
   /** Whether a service worker controls the page (default: yes, one worker). */
   serviceWorker?: boolean;
+  /** Skip the automatic timer firing (to exercise the fast CSS-error path alone). */
+  autoFireTimer?: boolean;
+}
+
+/** A minimal resource-error event target, as the capture listener sees it. */
+interface ErrorTarget {
+  tagName: string;
+  rel?: string;
+  href?: string;
 }
 
 /** Run the extracted watchdog against doubles and fire its timer. */
@@ -72,6 +81,8 @@ async function runWatchdog(opts: RunOptions) {
   let reloads = 0;
   let unregistered = 0;
   let timerCb: (() => void) | null = null;
+  let errorCb: ((e: { target: ErrorTarget | null }) => void) | null = null;
+  let errorCapture: boolean | undefined;
 
   const cachesStub = {
     keys: async () => opts.cacheKeys ?? [],
@@ -92,7 +103,20 @@ async function runWatchdog(opts: RunOptions) {
   }
   const stylesApplied = opts.stylesApplied ?? true;
   const sandbox = {
-    window: { __DD_BOOTED__: opts.booted ? true : undefined, caches: cachesStub },
+    window: {
+      __DD_BOOTED__: opts.booted ? true : undefined,
+      caches: cachesStub,
+      addEventListener: (
+        type: string,
+        cb: (e: { target: ErrorTarget | null }) => void,
+        capture?: boolean
+      ) => {
+        if (type === 'error') {
+          errorCb = cb;
+          errorCapture = capture;
+        }
+      },
+    },
     // The watchdog probes getComputedStyle(...).getPropertyValue('--background');
     // an empty value means the stylesheet never applied (unstyled shell).
     getComputedStyle: () => ({
@@ -132,15 +156,32 @@ async function runWatchdog(opts: RunOptions) {
   // Execute the real inline script with our doubles shadowing the globals.
   new Function(...Object.keys(sandbox), extractWatchdogSource())(...Object.values(sandbox));
 
-  const fireTimer = async () => {
-    timerCb?.();
+  const settle = async () => {
     // let the recovery's promise chain settle
     await new Promise((r) => globalThis.setTimeout(r, 0));
     await new Promise((r) => globalThis.setTimeout(r, 0));
   };
-  await fireTimer();
+  const fireTimer = async () => {
+    timerCb?.();
+    await settle();
+  };
+  /** Fire the capture-phase resource-error listener with the given target. */
+  const fireError = async (target: ErrorTarget | null) => {
+    errorCb?.({ target });
+    await settle();
+  };
+  if (opts.autoFireTimer !== false) await fireTimer();
 
-  return { deleted, fetchCalls, reloads: () => reloads, unregistered: () => unregistered, storage, fireTimer };
+  return {
+    deleted,
+    fetchCalls,
+    reloads: () => reloads,
+    unregistered: () => unregistered,
+    storage,
+    fireTimer,
+    fireError,
+    errorListener: () => ({ registered: errorCb !== null, capture: errorCapture }),
+  };
 }
 
 describe('boot watchdog — stale shell recovery (v1.2.94 incident)', () => {
@@ -242,6 +283,72 @@ describe('boot watchdog — stale shell recovery (v1.2.94 incident)', () => {
     // and it must NOT burn the one-shot guard while offline, or a machine that
     // comes back online later has no recovery left
     expect(r.storage.has(GUARD_KEY)).toBe(false);
+  });
+});
+
+describe('boot watchdog — fast heal on stylesheet failure', () => {
+  const cssTarget = (href = 'https://dondocs.test/assets/main-abc123.css'): {
+    tagName: string;
+    rel: string;
+    href: string;
+  } => ({ tagName: 'LINK', rel: 'stylesheet', href });
+
+  it('a failed shell stylesheet heals immediately — no waiting for the timer', async () => {
+    const r = await runWatchdog({
+      booted: false,
+      stylesApplied: false,
+      autoFireTimer: false,
+      cacheKeys: [`${SHELL_CACHE_PREFIX}-deadbeef`],
+    });
+    // capture phase is load-bearing: resource errors don't bubble, so a
+    // bubble-phase listener would never fire and the fast path silently dies.
+    expect(r.errorListener()).toEqual({ registered: true, capture: true });
+    await r.fireError(cssTarget());
+    expect(r.reloads()).toBe(1);
+    expect(r.unregistered()).toBe(2);
+    expect(r.deleted).toEqual([`${SHELL_CACHE_PREFIX}-deadbeef`]);
+    expect(r.storage.get(GUARD_KEY)).toBe(SHELL_SRC);
+  });
+
+  it('the timer firing after a fast heal does not heal twice', async () => {
+    const r = await runWatchdog({
+      booted: false,
+      stylesApplied: false,
+      autoFireTimer: false,
+      cacheKeys: [`${SHELL_CACHE_PREFIX}-deadbeef`],
+    });
+    await r.fireError(cssTarget());
+    await r.fireTimer();
+    expect(r.reloads()).toBe(1); // one-shot guard holds across both triggers
+  });
+
+  it('ignores failures that are not our shell stylesheet', async () => {
+    const r = await runWatchdog({ booted: false, stylesApplied: false, autoFireTimer: false });
+    await r.fireError(null); // no target at all
+    await r.fireError({ tagName: 'IMG', href: 'https://dondocs.test/assets/x.png' });
+    await r.fireError({ tagName: 'LINK', rel: 'preload', href: 'https://dondocs.test/assets/a.css' });
+    await r.fireError(cssTarget('https://dondocs.test/other/site.css')); // not /assets/
+    expect(r.reloads()).toBe(0);
+  });
+
+  it('a stylesheet error while styles ARE applied never nukes a healthy session', async () => {
+    // e.g. a secondary/print stylesheet failing after the main one applied.
+    const r = await runWatchdog({ booted: true, stylesApplied: true, autoFireTimer: false });
+    await r.fireError(cssTarget());
+    expect(r.reloads()).toBe(0);
+    expect(r.unregistered()).toBe(0);
+  });
+
+  it('offline: the fast path stands down like the timer path', async () => {
+    const r = await runWatchdog({
+      booted: false,
+      stylesApplied: false,
+      online: false,
+      autoFireTimer: false,
+    });
+    await r.fireError(cssTarget());
+    expect(r.reloads()).toBe(0);
+    expect(r.storage.has(GUARD_KEY)).toBe(false); // guard not burned while offline
   });
 });
 

--- a/tests/unit/documentsDb.test.ts
+++ b/tests/unit/documentsDb.test.ts
@@ -1,7 +1,7 @@
 // Sets a real (in-memory) IndexedDB on the global before documentsDb evaluates,
 // so its module-load `hasIndexedDb` probe sees a store. Must be the first import.
 import 'fake-indexeddb/auto';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import {
   isIdbAvailable,
   idbPutDocument,
@@ -12,6 +12,7 @@ import {
   idbAddSnapshot,
   idbGetSnapshots,
   idbDeleteSnapshots,
+  requestPersistentStorage,
   type StoredDocument,
 } from '@/lib/documentsDb';
 
@@ -86,5 +87,84 @@ describe('documentsDb (fake-indexeddb)', () => {
     const snaps = await idbGetSnapshots('race-doc');
     expect(snaps.map((s) => s.ts).sort((a, b) => a - b)).toEqual([100, 200]);
     await idbDeleteSnapshots('race-doc');
+  });
+});
+
+describe('requestPersistentStorage', () => {
+  // navigator.storage isn't provided by the test DOM — install a stub per test
+  // and always restore, so the suite's other files see the environment they
+  // expect.
+  const setStorage = (stub: unknown) =>
+    Object.defineProperty(navigator, 'storage', { value: stub, configurable: true });
+  const clearDocs = async () => {
+    const all = (await idbGetAllDocuments()) ?? [];
+    for (const d of all) await idbDeleteDocument(d.id);
+  };
+  afterEach(() => {
+    setStorage(undefined);
+  });
+
+  it('returns false (never throws) when the API is unavailable', async () => {
+    setStorage(undefined);
+    await expect(requestPersistentStorage()).resolves.toBe(false);
+  });
+
+  it('already persisted: reports true without re-requesting', async () => {
+    let persistCalls = 0;
+    setStorage({
+      persisted: async () => true,
+      persist: async () => {
+        persistCalls++;
+        return true;
+      },
+    });
+    await expect(requestPersistentStorage()).resolves.toBe(true);
+    expect(persistCalls).toBe(0);
+  });
+
+  it('does not prompt a user with nothing to lose (zero documents)', async () => {
+    await clearDocs();
+    let persistCalls = 0;
+    setStorage({
+      persisted: async () => false,
+      persist: async () => {
+        persistCalls++;
+        return true;
+      },
+    });
+    await expect(requestPersistentStorage()).resolves.toBe(false);
+    expect(persistCalls).toBe(0);
+  });
+
+  it('requests persistence once the user has documents at risk', async () => {
+    await idbPutDocument(doc('persist-1'));
+    let persistCalls = 0;
+    setStorage({
+      persisted: async () => false,
+      persist: async () => {
+        persistCalls++;
+        return true;
+      },
+    });
+    await expect(requestPersistentStorage()).resolves.toBe(true);
+    expect(persistCalls).toBe(1);
+    await idbDeleteDocument('persist-1');
+  });
+
+  it('a denied request reports false without throwing', async () => {
+    await idbPutDocument(doc('persist-2'));
+    setStorage({ persisted: async () => false, persist: async () => false });
+    await expect(requestPersistentStorage()).resolves.toBe(false);
+    await idbDeleteDocument('persist-2');
+  });
+
+  it('a throwing persisted() degrades to false, never an unhandled rejection', async () => {
+    setStorage({
+      persisted: async () => {
+        throw new Error('blocked by policy');
+      },
+      persist: async () => true,
+    });
+    await expect(requestPersistentStorage()).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

Users on machines with a wedged service-worker state hit an unstyled white page on **every refresh** of dondocs.marines.dev, recovering only after 3–5 seconds. Diagnosis against the live site:

- The edge and origin are healthy (HTML and `sw.js` are `no-cache`/revalidated; hashed assets immutable) — the stale shell comes from inside the browser: a service worker serving a shell whose stylesheet no longer exists (404) → unstyled paint.
- The 3–5s recovery is the silent fresh-visit auto-update, not the boot watchdog — the watchdog only fired at 10s.
- Recurrence points at storage eviction: disk pressure evicts the SW precache out from under an installed worker, and nothing ever asked the browser to protect the origin's storage.

## Fix (two layers)

1. **Fast heal** — the failed stylesheet's own `error` event (capture phase; resource errors don't bubble) now triggers the watchdog's one-shot recovery the moment the 404 lands, instead of after 10 seconds. All existing guards carry over: only our `/assets/` stylesheets qualify, a styled session is never touched, offline stands down, per-shell guard prevents loops. The 10s timer remains as the backstop for blank/hung shells.
2. **Root cause** — `navigator.storage.persist()` is requested once the user has saved documents (never on an empty first visit). Persistence protects IndexedDB, Cache Storage, and the SW registration from eviction — removing the mechanism that creates the broken state. The request runs before the storage-health probe, so the existing notice reflects the post-grant state.

## Verification

- Regression suite executes the real inline watchdog script through both triggers: 14 tests including immediate heal on CSS failure, no double-heal when the timer fires after, non-shell resources ignored, healthy-session and offline stand-downs, and the capture-phase pin.
- 6 new unit tests for `requestPersistentStorage` (already-persisted, zero-docs no-prompt, request-once, denial, throwing API).
- Full unit suite 1720 green; production build + CDN guard pass.
- Built artifact verified live: both triggers present in the shipped shell; injecting a failing `/assets/` stylesheet into a healthy page does **not** reload it (guard unburned).

Note: #219 (unmerged) also carries a 1.2.107 changelog entry — whichever lands second renumbers on rebase.