### PR TITLE
feat(import): open an existing naval letter from a PDF (1.2.110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,22 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
-## [1.2.108] — 2026-07-18
+## [1.2.109] — 2026-07-18
+
+### Added
+
+- **Import a letter from a PDF.** Save → "Import letter from PDF…" opens an
+  existing naval letter and reads it back into the editor as a new document —
+  the From/To/Via/Subj header, the SSIC / serial / date, the reference and
+  enclosure lists, the numbered-paragraph tree, and the signer's name. The old
+  way to reuse a letter you only had as a PDF was to retype it; now it's a file
+  pick and a review. The whole read happens in your browser through the pdf.js
+  already bundled for the preview — nothing is uploaded, so it's fine on
+  NMCI/air-gapped networks. It's a best-effort parse: a review dialog shows
+  every recognized field before anything is written, the letter opens as a new
+  document so your current one is untouched, and you check the fields after.
+  Text-based PDFs only — a scanned image has no text to read (that's a later
+  feature).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
 
 - **Import a letter from a PDF.** Save → "Import letter from PDF…" opens an
   existing naval letter and reads it back into the editor as a new document —
-  the From/To/Via/Subj header, the SSIC / serial / date, the reference and
-  enclosure lists, the numbered-paragraph tree, and the signer's name. The old
+  the From/To/Via/Subj header, the SSIC / serial / date, the reference,
+  enclosure, and copy-to lists, the numbered-paragraph tree, and the signer's
+  name (multiple Via addressees import as separate lines, so the letter
+  re-numbers them correctly). The old
   way to reuse a letter you only had as a PDF was to retype it; now it's a file
   pick and a review. The whole read happens in your browser through the pdf.js
   already bundled for the preview — nothing is uploaded, so it's fine on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,28 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
 
 ### Added
 
-- **Import a letter from a PDF.** Save → "Import letter from PDF…" opens an
-  existing naval letter and reads it back into the editor as a new document —
+- **Import a letter from a PDF or Word document.** Save → "Import letter…" opens
+  an existing letter and reads it back into the editor as a new document —
   the From/To/Via/Subj header, the SSIC / serial / date, the reference,
   enclosure, and copy-to lists, the numbered-paragraph tree, and the signer's
   name (multiple Via addressees import as separate lines, so the letter
   re-numbers them correctly). The old
-  way to reuse a letter you only had as a PDF was to retype it; now it's a file
-  pick and a review. The whole read happens in your browser through the pdf.js
-  already bundled for the preview — nothing is uploaded, so it's fine on
-  NMCI/air-gapped networks. It's a best-effort parse: a review dialog shows
+  way to reuse a letter you only had as a file was to retype it; now it's a file
+  pick and a review. The whole read happens in your browser — PDFs through the
+  pdf.js already bundled for the preview, Word (.docx) files through the same
+  pandoc engine that powers DOCX export — so nothing is uploaded and it's fine
+  on NMCI/air-gapped networks. It's a best-effort parse: a review dialog shows
   every recognized field before anything is written, the letter opens as a new
   document so your current one is untouched, and you check the fields after.
-  Text-based PDFs only — a scanned image has no text to read (that's a later
-  feature).
+  Text-based PDFs and .docx only — a scanned image has no text to read (that's a
+  later feature).
+- **The importer detects the document type.** It reads the file's text for the
+  tell-tale opener — an endorsement line, "MEMORANDUM FOR THE RECORD",
+  "MEMORANDUM OF AGREEMENT/UNDERSTANDING", or a From/To/Subj letter skeleton —
+  and pre-selects the matching type in the review dialog. When the type is clear
+  it says so; when it can't be sure (a bare "MEMORANDUM", or only partial
+  addressing) it flags the guess and asks you to confirm from the full list of
+  importable types before the letter opens.
 
 ## [1.2.109] — 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,11 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
   every recognized field before anything is written, the letter opens as a new
   document so your current one is untouched, and you check the fields after.
   Text-based PDFs and .docx only — a scanned image has no text to read (that's a
-  later feature).
+  later feature). The file type is detected from its contents (magic bytes) as
+  well as its name, so a Word document saved with the wrong extension still
+  imports; and the header block of a real letterhead Word document — which the
+  converter lays out as a table — is read correctly (From/To/Via/Subj and the
+  SSIC/serial/date) rather than skipped.
 - **The importer detects the document type.** It reads the file's text for the
   tell-tale opener — an endorsement line, "MEMORANDUM FOR THE RECORD",
   "MEMORANDUM OF AGREEMENT/UNDERSTANDING", or a From/To/Subj letter skeleton —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ Releases before 1.2.0 predate this file and are recorded only as git tags.
   it says so; when it can't be sure (a bare "MEMORANDUM", or only partial
   addressing) it flags the guess and asks you to confirm from the full list of
   importable types before the letter opens.
+- **The importer carries classification across.** When the source is marked, it
+  reads the banner (UNCLASSIFIED / CUI / CONFIDENTIAL / SECRET / TOP SECRET /
+  TOP SECRET//SCI — highest wins), the derivative-classification authority block
+  ("Classified by / Derived from / Declassify on / Reason"), and the
+  per-paragraph portion markings, and pre-sets the Classification section from
+  them. For Word files the banner lives in the page header/footer, which the
+  body read skips, so those parts are read directly from the .docx. Anything
+  above Unclassified is called out in the review dialog with a reminder to
+  verify the marking before you export; an unmarked file stays Unclassified.
 
 ## [1.2.109] — 2026-07-18
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dondocs",
-  "version": "1.2.108",
+  "version": "1.2.109",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dondocs",
-      "version": "1.2.108",
+      "version": "1.2.109",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.108",
+  "version": "1.2.109",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const MobilePreviewModal = lazy(() =>
   }))
 );
 import { AboutModal } from '@/components/modals/AboutModal';
+import { ImportLetterModal } from '@/components/modals/ImportLetterModal';
 import { NISTComplianceModal } from '@/components/modals/NISTComplianceModal';
 import { BatchModal } from '@/components/modals/BatchModal';
 import { FindReplaceModal } from '@/components/modals/FindReplaceModal';
@@ -1980,6 +1981,7 @@ ${texFiles['body.tex'] || '% No body content'}
       )}
       <AboutModal />
       <NISTComplianceModal />
+      <ImportLetterModal />
       {commandPaletteOpen && (
         <CommandPalette
           open

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -849,7 +849,7 @@ export function Header({
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => setImportLetterModalOpen(true)}>
                 <FileUp className="h-4 w-4 mr-2" />
-                Import letter from PDF…
+                Import letter from PDF or Word…
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">Backup file (.json)</DropdownMenuLabel>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -183,6 +183,7 @@ export function Header({
   const setAboutModalOpen = useUIStore((s) => s.setAboutModalOpen);
   const setNistModalOpen = useUIStore((s) => s.setNistModalOpen);
   const setBatchModalOpen = useUIStore((s) => s.setBatchModalOpen);
+  const setImportLetterModalOpen = useUIStore((s) => s.setImportLetterModalOpen);
   const setDocumentGuideOpen = useUIStore((s) => s.setDocumentGuideOpen);
   const setFindReplaceOpen = useUIStore((s) => s.setFindReplaceOpen);
   const setCommandPaletteOpen = useUIStore((s) => s.setCommandPaletteOpen);
@@ -845,6 +846,10 @@ export function Header({
               <DropdownMenuItem onClick={() => setShareModal('import')}>
                 <FileInput className="h-4 w-4 mr-2" />
                 Open from share link
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setImportLetterModalOpen(true)}>
+                <FileUp className="h-4 w-4 mr-2" />
+                Import letter from PDF…
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">Backup file (.json)</DropdownMenuLabel>

--- a/src/components/modals/ImportLetterModal.tsx
+++ b/src/components/modals/ImportLetterModal.tsx
@@ -1,0 +1,181 @@
+import { useState, useCallback } from 'react';
+import { FileUp, Loader2, AlertTriangle, FileText } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useUIStore } from '@/stores/uiStore';
+import { parseLetterFile, hasParsedContent, applyParsedLetter } from '@/lib/importLetter';
+import type { ParsedLetter } from '@/lib/parseNavalLetter';
+import { abbreviatedSignatoryName } from '@/lib/signatoryName';
+
+type Phase =
+  | { kind: 'idle' }
+  | { kind: 'parsing' }
+  | { kind: 'review'; parsed: ParsedLetter }
+  | { kind: 'error'; message: string };
+
+/** One "Label: value" row in the review summary; hidden when nothing parsed. */
+function Row({ label, value }: { label: string; value?: string | number }) {
+  if (value === undefined || value === '' || value === 0) return null;
+  return (
+    <div className="flex gap-2 text-sm">
+      <span className="w-28 shrink-0 font-medium text-muted-foreground">{label}</span>
+      <span className="min-w-0 break-words">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Import an existing naval letter from a PDF: read its text (offline, via the
+ * bundled pdf.js), parse the SECNAV structure, show what was recognized, and
+ * on confirm open it as a new editable document. Best-effort — the review step
+ * exists because parsing can't be perfect, and the letter opens for editing
+ * either way. Scanned/image PDFs have no text to read (OCR is out of scope).
+ */
+export function ImportLetterModal() {
+  const open = useUIStore((s) => s.importLetterModalOpen);
+  const setOpen = useUIStore((s) => s.setImportLetterModalOpen);
+  const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
+
+  const reset = useCallback(() => setPhase({ kind: 'idle' }), []);
+
+  const onOpenChange = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      if (!next) reset(); // start fresh next time it opens
+    },
+    [setOpen, reset]
+  );
+
+  const handleFile = useCallback(async (file: File) => {
+    setPhase({ kind: 'parsing' });
+    try {
+      const parsed = await parseLetterFile(file);
+      if (!hasParsedContent(parsed)) {
+        setPhase({
+          kind: 'error',
+          message:
+            "Couldn't find letter text in this PDF. If it's a scan or image, text import can't read it yet.",
+        });
+        return;
+      }
+      setPhase({ kind: 'review', parsed });
+    } catch {
+      setPhase({ kind: 'error', message: 'This PDF could not be read. It may be corrupt or protected.' });
+    }
+  }, []);
+
+  const doImport = useCallback(
+    (parsed: ParsedLetter) => {
+      applyParsedLetter(parsed);
+      onOpenChange(false);
+    },
+    [onOpenChange]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FileUp className="h-5 w-5 text-primary" />
+            Import a letter
+          </DialogTitle>
+          <DialogDescription>
+            Open an existing naval letter from a PDF as a new editable document. Everything is read
+            in your browser — nothing is uploaded.
+          </DialogDescription>
+        </DialogHeader>
+
+        {phase.kind === 'idle' && (
+          <label className="flex cursor-pointer flex-col items-center gap-2 rounded-md border-2 border-dashed border-border p-8 text-center transition-colors hover:border-primary/50 hover:bg-secondary/30">
+            <FileUp className="h-6 w-6 text-muted-foreground" />
+            <span className="text-sm font-medium">Choose a PDF to import</span>
+            <span className="text-xs text-muted-foreground">
+              Text-based PDFs only — a scanned image can&apos;t be read yet.
+            </span>
+            <input
+              type="file"
+              accept=".pdf,application/pdf"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) void handleFile(file);
+                e.target.value = '';
+              }}
+            />
+          </label>
+        )}
+
+        {phase.kind === 'parsing' && (
+          <div className="flex flex-col items-center gap-2 py-10 text-sm text-muted-foreground">
+            <Loader2 className="h-6 w-6 animate-spin" />
+            Reading the letter…
+          </div>
+        )}
+
+        {phase.kind === 'error' && (
+          <div className="flex flex-col items-center gap-3 py-8 text-center">
+            <AlertTriangle className="h-6 w-6 text-warning" />
+            <p className="text-sm text-muted-foreground">{phase.message}</p>
+            <Button variant="outline" size="sm" onClick={reset}>
+              Choose a different file
+            </Button>
+          </div>
+        )}
+
+        {phase.kind === 'review' && (
+          <ReviewBody parsed={phase.parsed} onBack={reset} onImport={() => doImport(phase.parsed)} />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ReviewBody({
+  parsed,
+  onBack,
+  onImport,
+}: {
+  parsed: ParsedLetter;
+  onBack: () => void;
+  onImport: () => void;
+}) {
+  const sig = parsed.signature
+    ? abbreviatedSignatoryName(parsed.signature.first, parsed.signature.middle, parsed.signature.last)
+    : undefined;
+  return (
+    <>
+      <div className="space-y-1.5 rounded-md border border-border bg-secondary/20 p-3">
+        <Row label="From" value={parsed.from} />
+        <Row label="To" value={parsed.to} />
+        <Row label="Via" value={parsed.via} />
+        <Row label="Subj" value={parsed.subject} />
+        <Row label="SSIC" value={parsed.ssic} />
+        <Row label="Serial" value={parsed.serial} />
+        <Row label="Date" value={parsed.date} />
+        <Row label="References" value={parsed.references.length} />
+        <Row label="Enclosures" value={parsed.enclosures.length} />
+        <Row label="Paragraphs" value={parsed.paragraphs.length} />
+        <Row label="Signature" value={sig} />
+      </div>
+      <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+        <FileText className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+        This is a best-effort read — check every field after importing. The letter opens as a new
+        document, so your current one is kept.
+      </p>
+      <DialogFooter>
+        <Button variant="outline" onClick={onBack}>
+          Choose a different file
+        </Button>
+        <Button onClick={onImport}>Import into editor</Button>
+      </DialogFooter>
+    </>
+  );
+}

--- a/src/components/modals/ImportLetterModal.tsx
+++ b/src/components/modals/ImportLetterModal.tsx
@@ -162,6 +162,7 @@ function ReviewBody({
         <Row label="Date" value={parsed.date} />
         <Row label="References" value={parsed.references.length} />
         <Row label="Enclosures" value={parsed.enclosures.length} />
+        <Row label="Copy to" value={parsed.copyTos.length} />
         <Row label="Paragraphs" value={parsed.paragraphs.length} />
         <Row label="Signature" value={sig} />
       </div>

--- a/src/components/modals/ImportLetterModal.tsx
+++ b/src/components/modals/ImportLetterModal.tsx
@@ -22,6 +22,7 @@ import {
   hasParsedContent,
   applyParsedLetter,
   isDocxFile,
+  isLegacyDocFile,
   type ParsedImport,
 } from '@/lib/importLetter';
 import { IMPORTABLE_DOC_TYPES } from '@/lib/detectDocumentType';
@@ -71,6 +72,16 @@ export function ImportLetterModal() {
   );
 
   const handleFile = useCallback(async (file: File) => {
+    // Legacy binary .doc can't be read by either engine — catch it up front with
+    // a message that tells the drafter how to proceed, not a vague failure.
+    if (isLegacyDocFile(file)) {
+      setPhase({
+        kind: 'error',
+        message:
+          'Legacy Word “.doc” files can’t be imported. Open it in Word and save as “.docx” (or print to PDF), then import that.',
+      });
+      return;
+    }
     setPhase({ kind: 'parsing' });
     const docx = isDocxFile(file);
     try {

--- a/src/components/modals/ImportLetterModal.tsx
+++ b/src/components/modals/ImportLetterModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { FileUp, Loader2, AlertTriangle, FileText, Info } from 'lucide-react';
+import { FileUp, Loader2, AlertTriangle, FileText, Info, ShieldAlert } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -19,6 +19,7 @@ import { Button } from '@/components/ui/button';
 import { useUIStore } from '@/stores/uiStore';
 import { parseLetterFile, hasParsedContent, applyParsedLetter, type ParsedImport } from '@/lib/importLetter';
 import { IMPORTABLE_DOC_TYPES } from '@/lib/detectDocumentType';
+import { CLASSIFICATION_LABELS } from '@/lib/detectClassification';
 import { DOC_TYPE_LABELS } from '@/types/document';
 import { abbreviatedSignatoryName } from '@/lib/signatoryName';
 
@@ -85,7 +86,7 @@ export function ImportLetterModal() {
 
   const doImport = useCallback(
     (result: ParsedImport, docType: string) => {
-      applyParsedLetter(result.parsed, docType);
+      applyParsedLetter(result.parsed, docType, result.classification);
       onOpenChange(false);
     },
     [onOpenChange]
@@ -163,9 +164,12 @@ function ReviewBody({
   onBack: () => void;
   onImport: (docType: string) => void;
 }) {
-  const { parsed, detection } = result;
+  const { parsed, detection, classification } = result;
   const [docType, setDocType] = useState(detection.docType);
   const lowConfidence = detection.confidence === 'low';
+  // Surface a classification marking when one was read from the source, and
+  // treat anything above Unclassified as needing the drafter's eye.
+  const classified = classification.found && classification.classLevel !== 'unclassified';
 
   const sig = parsed.signature
     ? abbreviatedSignatoryName(parsed.signature.first, parsed.signature.middle, parsed.signature.last)
@@ -186,7 +190,26 @@ function ReviewBody({
         <Row label="Copy to" value={parsed.copyTos.length} />
         <Row label="Paragraphs" value={parsed.paragraphs.length} />
         <Row label="Signature" value={sig} />
+        <Row
+          label="Classification"
+          value={classification.found ? CLASSIFICATION_LABELS[classification.classLevel] : undefined}
+        />
+        <Row label="Classified by" value={classification.classifiedBy} />
+        <Row label="Derived from" value={classification.derivedFrom} />
+        <Row label="Declassify on" value={classification.declassifyOn} />
       </div>
+
+      {/* Classification is safety-critical: when the source was marked, call it
+          out explicitly and note that the drafter still owns the marking. */}
+      {classification.found && (
+        <p
+          className={`flex items-start gap-1.5 text-xs ${classified ? 'text-warning' : 'text-muted-foreground'}`}
+        >
+          <ShieldAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          {classification.reason}
+          {classified && ' It carries into the Classification section — verify it there before you export.'}
+        </p>
+      )}
 
       {/* Document-type picker: pre-selected to the importer's guess. When the
           guess is uncertain we say so and ask the drafter to confirm. */}

--- a/src/components/modals/ImportLetterModal.tsx
+++ b/src/components/modals/ImportLetterModal.tsx
@@ -17,11 +17,18 @@ import {
 } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { useUIStore } from '@/stores/uiStore';
-import { parseLetterFile, hasParsedContent, applyParsedLetter, type ParsedImport } from '@/lib/importLetter';
+import {
+  parseLetterFile,
+  hasParsedContent,
+  applyParsedLetter,
+  isDocxFile,
+  type ParsedImport,
+} from '@/lib/importLetter';
 import { IMPORTABLE_DOC_TYPES } from '@/lib/detectDocumentType';
 import { CLASSIFICATION_LABELS } from '@/lib/detectClassification';
 import { DOC_TYPE_LABELS } from '@/types/document';
 import { abbreviatedSignatoryName } from '@/lib/signatoryName';
+import { debug } from '@/lib/debug';
 
 type Phase =
   | { kind: 'idle' }
@@ -65,29 +72,45 @@ export function ImportLetterModal() {
 
   const handleFile = useCallback(async (file: File) => {
     setPhase({ kind: 'parsing' });
+    const docx = isDocxFile(file);
     try {
       const result = await parseLetterFile(file);
       if (!hasParsedContent(result.parsed)) {
         setPhase({
           kind: 'error',
-          message:
-            "Couldn't find letter text in this file. If it's a scan or image PDF, text import can't read it yet.",
+          message: docx
+            ? "Couldn't find any letter text in this Word document — it may be empty or hold only images."
+            : "Couldn't find letter text in this PDF. If it's a scan or image, text import can't read it yet.",
         });
         return;
       }
       setPhase({ kind: 'review', result });
-    } catch {
+    } catch (err) {
+      // Surface the failure to the user and log the cause for diagnosis — a
+      // failed DOCX read on an air-gapped host is usually the pandoc engine not
+      // loading, which the generic "corrupt file" wording would hide.
+      debug.error('Import', `Failed to read ${docx ? 'DOCX' : 'PDF'} for import`, err);
       setPhase({
         kind: 'error',
-        message: 'This file could not be read. It may be corrupt, protected, or an unsupported format.',
+        message: docx
+          ? 'This Word document could not be read. It may be corrupt or password-protected, or the document engine could not start.'
+          : 'This PDF could not be read. It may be corrupt or password-protected.',
       });
     }
   }, []);
 
   const doImport = useCallback(
     (result: ParsedImport, docType: string) => {
-      applyParsedLetter(result.parsed, docType, result.classification);
-      onOpenChange(false);
+      try {
+        applyParsedLetter(result.parsed, docType, result.classification);
+        onOpenChange(false);
+      } catch (err) {
+        debug.error('Import', 'Failed to apply the parsed letter to the editor', err);
+        setPhase({
+          kind: 'error',
+          message: 'The letter was read, but could not be opened in the editor. Please try again.',
+        });
+      }
     },
     [onOpenChange]
   );

--- a/src/components/modals/ImportLetterModal.tsx
+++ b/src/components/modals/ImportLetterModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { FileUp, Loader2, AlertTriangle, FileText } from 'lucide-react';
+import { FileUp, Loader2, AlertTriangle, FileText, Info } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -8,16 +8,24 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { useUIStore } from '@/stores/uiStore';
-import { parseLetterFile, hasParsedContent, applyParsedLetter } from '@/lib/importLetter';
-import type { ParsedLetter } from '@/lib/parseNavalLetter';
+import { parseLetterFile, hasParsedContent, applyParsedLetter, type ParsedImport } from '@/lib/importLetter';
+import { IMPORTABLE_DOC_TYPES } from '@/lib/detectDocumentType';
+import { DOC_TYPE_LABELS } from '@/types/document';
 import { abbreviatedSignatoryName } from '@/lib/signatoryName';
 
 type Phase =
   | { kind: 'idle' }
   | { kind: 'parsing' }
-  | { kind: 'review'; parsed: ParsedLetter }
+  | { kind: 'review'; result: ParsedImport }
   | { kind: 'error'; message: string };
 
 /** One "Label: value" row in the review summary; hidden when nothing parsed. */
@@ -32,9 +40,10 @@ function Row({ label, value }: { label: string; value?: string | number }) {
 }
 
 /**
- * Import an existing naval letter from a PDF: read its text (offline, via the
- * bundled pdf.js), parse the SECNAV structure, show what was recognized, and
- * on confirm open it as a new editable document. Best-effort — the review step
+ * Import an existing naval letter from a PDF or Word document: read its text
+ * (offline, via the bundled pdf.js for PDFs or pandoc WASM for DOCX), parse the
+ * SECNAV structure, guess the document type, show what was recognized, and on
+ * confirm open it as a new editable document. Best-effort — the review step
  * exists because parsing can't be perfect, and the letter opens for editing
  * either way. Scanned/image PDFs have no text to read (OCR is out of scope).
  */
@@ -56,24 +65,27 @@ export function ImportLetterModal() {
   const handleFile = useCallback(async (file: File) => {
     setPhase({ kind: 'parsing' });
     try {
-      const parsed = await parseLetterFile(file);
-      if (!hasParsedContent(parsed)) {
+      const result = await parseLetterFile(file);
+      if (!hasParsedContent(result.parsed)) {
         setPhase({
           kind: 'error',
           message:
-            "Couldn't find letter text in this PDF. If it's a scan or image, text import can't read it yet.",
+            "Couldn't find letter text in this file. If it's a scan or image PDF, text import can't read it yet.",
         });
         return;
       }
-      setPhase({ kind: 'review', parsed });
+      setPhase({ kind: 'review', result });
     } catch {
-      setPhase({ kind: 'error', message: 'This PDF could not be read. It may be corrupt or protected.' });
+      setPhase({
+        kind: 'error',
+        message: 'This file could not be read. It may be corrupt, protected, or an unsupported format.',
+      });
     }
   }, []);
 
   const doImport = useCallback(
-    (parsed: ParsedLetter) => {
-      applyParsedLetter(parsed);
+    (result: ParsedImport, docType: string) => {
+      applyParsedLetter(result.parsed, docType);
       onOpenChange(false);
     },
     [onOpenChange]
@@ -88,21 +100,21 @@ export function ImportLetterModal() {
             Import a letter
           </DialogTitle>
           <DialogDescription>
-            Open an existing naval letter from a PDF as a new editable document. Everything is read
-            in your browser — nothing is uploaded.
+            Open an existing letter from a PDF or Word document as a new editable document.
+            Everything is read in your browser — nothing is uploaded.
           </DialogDescription>
         </DialogHeader>
 
         {phase.kind === 'idle' && (
           <label className="flex cursor-pointer flex-col items-center gap-2 rounded-md border-2 border-dashed border-border p-8 text-center transition-colors hover:border-primary/50 hover:bg-secondary/30">
             <FileUp className="h-6 w-6 text-muted-foreground" />
-            <span className="text-sm font-medium">Choose a PDF to import</span>
+            <span className="text-sm font-medium">Choose a PDF or Word file to import</span>
             <span className="text-xs text-muted-foreground">
-              Text-based PDFs only — a scanned image can&apos;t be read yet.
+              Text-based PDF (.pdf) or Word (.docx) — a scanned image can&apos;t be read yet.
             </span>
             <input
               type="file"
-              accept=".pdf,application/pdf"
+              accept=".pdf,application/pdf,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
               className="hidden"
               onChange={(e) => {
                 const file = e.target.files?.[0];
@@ -131,7 +143,11 @@ export function ImportLetterModal() {
         )}
 
         {phase.kind === 'review' && (
-          <ReviewBody parsed={phase.parsed} onBack={reset} onImport={() => doImport(phase.parsed)} />
+          <ReviewBody
+            result={phase.result}
+            onBack={reset}
+            onImport={(docType) => doImport(phase.result, docType)}
+          />
         )}
       </DialogContent>
     </Dialog>
@@ -139,17 +155,22 @@ export function ImportLetterModal() {
 }
 
 function ReviewBody({
-  parsed,
+  result,
   onBack,
   onImport,
 }: {
-  parsed: ParsedLetter;
+  result: ParsedImport;
   onBack: () => void;
-  onImport: () => void;
+  onImport: (docType: string) => void;
 }) {
+  const { parsed, detection } = result;
+  const [docType, setDocType] = useState(detection.docType);
+  const lowConfidence = detection.confidence === 'low';
+
   const sig = parsed.signature
     ? abbreviatedSignatoryName(parsed.signature.first, parsed.signature.middle, parsed.signature.last)
     : undefined;
+
   return (
     <>
       <div className="space-y-1.5 rounded-md border border-border bg-secondary/20 p-3">
@@ -166,6 +187,39 @@ function ReviewBody({
         <Row label="Paragraphs" value={parsed.paragraphs.length} />
         <Row label="Signature" value={sig} />
       </div>
+
+      {/* Document-type picker: pre-selected to the importer's guess. When the
+          guess is uncertain we say so and ask the drafter to confirm. */}
+      <div className="space-y-1.5">
+        <label htmlFor="import-doc-type" className="text-sm font-medium">
+          Document type
+        </label>
+        <Select value={docType} onValueChange={setDocType}>
+          <SelectTrigger id="import-doc-type" className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {IMPORTABLE_DOC_TYPES.map((t) => (
+              <SelectItem key={t} value={t}>
+                {DOC_TYPE_LABELS[t] ?? t}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p
+          className={`flex items-start gap-1.5 text-xs ${
+            lowConfidence ? 'text-warning' : 'text-muted-foreground'
+          }`}
+        >
+          {lowConfidence ? (
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          ) : (
+            <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          )}
+          {detection.reason}
+        </p>
+      </div>
+
       <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
         <FileText className="mt-0.5 h-3.5 w-3.5 shrink-0" />
         This is a best-effort read — check every field after importing. The letter opens as a new
@@ -175,7 +229,7 @@ function ReviewBody({
         <Button variant="outline" onClick={onBack}>
           Choose a different file
         </Button>
-        <Button onClick={onImport}>Import into editor</Button>
+        <Button onClick={() => onImport(docType)}>Import into editor</Button>
       </DialogFooter>
     </>
   );

--- a/src/lib/detectClassification.ts
+++ b/src/lib/detectClassification.ts
@@ -109,7 +109,16 @@ export function detectClassification(rawText: string): ClassificationDetection {
     }
   }
 
-  const hasAuthority = Object.keys(authority).length > 0;
+  // "Classified by / Derived from / Declassify on" are unambiguous authority-block
+  // labels; "Reason:" is not — it appears in ordinary prose — so it only counts
+  // as a classification field when one of the strong labels is also present.
+  const hasStrongAuthority =
+    authority.classifiedBy !== undefined ||
+    authority.derivedFrom !== undefined ||
+    authority.declassifyOn !== undefined;
+  if (!hasStrongAuthority) delete authority.classReason;
+
+  const hasAuthority = hasStrongAuthority;
   const classLevel = banner?.level ?? 'unclassified';
   const found = banner !== null || hasAuthority;
 

--- a/src/lib/detectClassification.ts
+++ b/src/lib/detectClassification.ts
@@ -32,16 +32,24 @@ export interface ClassificationDetection {
 
 // A standalone banner line → its level. Order matters: the most specific /
 // highest markings are tested first so "TOP SECRET//SCI" isn't read as plain
-// "TOP SECRET", and "SECRET" doesn't swallow a "TOP SECRET" line. Each anchors
-// the whole (trimmed) line and tolerates a trailing "//" control string
-// (e.g. "SECRET//NOFORN") without changing the base level.
+// "TOP SECRET", and "SECRET" doesn't swallow a "TOP SECRET" line.
+//
+// Each pattern anchors the WHOLE (trimmed) line: the base marking, optionally
+// followed by a "//" control string (e.g. "SECRET//NOFORN", "CUI//SP-CTI").
+// Requiring the trailer to start with "//" is deliberate — it keeps a prose
+// line that merely starts with the word ("SECRET SERVICE DETAIL",
+// "CONFIDENTIAL sources report…") from being mistaken for a banner.
+const TRAILER = String.raw`(?:\s*\/\/.*)?$`;
 const BANNER_MARKINGS: { re: RegExp; level: ClassificationLevel; label: string }[] = [
-  { re: /^top\s+secret\s*\/\/\s*sci\b.*$/i, level: 'top_secret_sci', label: 'TOP SECRET//SCI' },
-  { re: /^top\s+secret\b.*$/i, level: 'top_secret', label: 'TOP SECRET' },
-  { re: /^secret\b.*$/i, level: 'secret', label: 'SECRET' },
-  { re: /^confidential\b.*$/i, level: 'confidential', label: 'CONFIDENTIAL' },
-  { re: /^(?:cui|controlled\s+unclassified\s+information)\b.*$/i, level: 'cui', label: 'CUI' },
-  { re: /^unclassified\b.*$/i, level: 'unclassified', label: 'UNCLASSIFIED' },
+  { re: new RegExp(String.raw`^top\s+secret\s*\/\/\s*sci${TRAILER}`, 'i'), level: 'top_secret_sci', label: 'TOP SECRET//SCI' },
+  { re: new RegExp(String.raw`^top\s+secret${TRAILER}`, 'i'), level: 'top_secret', label: 'TOP SECRET' },
+  { re: new RegExp(String.raw`^secret${TRAILER}`, 'i'), level: 'secret', label: 'SECRET' },
+  { re: new RegExp(String.raw`^confidential${TRAILER}`, 'i'), level: 'confidential', label: 'CONFIDENTIAL' },
+  { re: new RegExp(String.raw`^(?:cui|controlled\s+unclassified\s+information)${TRAILER}`, 'i'), level: 'cui', label: 'CUI' },
+  // Legacy FOUO banner (retired into CUI, DoDI 5200.48) — common on older
+  // Marine correspondence, so recognize it and map it to CUI.
+  { re: new RegExp(String.raw`^(?:for\s+official\s+use\s+only|unclassified\s*\/\/\s*fouo)${TRAILER}`, 'i'), level: 'cui', label: 'CUI (FOUO)' },
+  { re: new RegExp(String.raw`^unclassified${TRAILER}`, 'i'), level: 'unclassified', label: 'UNCLASSIFIED' },
 ];
 
 const LEVEL_RANK: Record<ClassificationLevel, number> = {

--- a/src/lib/detectClassification.ts
+++ b/src/lib/detectClassification.ts
@@ -1,0 +1,120 @@
+/**
+ * Best-effort read of an imported document's security classification from its
+ * extracted text: the overall banner marking (top/bottom of every page) and, if
+ * the document is classified, the derivative-classification authority block at
+ * the foot ("Classified by / Derived from / Declassify on / Reason").
+ *
+ * The banner is the authority for the overall level — "highest classification
+ * wins" (DoDM 5200.01 Vol 2), so we take the highest marking found among the
+ * standalone banner lines. Portion markings inside paragraphs are recovered
+ * separately by the letter parser; this module reads only the document-level
+ * markings so the importer can pre-set the Classification section.
+ *
+ * Pure and leaf — unit-tested against text fixtures, independent of whether the
+ * text came from a PDF or a DOCX.
+ */
+
+import type { ClassificationLevel } from '@/lib/domainClassification';
+
+export interface ClassificationDetection {
+  /** The detected banner level; 'unclassified' when nothing was marked. */
+  classLevel: ClassificationLevel;
+  /** Derivative-classification authority block, when the document carries one. */
+  classifiedBy?: string;
+  derivedFrom?: string;
+  declassifyOn?: string;
+  classReason?: string;
+  /** True when any classification marking (banner or authority line) was found. */
+  found: boolean;
+  /** Human-readable summary for the review UI. */
+  reason: string;
+}
+
+// A standalone banner line → its level. Order matters: the most specific /
+// highest markings are tested first so "TOP SECRET//SCI" isn't read as plain
+// "TOP SECRET", and "SECRET" doesn't swallow a "TOP SECRET" line. Each anchors
+// the whole (trimmed) line and tolerates a trailing "//" control string
+// (e.g. "SECRET//NOFORN") without changing the base level.
+const BANNER_MARKINGS: { re: RegExp; level: ClassificationLevel; label: string }[] = [
+  { re: /^top\s+secret\s*\/\/\s*sci\b.*$/i, level: 'top_secret_sci', label: 'TOP SECRET//SCI' },
+  { re: /^top\s+secret\b.*$/i, level: 'top_secret', label: 'TOP SECRET' },
+  { re: /^secret\b.*$/i, level: 'secret', label: 'SECRET' },
+  { re: /^confidential\b.*$/i, level: 'confidential', label: 'CONFIDENTIAL' },
+  { re: /^(?:cui|controlled\s+unclassified\s+information)\b.*$/i, level: 'cui', label: 'CUI' },
+  { re: /^unclassified\b.*$/i, level: 'unclassified', label: 'UNCLASSIFIED' },
+];
+
+const LEVEL_RANK: Record<ClassificationLevel, number> = {
+  unclassified: 0,
+  cui: 1,
+  confidential: 2,
+  secret: 3,
+  top_secret: 4,
+  top_secret_sci: 5,
+};
+
+/** Human label for a detected level, for the review summary. */
+export const CLASSIFICATION_LABELS: Record<ClassificationLevel, string> = {
+  unclassified: 'UNCLASSIFIED',
+  cui: 'CUI',
+  confidential: 'CONFIDENTIAL',
+  secret: 'SECRET',
+  top_secret: 'TOP SECRET',
+  top_secret_sci: 'TOP SECRET//SCI',
+};
+
+// Derivative-classification authority block labels (DoDM 5200.01 Vol 2 §7).
+const AUTHORITY_LABELS: { key: 'classifiedBy' | 'derivedFrom' | 'declassifyOn' | 'classReason'; re: RegExp }[] = [
+  { key: 'classifiedBy', re: /^classified\s+by\s*:/i },
+  { key: 'derivedFrom', re: /^derived\s+from\s*:/i },
+  { key: 'declassifyOn', re: /^declassify\s+on\s*:/i },
+  { key: 'classReason', re: /^reason\s*:/i },
+];
+
+/** The banner level of a standalone line, or null if it isn't a banner. */
+function bannerLevelOf(line: string): { level: ClassificationLevel; label: string } | null {
+  for (const m of BANNER_MARKINGS) {
+    if (m.re.test(line)) return { level: m.level, label: m.label };
+  }
+  return null;
+}
+
+export function detectClassification(rawText: string): ClassificationDetection {
+  const lines = rawText.replace(/\r\n?/g, '\n').split('\n');
+
+  // Highest standalone banner marking wins.
+  let banner: { level: ClassificationLevel; label: string } | null = null;
+  const authority: Partial<Record<'classifiedBy' | 'derivedFrom' | 'declassifyOn' | 'classReason', string>> = {};
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+
+    const b = bannerLevelOf(line);
+    if (b && (!banner || LEVEL_RANK[b.level] > LEVEL_RANK[banner.level])) banner = b;
+
+    for (const a of AUTHORITY_LABELS) {
+      if (authority[a.key] === undefined && a.re.test(line)) {
+        const value = line.slice(line.indexOf(':') + 1).trim();
+        if (value) authority[a.key] = value;
+      }
+    }
+  }
+
+  const hasAuthority = Object.keys(authority).length > 0;
+  const classLevel = banner?.level ?? 'unclassified';
+  const found = banner !== null || hasAuthority;
+
+  let reason: string;
+  if (banner && banner.level !== 'unclassified') {
+    reason = `Detected a ${banner.label} banner${hasAuthority ? ' and a classification authority block' : ''}.`;
+  } else if (banner) {
+    reason = 'Marked UNCLASSIFIED.';
+  } else if (hasAuthority) {
+    reason = 'Found a classification authority block but no banner — please confirm the level.';
+  } else {
+    reason = 'No classification marking found — set to Unclassified.';
+  }
+
+  return { classLevel, ...authority, found, reason };
+}

--- a/src/lib/detectDocumentType.ts
+++ b/src/lib/detectDocumentType.ts
@@ -1,0 +1,101 @@
+/**
+ * Best-effort guess at which DonDocs document type an imported file is, from its
+ * extracted text. Naval correspondence carries strong, recognizable openers
+ * (an endorsement line, "MEMORANDUM FOR THE RECORD", "MEMORANDUM OF
+ * AGREEMENT", …); when one is present we're confident, and when the text is a
+ * plain From/To/Subj letter or an unqualified memorandum we say so, so the
+ * import flow can prompt the drafter to confirm instead of guessing wrong.
+ *
+ * Pure and leaf — the heuristics are unit-tested against text fixtures,
+ * independent of whether the text came from a PDF or a DOCX.
+ */
+
+export interface DocTypeDetection {
+  /** The best-guess DonDocs docType key. */
+  docType: string;
+  /** 'high' when a distinctive marker matched; 'low' when the drafter should confirm. */
+  confidence: 'high' | 'low';
+  /** Why (for the review UI): the marker that decided it, or the ambiguity. */
+  reason: string;
+}
+
+/** The document types the importer offers, in the order the picker lists them. */
+export const IMPORTABLE_DOC_TYPES = [
+  'naval_letter',
+  'standard_letter',
+  'business_letter',
+  'multiple_address_letter',
+  'same_page_endorsement',
+  'new_page_endorsement',
+  'plain_paper_memorandum',
+  'letterhead_memorandum',
+  'mfr',
+  'moa',
+  'mou',
+] as const;
+
+// Strong, unambiguous openers → a specific type, high confidence. Tested in order.
+const STRONG_MARKERS: { re: RegExp; docType: string; reason: string }[] = [
+  { re: /memorandum\s+for\s+the\s+record/i, docType: 'mfr', reason: 'Contains "MEMORANDUM FOR THE RECORD".' },
+  { re: /memorandum\s+of\s+agreement/i, docType: 'moa', reason: 'Contains "MEMORANDUM OF AGREEMENT".' },
+  { re: /memorandum\s+of\s+understanding/i, docType: 'mou', reason: 'Contains "MEMORANDUM OF UNDERSTANDING".' },
+  // "FIRST ENDORSEMENT", "SECOND ENDORSEMENT on …", "1st Endorsement". New-page
+  // is always a valid form, so it's the safe default guess for an endorsement.
+  {
+    re: /\b(?:first|second|third|fourth|fifth|\d+(?:st|nd|rd|th))\s+endorsement\b/i,
+    docType: 'new_page_endorsement',
+    reason: 'Contains an endorsement line.',
+  },
+];
+
+const hasLabel = (text: string, label: RegExp) => label.test(text);
+
+export function detectDocumentType(rawText: string): DocTypeDetection {
+  const text = rawText.replace(/\r\n?/g, '\n');
+
+  for (const m of STRONG_MARKERS) {
+    if (m.re.test(text)) return { docType: m.docType, confidence: 'high', reason: m.reason };
+  }
+
+  const hasFrom = hasLabel(text, /^\s*from\s*:/im);
+  const hasTo = hasLabel(text, /^\s*to\s*:/im);
+  const hasSubj = hasLabel(text, /^\s*subj(?:ect)?\s*:/im);
+
+  // A generic "MEMORANDUM" (including "MEMORANDUM FOR <name>") — the family is
+  // clear but the specific memo type isn't, so ask the drafter to confirm.
+  if (/\bmemorandum\b/i.test(text) && !(hasFrom && hasTo && hasSubj)) {
+    return {
+      docType: 'plain_paper_memorandum',
+      confidence: 'low',
+      reason: 'Looks like a memorandum, but the exact memo type is unclear — please confirm.',
+    };
+  }
+
+  // A business letter: salutation + complimentary close, no naval Subj line.
+  if (/^\s*dear\b/im.test(text) && /(sincerely|respectfully|very truly yours)/i.test(text) && !hasSubj) {
+    return { docType: 'business_letter', confidence: 'high', reason: 'Has a salutation and complimentary close.' };
+  }
+
+  // The standard naval-letter skeleton. From+To+Subj is the confident case;
+  // naval_letter is the USMC default, with standard_letter offered as the
+  // plain-paper alternative in the picker.
+  if (hasFrom && hasTo && hasSubj) {
+    return { docType: 'naval_letter', confidence: 'high', reason: 'Has From / To / Subj addressing.' };
+  }
+
+  // Some addressing but not the full set — parse what we can as a naval letter,
+  // but let the drafter confirm the type.
+  if (hasFrom || hasTo || hasSubj) {
+    return {
+      docType: 'naval_letter',
+      confidence: 'low',
+      reason: 'Partial addressing found — please confirm the document type.',
+    };
+  }
+
+  return {
+    docType: 'naval_letter',
+    confidence: 'low',
+    reason: "Couldn't identify the document type from the text — please choose.",
+  };
+}

--- a/src/lib/detectDocumentType.ts
+++ b/src/lib/detectDocumentType.ts
@@ -34,15 +34,18 @@ export const IMPORTABLE_DOC_TYPES = [
   'mou',
 ] as const;
 
-// Strong, unambiguous openers → a specific type, high confidence. Tested in order.
+// Strong, unambiguous openers → a specific type, high confidence. Tested in
+// order. Each is anchored to the START of a line (the `m` flag) because these
+// are title / endorsement lines, not phrases — a naval letter whose Subj reads
+// "RENEWAL OF MEMORANDUM OF AGREEMENT" must not be misread as an MOA.
 const STRONG_MARKERS: { re: RegExp; docType: string; reason: string }[] = [
-  { re: /memorandum\s+for\s+the\s+record/i, docType: 'mfr', reason: 'Contains "MEMORANDUM FOR THE RECORD".' },
-  { re: /memorandum\s+of\s+agreement/i, docType: 'moa', reason: 'Contains "MEMORANDUM OF AGREEMENT".' },
-  { re: /memorandum\s+of\s+understanding/i, docType: 'mou', reason: 'Contains "MEMORANDUM OF UNDERSTANDING".' },
+  { re: /^\s*memorandum\s+for\s+the\s+record/im, docType: 'mfr', reason: 'Contains "MEMORANDUM FOR THE RECORD".' },
+  { re: /^\s*memorandum\s+of\s+agreement/im, docType: 'moa', reason: 'Contains "MEMORANDUM OF AGREEMENT".' },
+  { re: /^\s*memorandum\s+of\s+understanding/im, docType: 'mou', reason: 'Contains "MEMORANDUM OF UNDERSTANDING".' },
   // "FIRST ENDORSEMENT", "SECOND ENDORSEMENT on …", "1st Endorsement". New-page
   // is always a valid form, so it's the safe default guess for an endorsement.
   {
-    re: /\b(?:first|second|third|fourth|fifth|\d+(?:st|nd|rd|th))\s+endorsement\b/i,
+    re: /^\s*(?:first|second|third|fourth|fifth|\d+(?:st|nd|rd|th))\s+endorsement\b/im,
     docType: 'new_page_endorsement',
     reason: 'Contains an endorsement line.',
   },
@@ -61,9 +64,10 @@ export function detectDocumentType(rawText: string): DocTypeDetection {
   const hasTo = hasLabel(text, /^\s*to\s*:/im);
   const hasSubj = hasLabel(text, /^\s*subj(?:ect)?\s*:/im);
 
-  // A generic "MEMORANDUM" (including "MEMORANDUM FOR <name>") — the family is
-  // clear but the specific memo type isn't, so ask the drafter to confirm.
-  if (/\bmemorandum\b/i.test(text) && !(hasFrom && hasTo && hasSubj)) {
+  // A generic "MEMORANDUM" title line (including "MEMORANDUM FOR <name>") — the
+  // family is clear but the specific memo type isn't, so ask the drafter to
+  // confirm. Line-anchored so a body mention ("per the memorandum") doesn't fire.
+  if (/^\s*memorandum\b/im.test(text) && !(hasFrom && hasTo && hasSubj)) {
     return {
       docType: 'plain_paper_memorandum',
       confidence: 'low',

--- a/src/lib/importFormat.ts
+++ b/src/lib/importFormat.ts
@@ -1,0 +1,31 @@
+/**
+ * Decide how an imported file should be read. Pure and dependency-free so it can
+ * be unit-tested without loading the PDF or DOCX engines.
+ *
+ * Extension/MIME is trusted first; magic bytes are the fallback so a mislabeled
+ * or extension-less file (a `.docx` served as octet-stream, a file dropped with
+ * no name) still routes correctly instead of failing.
+ */
+
+export const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+export type ImportFormat = 'pdf' | 'docx';
+
+/** True when the file name or MIME type identifies a Word document. */
+export function isDocxFile(file: Pick<File, 'name' | 'type'>): boolean {
+  return /\.docx$/i.test(file.name) || file.type === DOCX_MIME;
+}
+
+/**
+ * The import format of a file, or null when it is neither a PDF nor a Word
+ * document. `%PDF` (25 50 44 46) marks a PDF; the ZIP local-file header
+ * `PK\x03\x04` (50 4B 03 04) marks a .docx (an OOXML zip).
+ */
+export function detectImportFormat(file: Pick<File, 'name' | 'type'>, bytes: Uint8Array): ImportFormat | null {
+  const name = file.name.toLowerCase();
+  if (name.endsWith('.docx') || file.type === DOCX_MIME) return 'docx';
+  if (name.endsWith('.pdf') || file.type === 'application/pdf') return 'pdf';
+  if (bytes[0] === 0x25 && bytes[1] === 0x50 && bytes[2] === 0x44 && bytes[3] === 0x46) return 'pdf';
+  if (bytes[0] === 0x50 && bytes[1] === 0x4b && bytes[2] === 0x03 && bytes[3] === 0x04) return 'docx';
+  return null;
+}

--- a/src/lib/importFormat.ts
+++ b/src/lib/importFormat.ts
@@ -2,30 +2,66 @@
  * Decide how an imported file should be read. Pure and dependency-free so it can
  * be unit-tested without loading the PDF or DOCX engines.
  *
- * Extension/MIME is trusted first; magic bytes are the fallback so a mislabeled
- * or extension-less file (a `.docx` served as octet-stream, a file dropped with
- * no name) still routes correctly instead of failing.
+ * Three signals, cheapest and most trustworthy first: the file extension, then
+ * the MIME type the browser reported, then the leading "magic" bytes. The byte
+ * check is the safety net for a file whose name and type both lie — a `.docx`
+ * served as octet-stream, or a document dropped with no name at all.
  */
 
 export const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
 
 export type ImportFormat = 'pdf' | 'docx';
 
-/** True when the file name or MIME type identifies a Word document. */
+/** A leading byte sequence that identifies a container format. */
+interface Signature {
+  magic: readonly number[];
+  format: ImportFormat;
+}
+
+// Table-driven so a new format is one row, not another hand-rolled comparison.
+//   "%PDF"          → 25 50 44 46   (every PDF opens with it)
+//   "PK\x03\x04"    → 50 4B 03 04   (ZIP local-file header; a .docx is a ZIP)
+const SIGNATURES: readonly Signature[] = [
+  { magic: [0x25, 0x50, 0x44, 0x46], format: 'pdf' },
+  { magic: [0x50, 0x4b, 0x03, 0x04], format: 'docx' },
+];
+
+// The OLE compound-file header shared by the legacy binary Office formats
+// (.doc/.xls/.ppt). Not importable — pandoc and pdf.js can't read it — but
+// recognizing it lets the UI say "re-save as .docx" instead of "corrupt file".
+const OLE_MAGIC: readonly number[] = [0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1];
+
+const leadsWith = (bytes: Uint8Array, magic: readonly number[]): boolean =>
+  magic.every((b, i) => bytes[i] === b);
+
+/** True when the file name or MIME type identifies a modern Word document. */
 export function isDocxFile(file: Pick<File, 'name' | 'type'>): boolean {
   return /\.docx$/i.test(file.name) || file.type === DOCX_MIME;
 }
 
 /**
- * The import format of a file, or null when it is neither a PDF nor a Word
- * document. `%PDF` (25 50 44 46) marks a PDF; the ZIP local-file header
- * `PK\x03\x04` (50 4B 03 04) marks a .docx (an OOXML zip).
+ * True for a legacy binary Word (.doc) file. Recognized so the importer can give
+ * a specific "save it as .docx and try again" message rather than failing as if
+ * the file were corrupt. `.doc$` never matches `.docx` (that ends in "x").
+ */
+export function isLegacyDocFile(file: Pick<File, 'name' | 'type'>, bytes?: Uint8Array): boolean {
+  return (
+    /\.doc$/i.test(file.name) ||
+    file.type === 'application/msword' ||
+    (bytes !== undefined && leadsWith(bytes, OLE_MAGIC))
+  );
+}
+
+/**
+ * The import format of a file, or null when it is neither a PDF nor a modern
+ * Word document. Extension/MIME win; magic bytes are the fallback.
  */
 export function detectImportFormat(file: Pick<File, 'name' | 'type'>, bytes: Uint8Array): ImportFormat | null {
   const name = file.name.toLowerCase();
   if (name.endsWith('.docx') || file.type === DOCX_MIME) return 'docx';
   if (name.endsWith('.pdf') || file.type === 'application/pdf') return 'pdf';
-  if (bytes[0] === 0x25 && bytes[1] === 0x50 && bytes[2] === 0x44 && bytes[3] === 0x46) return 'pdf';
-  if (bytes[0] === 0x50 && bytes[1] === 0x4b && bytes[2] === 0x03 && bytes[3] === 0x04) return 'docx';
+  for (const sig of SIGNATURES) {
+    if (leadsWith(bytes, sig.magic)) return sig.format;
+  }
   return null;
 }

--- a/src/lib/importLetter.ts
+++ b/src/lib/importLetter.ts
@@ -1,15 +1,41 @@
 import { readFileAsArrayBuffer, arrayBufferToUint8Array } from '@/lib/encoding';
 import { extractPdfText } from '@/lib/pdfText';
 import { parseNavalLetter, type ParsedLetter } from '@/lib/parseNavalLetter';
+import { detectDocumentType, type DocTypeDetection } from '@/lib/detectDocumentType';
+import { convertDocxToPlainText } from '@/services/docx/pandoc-converter';
 import { useDocumentStore, persistUnsavedEnclosures } from '@/stores/documentStore';
 import { useDocumentsStore } from '@/stores/documentsStore';
 import type { DocumentData } from '@/types/document';
 
-/** Read a PDF File and parse it into naval-letter fields. Text-layer PDFs only. */
-export async function parseLetterFile(file: File): Promise<ParsedLetter> {
+/** A parsed file plus the importer's best guess at which document type it is. */
+export interface ParsedImport {
+  parsed: ParsedLetter;
+  detection: DocTypeDetection;
+}
+
+/** True when the file name or MIME type identifies a Word document. */
+function isDocxFile(file: File): boolean {
+  return (
+    /\.docx$/i.test(file.name) ||
+    file.type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+  );
+}
+
+/** Extract the plain text of a supported letter file (PDF text-layer or DOCX). */
+async function extractLetterText(file: File): Promise<string> {
   const buffer = await readFileAsArrayBuffer(file);
-  const text = await extractPdfText(arrayBufferToUint8Array(buffer));
-  return parseNavalLetter(text);
+  const bytes = arrayBufferToUint8Array(buffer);
+  return isDocxFile(file) ? convertDocxToPlainText(bytes) : extractPdfText(bytes);
+}
+
+/**
+ * Read a letter file (PDF or DOCX), parse it into naval-letter fields, and
+ * detect which document type it most likely is. Text-layer PDFs and Word
+ * documents only — a scanned image PDF has no text to read.
+ */
+export async function parseLetterFile(file: File): Promise<ParsedImport> {
+  const text = await extractLetterText(file);
+  return { parsed: parseNavalLetter(text), detection: detectDocumentType(text) };
 }
 
 /** Whether the parser recognized anything worth importing. */
@@ -30,8 +56,12 @@ export function hasParsedContent(p: ParsedLetter): boolean {
  * Header.tsx: set the document type, then the scalar fields, then the arrays,
  * then open the result as its own recents entry. Only fields the parser filled
  * are written — everything else stays at the fresh-letter default.
+ *
+ * `docType` is the type the drafter confirmed in the review step (defaulting to
+ * the importer's detection); every importable type lives in the correspondence
+ * category, and `setDocType` derives the per-type layout config from it.
  */
-export function applyParsedLetter(parsed: ParsedLetter): void {
+export function applyParsedLetter(parsed: ParsedLetter, docType = 'naval_letter'): void {
   const docs = useDocumentsStore.getState();
   const ds = useDocumentStore.getState();
 
@@ -40,7 +70,7 @@ export function applyParsedLetter(parsed: ParsedLetter): void {
 
   ds.setDocumentMode('compliant');
   ds.setDocumentCategory('correspondence');
-  ds.setDocType('naval_letter');
+  ds.setDocType(docType);
 
   const formData: Partial<DocumentData> = {};
   if (parsed.ssic) formData.ssic = parsed.ssic;

--- a/src/lib/importLetter.ts
+++ b/src/lib/importLetter.ts
@@ -16,7 +16,7 @@ export interface ParsedImport {
 }
 
 /** True when the file name or MIME type identifies a Word document. */
-function isDocxFile(file: File): boolean {
+export function isDocxFile(file: File): boolean {
   return (
     /\.docx$/i.test(file.name) ||
     file.type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'

--- a/src/lib/importLetter.ts
+++ b/src/lib/importLetter.ts
@@ -2,15 +2,17 @@ import { readFileAsArrayBuffer, arrayBufferToUint8Array } from '@/lib/encoding';
 import { extractPdfText } from '@/lib/pdfText';
 import { parseNavalLetter, type ParsedLetter } from '@/lib/parseNavalLetter';
 import { detectDocumentType, type DocTypeDetection } from '@/lib/detectDocumentType';
-import { convertDocxToPlainText } from '@/services/docx/pandoc-converter';
+import { detectClassification, type ClassificationDetection } from '@/lib/detectClassification';
+import { convertDocxToPlainText, extractDocxMarkingText } from '@/services/docx/pandoc-converter';
 import { useDocumentStore, persistUnsavedEnclosures } from '@/stores/documentStore';
 import { useDocumentsStore } from '@/stores/documentsStore';
 import type { DocumentData } from '@/types/document';
 
-/** A parsed file plus the importer's best guess at which document type it is. */
+/** A parsed file plus the importer's guesses at document type and classification. */
 export interface ParsedImport {
   parsed: ParsedLetter;
   detection: DocTypeDetection;
+  classification: ClassificationDetection;
 }
 
 /** True when the file name or MIME type identifies a Word document. */
@@ -21,21 +23,38 @@ function isDocxFile(file: File): boolean {
   );
 }
 
-/** Extract the plain text of a supported letter file (PDF text-layer or DOCX). */
-async function extractLetterText(file: File): Promise<string> {
+/**
+ * Extract the text of a supported letter file (PDF text-layer or DOCX). Returns
+ * the readable `body` used for parsing, plus any `markings` text that lives
+ * outside the body — the classification banner rides in the Word page
+ * header/footer, which the body-only DOCX read can't see, so it is pulled
+ * separately. A PDF's banner is already in the page text, so `markings` is
+ * empty there.
+ */
+async function extractLetterText(file: File): Promise<{ body: string; markings: string }> {
   const buffer = await readFileAsArrayBuffer(file);
   const bytes = arrayBufferToUint8Array(buffer);
-  return isDocxFile(file) ? convertDocxToPlainText(bytes) : extractPdfText(bytes);
+  if (isDocxFile(file)) {
+    const [body, markings] = await Promise.all([convertDocxToPlainText(bytes), extractDocxMarkingText(bytes)]);
+    return { body, markings };
+  }
+  return { body: await extractPdfText(bytes), markings: '' };
 }
 
 /**
  * Read a letter file (PDF or DOCX), parse it into naval-letter fields, and
- * detect which document type it most likely is. Text-layer PDFs and Word
- * documents only — a scanned image PDF has no text to read.
+ * detect the document type and classification. Text-layer PDFs and Word
+ * documents only — a scanned image PDF has no text to read. The letter
+ * structure is parsed from the body; classification also considers the
+ * header/footer markings (where the DOCX banner lives).
  */
 export async function parseLetterFile(file: File): Promise<ParsedImport> {
-  const text = await extractLetterText(file);
-  return { parsed: parseNavalLetter(text), detection: detectDocumentType(text) };
+  const { body, markings } = await extractLetterText(file);
+  return {
+    parsed: parseNavalLetter(body),
+    detection: detectDocumentType(body),
+    classification: detectClassification(markings ? `${markings}\n${body}` : body),
+  };
 }
 
 /** Whether the parser recognized anything worth importing. */
@@ -60,8 +79,17 @@ export function hasParsedContent(p: ParsedLetter): boolean {
  * `docType` is the type the drafter confirmed in the review step (defaulting to
  * the importer's detection); every importable type lives in the correspondence
  * category, and `setDocType` derives the per-type layout config from it.
+ *
+ * `classification`, when the source was marked, pre-sets the banner level and
+ * any derivative-classification authority block; per-paragraph portion markings
+ * ride in on the parsed paragraphs. The drafter still owns the Classification
+ * section after import (and the domain restriction applies there as usual).
  */
-export function applyParsedLetter(parsed: ParsedLetter, docType = 'naval_letter'): void {
+export function applyParsedLetter(
+  parsed: ParsedLetter,
+  docType = 'naval_letter',
+  classification?: ClassificationDetection
+): void {
   const docs = useDocumentsStore.getState();
   const ds = useDocumentStore.getState();
 
@@ -85,13 +113,26 @@ export function applyParsedLetter(parsed: ParsedLetter, docType = 'naval_letter'
     formData.sigMiddle = parsed.signature.middle;
     formData.sigLast = parsed.signature.last;
   }
+  // Classification: only write when the source actually carried markings, so an
+  // unmarked import stays at the fresh-letter Unclassified default.
+  if (classification?.found) {
+    formData.classLevel = classification.classLevel;
+    if (classification.classifiedBy) formData.classifiedBy = classification.classifiedBy;
+    if (classification.derivedFrom) formData.derivedFrom = classification.derivedFrom;
+    if (classification.declassifyOn) formData.declassifyOn = classification.declassifyOn;
+    if (classification.classReason) formData.classReason = classification.classReason;
+  }
   ds.setFormData(formData);
 
   ds.loadTemplate({
     // `letter` is re-assigned by the store from array position.
     references: parsed.references.map((title) => ({ letter: '', title })),
     enclosures: parsed.enclosures.map((title) => ({ title })),
-    paragraphs: parsed.paragraphs.map((p) => ({ text: p.text, level: p.level })),
+    paragraphs: parsed.paragraphs.map((p) => ({
+      text: p.text,
+      level: p.level,
+      ...(p.portionMarking && { portionMarking: p.portionMarking }),
+    })),
     copyTos: parsed.copyTos.map((text) => ({ text })),
   });
 

--- a/src/lib/importLetter.ts
+++ b/src/lib/importLetter.ts
@@ -1,0 +1,69 @@
+import { readFileAsArrayBuffer, arrayBufferToUint8Array } from '@/lib/encoding';
+import { extractPdfText } from '@/lib/pdfText';
+import { parseNavalLetter, type ParsedLetter } from '@/lib/parseNavalLetter';
+import { useDocumentStore, persistUnsavedEnclosures } from '@/stores/documentStore';
+import { useDocumentsStore } from '@/stores/documentsStore';
+import type { DocumentData } from '@/types/document';
+
+/** Read a PDF File and parse it into naval-letter fields. Text-layer PDFs only. */
+export async function parseLetterFile(file: File): Promise<ParsedLetter> {
+  const buffer = await readFileAsArrayBuffer(file);
+  const text = await extractPdfText(arrayBufferToUint8Array(buffer));
+  return parseNavalLetter(text);
+}
+
+/** Whether the parser recognized anything worth importing. */
+export function hasParsedContent(p: ParsedLetter): boolean {
+  return Boolean(
+    p.from ||
+      p.to ||
+      p.subject ||
+      p.paragraphs.length > 0 ||
+      p.references.length > 0 ||
+      p.enclosures.length > 0
+  );
+}
+
+/**
+ * Load a parsed letter into the editor as a NEW document (the current one is
+ * synced first, never clobbered). Mirrors the draft-import sequence in
+ * Header.tsx: set the document type, then the scalar fields, then the arrays,
+ * then open the result as its own recents entry. Only fields the parser filled
+ * are written — everything else stays at the fresh-letter default.
+ */
+export function applyParsedLetter(parsed: ParsedLetter): void {
+  const docs = useDocumentsStore.getState();
+  const ds = useDocumentStore.getState();
+
+  // Preserve the document being left before we overwrite the live editor state.
+  docs.syncCurrent();
+
+  ds.setDocumentMode('compliant');
+  ds.setDocumentCategory('correspondence');
+  ds.setDocType('naval_letter');
+
+  const formData: Partial<DocumentData> = {};
+  if (parsed.ssic) formData.ssic = parsed.ssic;
+  if (parsed.serial) formData.serial = parsed.serial;
+  if (parsed.date) formData.date = parsed.date;
+  if (parsed.from) formData.from = parsed.from;
+  if (parsed.to) formData.to = parsed.to;
+  if (parsed.via) formData.via = parsed.via;
+  if (parsed.subject) formData.subject = parsed.subject;
+  if (parsed.signature) {
+    formData.sigFirst = parsed.signature.first;
+    formData.sigMiddle = parsed.signature.middle;
+    formData.sigLast = parsed.signature.last;
+  }
+  ds.setFormData(formData);
+
+  ds.loadTemplate({
+    // `letter` is re-assigned by the store from array position.
+    references: parsed.references.map((title) => ({ letter: '', title })),
+    enclosures: parsed.enclosures.map((title) => ({ title })),
+    paragraphs: parsed.paragraphs.map((p) => ({ text: p.text, level: p.level })),
+  });
+
+  docs.openLoadedAsNew();
+  void persistUnsavedEnclosures();
+}

--- a/src/lib/importLetter.ts
+++ b/src/lib/importLetter.ts
@@ -35,7 +35,12 @@ async function extractLetterText(file: File): Promise<{ body: string; markings: 
   const buffer = await readFileAsArrayBuffer(file);
   const bytes = arrayBufferToUint8Array(buffer);
   if (isDocxFile(file)) {
-    const [body, markings] = await Promise.all([convertDocxToPlainText(bytes), extractDocxMarkingText(bytes)]);
+    // The body is essential; the header/footer markings only feed classification
+    // detection, so a hiccup reading them must not fail the whole import.
+    const [body, markings] = await Promise.all([
+      convertDocxToPlainText(bytes),
+      extractDocxMarkingText(bytes).catch(() => ''),
+    ]);
     return { body, markings };
   }
   return { body: await extractPdfText(bytes), markings: '' };

--- a/src/lib/importLetter.ts
+++ b/src/lib/importLetter.ts
@@ -4,23 +4,18 @@ import { parseNavalLetter, type ParsedLetter } from '@/lib/parseNavalLetter';
 import { detectDocumentType, type DocTypeDetection } from '@/lib/detectDocumentType';
 import { detectClassification, type ClassificationDetection } from '@/lib/detectClassification';
 import { convertDocxToPlainText, extractDocxMarkingText } from '@/services/docx/pandoc-converter';
+import { detectImportFormat } from '@/lib/importFormat';
 import { useDocumentStore, persistUnsavedEnclosures } from '@/stores/documentStore';
 import { useDocumentsStore } from '@/stores/documentsStore';
 import type { DocumentData } from '@/types/document';
+
+export { isDocxFile, detectImportFormat, type ImportFormat } from '@/lib/importFormat';
 
 /** A parsed file plus the importer's guesses at document type and classification. */
 export interface ParsedImport {
   parsed: ParsedLetter;
   detection: DocTypeDetection;
   classification: ClassificationDetection;
-}
-
-/** True when the file name or MIME type identifies a Word document. */
-export function isDocxFile(file: File): boolean {
-  return (
-    /\.docx$/i.test(file.name) ||
-    file.type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-  );
 }
 
 /**
@@ -34,7 +29,8 @@ export function isDocxFile(file: File): boolean {
 async function extractLetterText(file: File): Promise<{ body: string; markings: string }> {
   const buffer = await readFileAsArrayBuffer(file);
   const bytes = arrayBufferToUint8Array(buffer);
-  if (isDocxFile(file)) {
+  const format = detectImportFormat(file, bytes);
+  if (format === 'docx') {
     // The body is essential; the header/footer markings only feed classification
     // detection, so a hiccup reading them must not fail the whole import.
     const [body, markings] = await Promise.all([
@@ -43,7 +39,8 @@ async function extractLetterText(file: File): Promise<{ body: string; markings: 
     ]);
     return { body, markings };
   }
-  return { body: await extractPdfText(bytes), markings: '' };
+  if (format === 'pdf') return { body: await extractPdfText(bytes), markings: '' };
+  throw new Error(`Unsupported file type for import: ${file.name || '(unnamed file)'}`);
 }
 
 /**

--- a/src/lib/importLetter.ts
+++ b/src/lib/importLetter.ts
@@ -62,6 +62,7 @@ export function applyParsedLetter(parsed: ParsedLetter): void {
     references: parsed.references.map((title) => ({ letter: '', title })),
     enclosures: parsed.enclosures.map((title) => ({ title })),
     paragraphs: parsed.paragraphs.map((p) => ({ text: p.text, level: p.level })),
+    copyTos: parsed.copyTos.map((text) => ({ text })),
   });
 
   docs.openLoadedAsNew();

--- a/src/lib/importLetter.ts
+++ b/src/lib/importLetter.ts
@@ -9,7 +9,7 @@ import { useDocumentStore, persistUnsavedEnclosures } from '@/stores/documentSto
 import { useDocumentsStore } from '@/stores/documentsStore';
 import type { DocumentData } from '@/types/document';
 
-export { isDocxFile, detectImportFormat, type ImportFormat } from '@/lib/importFormat';
+export { isDocxFile, isLegacyDocFile, detectImportFormat, type ImportFormat } from '@/lib/importFormat';
 
 /** A parsed file plus the importer's guesses at document type and classification. */
 export interface ParsedImport {

--- a/src/lib/parseNavalLetter.ts
+++ b/src/lib/parseNavalLetter.ts
@@ -1,0 +1,228 @@
+/**
+ * Best-effort parser: the text lines of an existing naval letter → the fields
+ * DonDocs' editor holds. It reverses the format the app renders — the SECNAV
+ * M-5216.5 header block (From/To/Via/Subj/Ref/Encl), the identification symbols
+ * (SSIC / serial / date), the numbered-paragraph tree, and the signature name.
+ *
+ * It is deliberately forgiving and never throws: a letter that doesn't follow
+ * the format yields whatever fields were recognizable (often just the body),
+ * and the import flow shows the result for review before anything is written.
+ * Pure and leaf so it can be exhaustively unit-tested against line fixtures,
+ * independent of how those lines were extracted (PDF today, DOCX later).
+ */
+
+export interface ParsedLetter {
+  ssic?: string;
+  serial?: string;
+  date?: string;
+  from?: string;
+  to?: string;
+  via?: string;
+  subject?: string;
+  /** Reference titles in order; the letter (a),(b)… is re-assigned by the store. */
+  references: string[];
+  /** Enclosure titles in order; numbering is positional in the store. */
+  enclosures: string[];
+  paragraphs: { text: string; level: number }[];
+  signature?: { first: string; middle: string; last: string };
+}
+
+// The labels that open a header field. Longer/aliased spellings first so
+// "Subject" matches before a naive "Subj" prefix test would.
+const HEADER_LABELS: { key: 'from' | 'to' | 'via' | 'subject' | 'ref' | 'encl'; re: RegExp }[] = [
+  { key: 'from', re: /^from\s*:/i },
+  { key: 'to', re: /^to\s*:/i },
+  { key: 'via', re: /^via\s*:/i },
+  { key: 'subject', re: /^subj(?:ect)?\s*:/i },
+  { key: 'ref', re: /^ref(?:erence)?\s*:/i },
+  { key: 'encl', re: /^encl(?:osure)?\s*:/i },
+];
+
+// A line that ends the letter body — the trailing blocks the editor holds
+// separately (Copy to / Distribution) must not be swept in as paragraphs.
+const BODY_TERMINATORS = /^(copy\s*to|distribution|blind\s*copy|bcc)\s*:/i;
+
+/** Strip the "Label:" prefix, returning the value on that line. */
+function afterColon(line: string): string {
+  const i = line.indexOf(':');
+  return i === -1 ? '' : line.slice(i + 1).trim();
+}
+
+/** Which header label (if any) this line opens. */
+function headerLabelOf(line: string): (typeof HEADER_LABELS)[number]['key'] | null {
+  for (const label of HEADER_LABELS) if (label.re.test(line)) return label.key;
+  return null;
+}
+
+// Paragraph label → SECNAV nesting level (Ch 7 ¶13a): 1. / a. / (1) / (a) / …
+// Order matters — (1) must be tested before 1. so a paren item isn't read as
+// arabic. `text` is the paragraph with its label stripped.
+const PARAGRAPH_LABELS: { level: number; re: RegExp }[] = [
+  { level: 3, re: /^\(([a-z])\)\s+(.*)$/ }, // (a)
+  { level: 2, re: /^\((\d+)\)\s+(.*)$/ }, // (1)
+  { level: 1, re: /^([a-z])\.\s+(.*)$/ }, // a.
+  { level: 0, re: /^(\d+)\.\s+(.*)$/ }, // 1.
+];
+
+// The body of a naval letter always opens at a top-level arabic paragraph
+// ("1."). A "(b)" or "a." at the start of a line inside the header is a Ref/
+// Encl list marker, not the body — so only "N." ends the header block.
+const BODY_START_RE = /^\d+\.\s+/;
+
+/** If the line opens a numbered paragraph, its level and label-stripped text. */
+function paragraphStartOf(line: string): { level: number; text: string } | null {
+  const trimmed = line.trim();
+  for (const { level, re } of PARAGRAPH_LABELS) {
+    const m = trimmed.match(re);
+    if (m) return { level, text: m[2] };
+  }
+  return null;
+}
+
+// Split a Ref/Encl value into its items. The list may run inline
+// ("(a) Foo (b) Bar") or across lines, each item marked "(a)" / "(1)".
+function splitLabeledItems(raw: string): string[] {
+  const items = raw
+    .split(/\((?:[a-z]|\d+)\)/i)
+    .map((s) => s.replace(/\s+/g, ' ').trim())
+    .filter(Boolean);
+  return items;
+}
+
+// Initials + SURNAME, e.g. "R. L. SMITH" or "P. W. McNALLY" (prefix surnames
+// keep their internal capital). Rank/title are never on this line (SECNAV ¶14a).
+const SIGNATURE_RE = /^([A-Z])\.\s*(?:([A-Z])\.\s*)?([A-Z][A-Za-z']+)$/;
+
+function parseSignature(line: string): ParsedLetter['signature'] | null {
+  const m = line.trim().match(SIGNATURE_RE);
+  if (!m) return null;
+  // Two-initial form → first, middle, last. One-initial form → first, last.
+  return m[2]
+    ? { first: m[1], middle: m[2], last: m[3] }
+    : { first: m[1], middle: '', last: m[3] };
+}
+
+// SSIC: a standalone 4–5 digit code (optionally with a subcode like 5216.5).
+const SSIC_RE = /^\d{4,5}(?:\.\d+)?$/;
+// Serial: "Ser 1710/024", "Ser 024", or a bare "1710/024".
+const SERIAL_RE = /^(?:ser\s+)?(\d+(?:\/\d+)?)$/i;
+// Military date "4 Jan 26" / "15 January 2025", or "January 4, 2026".
+const DATE_RE =
+  /^(?:\d{1,2}\s+[A-Za-z]{3,9}\s+\d{2,4}|[A-Za-z]{3,9}\s+\d{1,2},?\s+\d{4})$/;
+
+/**
+ * Parse the identification block (SSIC / serial / date) that sits above the
+ * "From:" line. Scans only the pre-header region so a number inside the body
+ * can't be mistaken for an SSIC.
+ */
+function parseIdentification(preHeader: string[]): Pick<ParsedLetter, 'ssic' | 'serial' | 'date'> {
+  const out: Pick<ParsedLetter, 'ssic' | 'serial' | 'date'> = {};
+  // The block prints top-to-bottom as SSIC, serial, date. Claim the SSIC line
+  // first; the next number is the serial *by position*, even when it is itself
+  // four digits (DonDocs prints a bare "0042", not "Ser 0042") — which a
+  // shape-only test would otherwise reject as another SSIC.
+  for (const raw of preHeader) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (!out.ssic && SSIC_RE.test(line)) {
+      out.ssic = line;
+      continue;
+    }
+    if (!out.serial) {
+      const m = line.match(SERIAL_RE);
+      if (m) {
+        out.serial = m[1];
+        continue;
+      }
+    }
+    if (!out.date && DATE_RE.test(line)) out.date = line;
+  }
+  return out;
+}
+
+export function parseNavalLetter(rawText: string): ParsedLetter {
+  const lines = rawText.replace(/\r\n?/g, '\n').split('\n');
+
+  const result: ParsedLetter = { references: [], enclosures: [], paragraphs: [] };
+
+  // ── 1. Header block (first From:/To:/…: line onward) ──
+  // With no recognizable header the whole document is body; bodyStart = 0 and
+  // the header loop is skipped, but paragraphs and the signature are still read.
+  const firstHeaderIdx = lines.findIndex((l) => headerLabelOf(l) !== null);
+  let bodyStart = firstHeaderIdx === -1 ? 0 : lines.length;
+
+  if (firstHeaderIdx !== -1) {
+    Object.assign(result, parseIdentification(lines.slice(0, firstHeaderIdx)));
+
+    // Walk the header, accumulating each field's value across continuation lines.
+    const fields: Record<string, string[]> = {};
+    let current: string | null = null;
+
+    for (let i = firstHeaderIdx; i < lines.length; i++) {
+      const line = lines[i];
+      const label = headerLabelOf(line);
+      if (label) {
+        current = label;
+        fields[label] = [afterColon(line)];
+        continue;
+      }
+      // The first top-level "N." paragraph ends the header and starts the body.
+      // (A "(b)"/"a." line here is a Ref/Encl list item, not the body.)
+      if (current && BODY_START_RE.test(line.trim())) {
+        bodyStart = i;
+        break;
+      }
+      // Blank lines don't close a field (values may wrap); non-label content
+      // continues the current field.
+      if (!line.trim()) continue;
+      if (current) fields[current].push(line.trim());
+    }
+
+    const joinField = (key: string) =>
+      (fields[key] ?? []).map((s) => s.trim()).filter(Boolean).join(' ').trim() || undefined;
+
+    result.from = joinField('from');
+    result.to = joinField('to');
+    result.via = joinField('via');
+    result.subject = joinField('subject');
+    if (fields.ref) result.references = splitLabeledItems(fields.ref.join(' '));
+    if (fields.encl) result.enclosures = splitLabeledItems(fields.encl.join(' '));
+  }
+
+  // ── 2. Body paragraphs + signature (always, header or not) ──
+  result.paragraphs = collectParagraphs(lines, bodyStart);
+  result.signature = findSignature(lines, bodyStart) ?? undefined;
+
+  return result;
+}
+
+/**
+ * Collect numbered paragraphs from `start` to the signature/terminator/EOF.
+ * A line without a label continues the current paragraph (wrapped text);
+ * levels are emitted as-is and the store clamps any illegal jump.
+ */
+function collectParagraphs(lines: string[], start: number): { text: string; level: number }[] {
+  const paras: { text: string; level: number }[] = [];
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i];
+    if (BODY_TERMINATORS.test(line.trim())) break;
+    if (parseSignature(line)) break; // reached the signature block
+    const p = paragraphStartOf(line);
+    if (p) {
+      paras.push({ text: p.text.trim(), level: p.level });
+    } else if (line.trim() && paras.length > 0) {
+      // Continuation of the paragraph above — rejoin the wrapped line.
+      paras[paras.length - 1].text = `${paras[paras.length - 1].text} ${line.trim()}`.trim();
+    }
+  }
+  return paras;
+}
+
+/** The last signature-shaped line at/after `bodyStart` (the closing signer). */
+function findSignature(lines: string[], bodyStart: number): ParsedLetter['signature'] | null {
+  for (let i = lines.length - 1; i >= bodyStart; i--) {
+    const sig = parseSignature(lines[i]);
+    if (sig) return sig;
+  }
+  return null;
+}

--- a/src/lib/parseNavalLetter.ts
+++ b/src/lib/parseNavalLetter.ts
@@ -11,6 +11,8 @@
  * independent of how those lines were extracted (PDF today, DOCX later).
  */
 
+import type { PortionMarking } from '@/types/document';
+
 export interface ParsedLetter {
   ssic?: string;
   serial?: string;
@@ -25,7 +27,7 @@ export interface ParsedLetter {
   enclosures: string[];
   /** "Copy to" recipients, one per entry. */
   copyTos: string[];
-  paragraphs: { text: string; level: number }[];
+  paragraphs: { text: string; level: number; portionMarking?: PortionMarking }[];
   signature?: { first: string; middle: string; last: string };
 }
 
@@ -71,12 +73,25 @@ const PARAGRAPH_LABELS: { level: number; re: RegExp }[] = [
 // Encl list marker, not the body — so only "N." ends the header block.
 const BODY_START_RE = /^\d+\.\s+/;
 
-/** If the line opens a numbered paragraph, its level and label-stripped text. */
-function paragraphStartOf(line: string): { level: number; text: string } | null {
+// A portion mark leads the paragraph text after its number label, per SECNAV
+// M-5216.5 / DoDM 5200.01: "1.  (S) The text…". Captured so an imported
+// classified letter keeps its per-paragraph markings, not just the banner.
+const PORTION_MARK_RE = /^\((U|CUI|FOUO|C|S|TS)\)\s+(.*)$/;
+
+/** Peel a leading "(S)" portion mark off paragraph text, if present. */
+function splitPortionMark(text: string): { text: string; portionMarking?: PortionMarking } {
+  const m = text.match(PORTION_MARK_RE);
+  return m ? { portionMarking: m[1] as PortionMarking, text: m[2] } : { text };
+}
+
+/** If the line opens a numbered paragraph, its level, text, and portion mark. */
+function paragraphStartOf(
+  line: string
+): { level: number; text: string; portionMarking?: PortionMarking } | null {
   const trimmed = line.trim();
   for (const { level, re } of PARAGRAPH_LABELS) {
     const m = trimmed.match(re);
-    if (m) return { level, text: m[2] };
+    if (m) return { level, ...splitPortionMark(m[2]) };
   }
   return null;
 }
@@ -234,15 +249,15 @@ function parseCopyTo(lines: string[]): string[] {
  * A line without a label continues the current paragraph (wrapped text);
  * levels are emitted as-is and the store clamps any illegal jump.
  */
-function collectParagraphs(lines: string[], start: number): { text: string; level: number }[] {
-  const paras: { text: string; level: number }[] = [];
+function collectParagraphs(lines: string[], start: number): ParsedLetter['paragraphs'] {
+  const paras: ParsedLetter['paragraphs'] = [];
   for (let i = start; i < lines.length; i++) {
     const line = lines[i];
     if (BODY_TERMINATORS.test(line.trim())) break;
     if (parseSignature(line)) break; // reached the signature block
     const p = paragraphStartOf(line);
     if (p) {
-      paras.push({ text: p.text.trim(), level: p.level });
+      paras.push({ text: p.text.trim(), level: p.level, ...(p.portionMarking && { portionMarking: p.portionMarking }) });
     } else if (line.trim() && paras.length > 0) {
       // Continuation of the paragraph above — rejoin the wrapped line.
       paras[paras.length - 1].text = `${paras[paras.length - 1].text} ${line.trim()}`.trim();

--- a/src/lib/parseNavalLetter.ts
+++ b/src/lib/parseNavalLetter.ts
@@ -23,6 +23,8 @@ export interface ParsedLetter {
   references: string[];
   /** Enclosure titles in order; numbering is positional in the store. */
   enclosures: string[];
+  /** "Copy to" recipients, one per entry. */
+  copyTos: string[];
   paragraphs: { text: string; level: number }[];
   signature?: { first: string; middle: string; last: string };
 }
@@ -143,7 +145,7 @@ function parseIdentification(preHeader: string[]): Pick<ParsedLetter, 'ssic' | '
 export function parseNavalLetter(rawText: string): ParsedLetter {
   const lines = rawText.replace(/\r\n?/g, '\n').split('\n');
 
-  const result: ParsedLetter = { references: [], enclosures: [], paragraphs: [] };
+  const result: ParsedLetter = { references: [], enclosures: [], copyTos: [], paragraphs: [] };
 
   // ── 1. Header block (first From:/To:/…: line onward) ──
   // With no recognizable header the whole document is body; bodyStart = 0 and
@@ -183,8 +185,14 @@ export function parseNavalLetter(rawText: string): ParsedLetter {
 
     result.from = joinField('from');
     result.to = joinField('to');
-    result.via = joinField('via');
     result.subject = joinField('subject');
+    // Via is one addressee per line — the generator re-adds the "(1)/(2)"
+    // numbering, so strip the source's markers and store newline-separated,
+    // never a single "(1) X (2) Y" line that would render un-numbered.
+    if (fields.via) {
+      const vias = splitLabeledItems(fields.via.join(' '));
+      result.via = vias.length ? vias.join('\n') : undefined;
+    }
     if (fields.ref) result.references = splitLabeledItems(fields.ref.join(' '));
     if (fields.encl) result.enclosures = splitLabeledItems(fields.encl.join(' '));
   }
@@ -192,8 +200,33 @@ export function parseNavalLetter(rawText: string): ParsedLetter {
   // ── 2. Body paragraphs + signature (always, header or not) ──
   result.paragraphs = collectParagraphs(lines, bodyStart);
   result.signature = findSignature(lines, bodyStart) ?? undefined;
+  result.copyTos = parseCopyTo(lines);
 
   return result;
+}
+
+// A trailing block that isn't Copy to — ends the copy-to recipient list.
+const OTHER_TRAILING_BLOCK = /^(distribution|blind\s*copy|bcc)\s*:/i;
+
+/**
+ * Collect the "Copy to" recipients — one per line — from the trailing block,
+ * so an imported letter keeps its copy-to list instead of dropping it. The
+ * block sits after the signature; entries run until a blank line, the next
+ * trailing block (Distribution/BCC), a header label, or EOF.
+ */
+function parseCopyTo(lines: string[]): string[] {
+  const start = lines.findIndex((l) => /^copy\s*to\s*:/i.test(l.trim()));
+  if (start === -1) return [];
+  const recipients: string[] = [];
+  const first = afterColon(lines[start]).trim();
+  if (first) recipients.push(first); // "Copy to: Foo" on the label line
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) break; // a blank line closes the list
+    if (OTHER_TRAILING_BLOCK.test(line) || headerLabelOf(line) || parseSignature(line)) break;
+    recipients.push(line);
+  }
+  return recipients;
 }
 
 /**

--- a/src/lib/parseNavalLetter.ts
+++ b/src/lib/parseNavalLetter.ts
@@ -33,14 +33,27 @@ export interface ParsedLetter {
 
 // The labels that open a header field. Longer/aliased spellings first so
 // "Subject" matches before a naive "Subj" prefix test would.
+// Leading `\s*` tolerates indentation: pandoc renders the header block of a
+// DOCX letter as a grid table, so labels arrive indented ("  From:  …") rather
+// than at the line start.
 const HEADER_LABELS: { key: 'from' | 'to' | 'via' | 'subject' | 'ref' | 'encl'; re: RegExp }[] = [
-  { key: 'from', re: /^from\s*:/i },
-  { key: 'to', re: /^to\s*:/i },
-  { key: 'via', re: /^via\s*:/i },
-  { key: 'subject', re: /^subj(?:ect)?\s*:/i },
-  { key: 'ref', re: /^ref(?:erence)?\s*:/i },
-  { key: 'encl', re: /^encl(?:osure)?\s*:/i },
+  { key: 'from', re: /^\s*from\s*:/i },
+  { key: 'to', re: /^\s*to\s*:/i },
+  { key: 'via', re: /^\s*via\s*:/i },
+  { key: 'subject', re: /^\s*subj(?:ect)?\s*:/i },
+  { key: 'ref', re: /^\s*ref(?:erence)?\s*:/i },
+  { key: 'encl', re: /^\s*encl(?:osure)?\s*:/i },
 ];
+
+// A grid-table rule line, e.g. "  ------- ----------------". Pandoc draws the
+// letterhead, identification, and From/To/Subj blocks of a DOCX letter as grid
+// tables; these separator rows are layout, not content, and must be dropped
+// before parsing or they get swept into a field value. A blank line (no dashes)
+// is NOT a separator — those carry paragraph structure and are kept.
+const GRID_SEPARATOR = /^[\s\-+|]*$/;
+function isGridSeparator(line: string): boolean {
+  return GRID_SEPARATOR.test(line) && (line.match(/-/g)?.length ?? 0) >= 3;
+}
 
 // A line that ends the letter body — the trailing blocks the editor holds
 // separately (Copy to / Distribution) must not be swept in as paragraphs.
@@ -158,7 +171,10 @@ function parseIdentification(preHeader: string[]): Pick<ParsedLetter, 'ssic' | '
 }
 
 export function parseNavalLetter(rawText: string): ParsedLetter {
-  const lines = rawText.replace(/\r\n?/g, '\n').split('\n');
+  const lines = rawText
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .filter((l) => !isGridSeparator(l));
 
   const result: ParsedLetter = { references: [], enclosures: [], copyTos: [], paragraphs: [] };
 

--- a/src/lib/pdfText.ts
+++ b/src/lib/pdfText.ts
@@ -1,0 +1,98 @@
+import { pdfjs } from 'react-pdf';
+import { HARDENED_PDF_OPTIONS } from '@/components/pdf/pdfConfig';
+
+/**
+ * Extract text from a PDF as ordered lines, in the browser, from the pdf.js
+ * already bundled for the preview (same worker, same CVE-2024-4367 hardening).
+ * Nothing leaves the tab — consistent with the app's offline/air-gap posture.
+ *
+ * pdf.js hands back positioned text *fragments*, not lines: a line rendered in
+ * two fonts arrives as two items, and items aren't guaranteed left-to-right.
+ * So we regroup by vertical position — items whose baseline Y is within a
+ * tolerance form one line, sorted left-to-right — and read a paragraph break
+ * from a larger-than-normal vertical gap. That reconstruction is what lets the
+ * naval-letter parser see "From:", "Subj:", and "1." as whole lines again.
+ *
+ * Text-layer only: a scanned/image PDF has no text to extract and yields an
+ * empty result (that's the OCR path, deliberately out of scope here).
+ */
+
+export interface PositionedItem {
+  str: string;
+  x: number;
+  y: number;
+  height: number;
+}
+
+// Two fragments belong to the same line when their baselines sit within this
+// fraction of the text height — enough to absorb sub/superscript jitter without
+// merging adjacent lines.
+const LINE_TOLERANCE_RATIO = 0.5;
+
+/** Group positioned fragments on one page into left-to-right lines, top-down.
+ *  Exported for unit testing without a live pdf.js document. */
+export function itemsToLines(items: PositionedItem[]): string[] {
+  if (items.length === 0) return [];
+  // Top-to-bottom (PDF Y grows upward), then left-to-right within a line.
+  const sorted = [...items].sort((a, b) => b.y - a.y || a.x - b.x);
+
+  const lines: string[] = [];
+  let bucket: PositionedItem[] = [sorted[0]];
+  let bucketY = sorted[0].y;
+  const medianHeight = sorted[0].height || 10;
+
+  const flush = () => {
+    const line = bucket
+      .sort((a, b) => a.x - b.x)
+      .map((it) => it.str)
+      .join('')
+      .replace(/\s+/g, ' ')
+      .trimEnd();
+    lines.push(line);
+  };
+
+  for (let i = 1; i < sorted.length; i++) {
+    const it = sorted[i];
+    const tol = Math.max(medianHeight, it.height || medianHeight) * LINE_TOLERANCE_RATIO;
+    if (Math.abs(it.y - bucketY) <= tol) {
+      bucket.push(it);
+    } else {
+      flush();
+      bucket = [it];
+      bucketY = it.y;
+    }
+  }
+  flush();
+  return lines;
+}
+
+/**
+ * Read every page of a PDF (given as bytes) into text lines. Pages are joined
+ * with a blank line so the parser sees page breaks as paragraph boundaries.
+ * Returns `''` for a PDF with no text layer.
+ */
+export async function extractPdfText(data: Uint8Array | ArrayBuffer): Promise<string> {
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+  const doc = await pdfjs.getDocument({ data: bytes, ...HARDENED_PDF_OPTIONS }).promise;
+  try {
+    const pageLines: string[][] = [];
+    for (let n = 1; n <= doc.numPages; n++) {
+      const page = await doc.getPage(n);
+      const content = await page.getTextContent();
+      const items: PositionedItem[] = content.items
+        .filter((it): it is Extract<typeof it, { str: string }> => 'str' in it)
+        .map((it) => ({
+          str: it.str,
+          x: it.transform[4],
+          y: it.transform[5],
+          height: Math.abs(it.transform[3]) || it.height || 10,
+        }));
+      pageLines.push(itemsToLines(items));
+      page.cleanup();
+    }
+    return pageLines.map((lines) => lines.join('\n')).join('\n\n').trim();
+  } finally {
+    // Free the worker-side document; a leaked handle keeps the PDF in memory.
+    await doc.destroy();
+  }
+}

--- a/src/services/docx/pandoc-converter.ts
+++ b/src/services/docx/pandoc-converter.ts
@@ -228,6 +228,31 @@ export async function convertDocxToPlainText(bytes: Uint8Array): Promise<string>
   return result.stdout ?? '';
 }
 
+/**
+ * Extract the text of a .docx file's headers and footers, one line per source
+ * paragraph. The classification banner is rendered into the Word page header
+ * and footer (word/header*.xml, word/footer*.xml), which pandoc's body-only
+ * `docx → plain` read never sees — so the importer reads these parts directly
+ * to recover the banner marking. Pure text, in-browser (JSZip), no network.
+ */
+export async function extractDocxMarkingText(bytes: Uint8Array): Promise<string> {
+  const zip = await JSZip.loadAsync(bytes.slice().buffer);
+  const parts = Object.keys(zip.files).filter((n) => /word\/(?:header|footer)\d*\.xml$/i.test(n));
+  const chunks: string[] = [];
+  for (const name of parts) {
+    const xml = await zip.files[name].async('string');
+    const text = xml
+      .replace(/<\/w:p>/g, '\n') // paragraph break → newline (banner on its own line)
+      .replace(/<[^>]+>/g, '') // drop all tags, keeping run text
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/[ \t]+/g, ' ');
+    if (text.trim()) chunks.push(text.trim());
+  }
+  return chunks.join('\n');
+}
+
 function getSealFilename(sealType?: string, letterheadColor?: string): string {
   const type = sealType || 'dow';
   const bwSuffix = letterheadColor === 'black' ? '-bw' : '';

--- a/src/services/docx/pandoc-converter.ts
+++ b/src/services/docx/pandoc-converter.ts
@@ -228,12 +228,29 @@ export async function convertDocxToPlainText(bytes: Uint8Array): Promise<string>
   return result.stdout ?? '';
 }
 
+// Decode the five predefined XML entities. Order matters: "&amp;" is decoded
+// LAST so an input like "&amp;lt;" resolves to the literal "&lt;" rather than
+// being double-unescaped into "<".
+function decodeXmlText(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
 /**
  * Extract the text of a .docx file's headers and footers, one line per source
  * paragraph. The classification banner is rendered into the Word page header
  * and footer (word/header*.xml, word/footer*.xml), which pandoc's body-only
  * `docx → plain` read never sees — so the importer reads these parts directly
  * to recover the banner marking. Pure text, in-browser (JSZip), no network.
+ *
+ * Rather than strip tags from the raw XML (an incomplete, injection-prone form
+ * of sanitization), it pulls the text out of each `<w:t>` run and joins the runs
+ * within a `<w:p>` paragraph — OOXML run text contains no nested markup, so this
+ * is exact. Paragraphs become newlines, keeping the banner on its own line.
  */
 export async function extractDocxMarkingText(bytes: Uint8Array): Promise<string> {
   const zip = await JSZip.loadAsync(bytes.slice().buffer);
@@ -241,14 +258,14 @@ export async function extractDocxMarkingText(bytes: Uint8Array): Promise<string>
   const chunks: string[] = [];
   for (const name of parts) {
     const xml = await zip.files[name].async('string');
-    const text = xml
-      .replace(/<\/w:p>/g, '\n') // paragraph break → newline (banner on its own line)
-      .replace(/<[^>]+>/g, '') // drop all tags, keeping run text
-      .replace(/&amp;/g, '&')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/[ \t]+/g, ' ');
-    if (text.trim()) chunks.push(text.trim());
+    const lines: string[] = [];
+    // Split on the paragraph close tag so each <w:p> becomes its own line.
+    for (const paragraph of xml.split(/<\/w:p>/)) {
+      const runs = [...paragraph.matchAll(/<w:t\b[^>]*>([\s\S]*?)<\/w:t>/g)].map((m) => m[1]);
+      const text = decodeXmlText(runs.join('')).replace(/[ \t]+/g, ' ').trim();
+      if (text) lines.push(text);
+    }
+    if (lines.length) chunks.push(lines.join('\n'));
   }
   return chunks.join('\n');
 }

--- a/src/services/docx/pandoc-converter.ts
+++ b/src/services/docx/pandoc-converter.ts
@@ -187,6 +187,47 @@ export async function prefetchPandocModule(): Promise<void> {
   }
 }
 
+/**
+ * Read a .docx file's text content by running pandoc WASM in reverse
+ * (docx → plain). Used by the letter importer so the same SECNAV parser can
+ * consume Word documents, not just PDFs. Everything runs in-browser, offline.
+ *
+ * The bytes are handed to pandoc through the virtual-FS `files` map (binary
+ * input can't go through the string `stdin` channel — it would be mangled by
+ * UTF-8 encoding); `input-files` names the entry to read. `wrap: 'none'` keeps
+ * each source paragraph on a single line so the line-oriented header parser
+ * sees "From:", "To:", "Subj:" intact rather than hard-wrapped at 72 columns.
+ */
+export async function convertDocxToPlainText(bytes: Uint8Array): Promise<string> {
+  const mod = await ensureLoaded();
+
+  // Copy into a standalone ArrayBuffer so the Blob owns its bytes regardless of
+  // how the caller allocated the view (e.g. a subarray of a larger buffer).
+  const buffer = bytes.slice().buffer;
+  const files: Record<string, Blob> = {
+    'input.docx': new Blob([buffer], {
+      type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    }),
+  };
+
+  const options: Record<string, unknown> = {
+    from: 'docx',
+    to: 'plain',
+    'input-files': ['input.docx'],
+    'output-file': 'output.txt',
+    wrap: 'none',
+  };
+
+  debug.log('DOCX', 'Reading DOCX text via pandoc (docx → plain)...');
+  const result = await mod.convert(options, null, files);
+  if (result.stderr) debug.warn('DOCX', `Pandoc docx-read stderr: ${result.stderr}`);
+
+  const out = files['output.txt'];
+  if (out && out.size > 0) return out.text();
+  // Fall back to stdout if the build streams the result there instead.
+  return result.stdout ?? '';
+}
+
 function getSealFilename(sealType?: string, letterheadColor?: string): string {
   const type = sealType || 'dow';
   const bwSuffix = letterheadColor === 'black' ? '-bw' : '';

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -45,6 +45,7 @@ interface UIState {
   aboutModalOpen: boolean;
   nistModalOpen: boolean;
   batchModalOpen: boolean;
+  importLetterModalOpen: boolean;
   commandPaletteOpen: boolean;
   findReplaceOpen: boolean;
   templateLoaderOpen: boolean;
@@ -71,6 +72,7 @@ interface UIState {
   setAboutModalOpen: (open: boolean) => void;
   setNistModalOpen: (open: boolean) => void;
   setBatchModalOpen: (open: boolean) => void;
+  setImportLetterModalOpen: (open: boolean) => void;
   setCommandPaletteOpen: (open: boolean) => void;
   setFindReplaceOpen: (open: boolean) => void;
   setTemplateLoaderOpen: (open: boolean) => void;
@@ -164,6 +166,7 @@ export const useUIStore = create<UIState>()(
       aboutModalOpen: false,
       nistModalOpen: false,
       batchModalOpen: false,
+      importLetterModalOpen: false,
       commandPaletteOpen: false,
       findReplaceOpen: false,
       templateLoaderOpen: false,
@@ -182,6 +185,7 @@ export const useUIStore = create<UIState>()(
       setAboutModalOpen: (open) => set({ aboutModalOpen: open }),
       setNistModalOpen: (open) => set({ nistModalOpen: open }),
       setBatchModalOpen: (open) => set({ batchModalOpen: open }),
+      setImportLetterModalOpen: (open) => set({ importLetterModalOpen: open }),
       setCommandPaletteOpen: (open) => set({ commandPaletteOpen: open }),
       setFindReplaceOpen: (open) => set({ findReplaceOpen: open }),
       setTemplateLoaderOpen: (open) => set({ templateLoaderOpen: open }),
@@ -233,6 +237,7 @@ export const useUIStore = create<UIState>()(
         aboutModalOpen: false,
         nistModalOpen: false,
         batchModalOpen: false,
+        importLetterModalOpen: false,
         commandPaletteOpen: false,
         findReplaceOpen: false,
         templateLoaderOpen: false,

--- a/tests/component/ImportLetterModal.test.tsx
+++ b/tests/component/ImportLetterModal.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@/lib/importLetter', () => ({
   isDocxFile: (f: File) =>
     /\.docx$/i.test(f.name) ||
     f.type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  isLegacyDocFile: (f: File) => /\.doc$/i.test(f.name) || f.type === 'application/msword',
 }));
 
 import { ImportLetterModal } from '@/components/modals/ImportLetterModal';
@@ -72,6 +73,15 @@ describe('ImportLetterModal — failed imports reach the error phase', () => {
     selectFile(new File(['x'], 'blank.pdf', { type: 'application/pdf' }));
 
     expect(await screen.findByText(/Couldn't find letter text in this PDF/i)).toBeTruthy();
+  });
+
+  it('rejects a legacy .doc up front with a re-save hint (no parse attempted)', async () => {
+    render(<ImportLetterModal />);
+    selectFile(new File(['x'], 'memo.doc', { type: 'application/msword' }));
+
+    expect(await screen.findByText(/Legacy Word .* can.t be imported/i)).toBeTruthy();
+    expect(await screen.findByText(/save as .*docx/i)).toBeTruthy();
+    expect(mockParse).not.toHaveBeenCalled();
   });
 
   it('recovers to the file picker after an error', async () => {

--- a/tests/component/ImportLetterModal.test.tsx
+++ b/tests/component/ImportLetterModal.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Component tests for <ImportLetterModal>.
+ *
+ * These lock in that a *failed* import surfaces the error phase (not a silent
+ * failure or a crash): a thrown read error, and a file with no recognizable
+ * text, both land on the themed error message with a way to pick another file.
+ * The heavy readers (pandoc/pdf.js) are mocked out — this is about the modal's
+ * failure wiring, not extraction.
+ */
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// Mock the import pipeline so no PDF/DOCX engine loads; isDocxFile stays real
+// so the message branches by extension.
+vi.mock('@/lib/importLetter', () => ({
+  parseLetterFile: vi.fn(),
+  hasParsedContent: vi.fn(),
+  applyParsedLetter: vi.fn(),
+  isDocxFile: (f: File) =>
+    /\.docx$/i.test(f.name) ||
+    f.type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+}));
+
+import { ImportLetterModal } from '@/components/modals/ImportLetterModal';
+import { useUIStore } from '@/stores/uiStore';
+import { parseLetterFile, hasParsedContent } from '@/lib/importLetter';
+
+const mockParse = vi.mocked(parseLetterFile);
+const mockHasContent = vi.mocked(hasParsedContent);
+
+// The dialog (and its file input) render through a Radix portal on document.body,
+// not inside the render container.
+function selectFile(file: File) {
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+  fireEvent.change(input, { target: { files: [file] } });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useUIStore.setState({ importLetterModalOpen: true });
+});
+
+describe('ImportLetterModal — failed imports reach the error phase', () => {
+  it('shows a PDF-specific error when the read throws', async () => {
+    mockParse.mockRejectedValue(new Error('bad pdf'));
+    render(<ImportLetterModal />);
+    selectFile(new File(['x'], 'letter.pdf', { type: 'application/pdf' }));
+
+    expect(await screen.findByText(/This PDF could not be read/i)).toBeTruthy();
+    // And offers a way to recover.
+    expect(screen.getByRole('button', { name: /choose a different file/i })).toBeTruthy();
+  });
+
+  it('shows a Word-specific error (engine hint) when a DOCX read throws', async () => {
+    mockParse.mockRejectedValue(new Error('pandoc failed'));
+    render(<ImportLetterModal />);
+    selectFile(new File(['x'], 'letter.docx'));
+
+    expect(await screen.findByText(/Word document could not be read/i)).toBeTruthy();
+    expect(await screen.findByText(/document engine could not start/i)).toBeTruthy();
+  });
+
+  it('shows a "no text" error when nothing parseable was found', async () => {
+    mockParse.mockResolvedValue({
+      parsed: { references: [], enclosures: [], copyTos: [], paragraphs: [] },
+      detection: { docType: 'naval_letter', confidence: 'low', reason: '' },
+      classification: { classLevel: 'unclassified', found: false, reason: '' },
+    });
+    mockHasContent.mockReturnValue(false);
+    render(<ImportLetterModal />);
+    selectFile(new File(['x'], 'blank.pdf', { type: 'application/pdf' }));
+
+    expect(await screen.findByText(/Couldn't find letter text in this PDF/i)).toBeTruthy();
+  });
+
+  it('recovers to the file picker after an error', async () => {
+    mockParse.mockRejectedValue(new Error('bad'));
+    render(<ImportLetterModal />);
+    selectFile(new File(['x'], 'letter.pdf', { type: 'application/pdf' }));
+
+    const back = await screen.findByRole('button', { name: /choose a different file/i });
+    fireEvent.click(back);
+    // Back to idle: the drop target prompt is shown again.
+    expect(await screen.findByText(/Choose a PDF or Word file to import/i)).toBeTruthy();
+  });
+});

--- a/tests/unit/detectClassification.test.ts
+++ b/tests/unit/detectClassification.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { detectClassification, CLASSIFICATION_LABELS } from '@/lib/detectClassification';
+
+describe('detectClassification — banner level', () => {
+  it('reads a SECRET banner from a standalone line', () => {
+    const d = detectClassification(['SECRET', '', 'From: A', '', '1. Body.', '', 'SECRET'].join('\n'));
+    expect(d).toMatchObject({ classLevel: 'secret', found: true });
+  });
+
+  it('reads CONFIDENTIAL', () => {
+    expect(detectClassification('CONFIDENTIAL\n\n1. Body.').classLevel).toBe('confidential');
+  });
+
+  it('reads CUI (and the spelled-out form)', () => {
+    expect(detectClassification('CUI\n1. x').classLevel).toBe('cui');
+    expect(detectClassification('CONTROLLED UNCLASSIFIED INFORMATION\n1. x').classLevel).toBe('cui');
+  });
+
+  it('distinguishes TOP SECRET from SECRET', () => {
+    expect(detectClassification('TOP SECRET\n1. x').classLevel).toBe('top_secret');
+  });
+
+  it('reads TOP SECRET//SCI as its own level', () => {
+    expect(detectClassification('TOP SECRET//SCI\n1. x').classLevel).toBe('top_secret_sci');
+  });
+
+  it('tolerates a dissemination trailer on the banner (SECRET//NOFORN)', () => {
+    expect(detectClassification('SECRET//NOFORN\n1. x').classLevel).toBe('secret');
+  });
+
+  it('takes the highest marking when several appear (highest wins)', () => {
+    // A page footer might read UNCLASSIFIED while a header reads SECRET.
+    const d = detectClassification(['SECRET', '1. x', 'UNCLASSIFIED'].join('\n'));
+    expect(d.classLevel).toBe('secret');
+  });
+});
+
+describe('detectClassification — false positives', () => {
+  it('does not treat "SECRETARY OF THE NAVY" as a SECRET banner', () => {
+    const d = detectClassification('From: SECRETARY OF THE NAVY\n\n1. Body.');
+    expect(d.found).toBe(false);
+    expect(d.classLevel).toBe('unclassified');
+  });
+
+  it('does not fire on the word secret mid-sentence', () => {
+    const d = detectClassification('1. Keep this a secret between us.');
+    expect(d.found).toBe(false);
+  });
+
+  it('reports not-found for a plain unmarked letter', () => {
+    const d = detectClassification('From: A\nTo: B\nSubj: C\n\n1. Body.');
+    expect(d).toMatchObject({ found: false, classLevel: 'unclassified' });
+  });
+});
+
+describe('detectClassification — derivative classification authority block', () => {
+  it('captures Classified by / Derived from / Declassify on / Reason', () => {
+    const d = detectClassification(
+      [
+        'SECRET',
+        '',
+        '1. Body.',
+        '',
+        'Classified by: Director, Naval Intelligence',
+        'Derived from: OPNAV SCG 5510.1',
+        'Declassify on: 20501231',
+        'Reason: 1.4(c)',
+        '',
+        'SECRET',
+      ].join('\n')
+    );
+    expect(d.classLevel).toBe('secret');
+    expect(d.classifiedBy).toBe('Director, Naval Intelligence');
+    expect(d.derivedFrom).toBe('OPNAV SCG 5510.1');
+    expect(d.declassifyOn).toBe('20501231');
+    expect(d.classReason).toBe('1.4(c)');
+  });
+
+  it('finds an authority block even with no clean banner, and asks to confirm', () => {
+    const d = detectClassification('Derived from: Multiple Sources\nDeclassify on: 20301231');
+    expect(d.found).toBe(true);
+    expect(d.derivedFrom).toBe('Multiple Sources');
+    expect(d.reason).toMatch(/confirm/i);
+  });
+});
+
+describe('detectClassification — labels', () => {
+  it('has a label for every classification level', () => {
+    for (const level of ['unclassified', 'cui', 'confidential', 'secret', 'top_secret', 'top_secret_sci'] as const) {
+      expect(CLASSIFICATION_LABELS[level]).toBeTruthy();
+    }
+  });
+});

--- a/tests/unit/detectClassification.test.ts
+++ b/tests/unit/detectClassification.test.ts
@@ -33,6 +33,20 @@ describe('detectClassification — banner level', () => {
     const d = detectClassification(['SECRET', '1. x', 'UNCLASSIFIED'].join('\n'));
     expect(d.classLevel).toBe('secret');
   });
+
+  it('tolerates whitespace around the // control separator', () => {
+    expect(detectClassification('TOP SECRET // SCI\n1. x').classLevel).toBe('top_secret_sci');
+  });
+
+  it('reads a legacy FOUO banner as CUI', () => {
+    expect(detectClassification('FOR OFFICIAL USE ONLY\n1. x').classLevel).toBe('cui');
+    expect(detectClassification('UNCLASSIFIED//FOUO\n1. x').classLevel).toBe('cui');
+  });
+
+  it('detects a banner that appears only once (single-page document)', () => {
+    const d = detectClassification('SECRET\n\nFrom: A\n\n1. Body.');
+    expect(d).toMatchObject({ classLevel: 'secret', found: true });
+  });
 });
 
 describe('detectClassification — false positives', () => {
@@ -45,6 +59,13 @@ describe('detectClassification — false positives', () => {
   it('does not fire on the word secret mid-sentence', () => {
     const d = detectClassification('1. Keep this a secret between us.');
     expect(d.found).toBe(false);
+  });
+
+  it('does not treat a prose line that merely starts with the word as a banner', () => {
+    // The trailer must start with "//" — plain trailing words are not a banner.
+    expect(detectClassification('SECRET SERVICE DETAIL ASSIGNMENTS').found).toBe(false);
+    expect(detectClassification('CONFIDENTIAL sources report the following.').found).toBe(false);
+    expect(detectClassification('TOP SECRETARY DUTIES').found).toBe(false);
   });
 
   it('reports not-found for a plain unmarked letter', () => {

--- a/tests/unit/detectClassification.test.ts
+++ b/tests/unit/detectClassification.test.ts
@@ -103,6 +103,14 @@ describe('detectClassification — derivative classification authority block', (
     expect(d.derivedFrom).toBe('Multiple Sources');
     expect(d.reason).toMatch(/confirm/i);
   });
+
+  it('does not treat a lone "Reason:" line as a classification block', () => {
+    // "Reason:" appears in ordinary prose; it only counts alongside a strong
+    // authority label (Classified by / Derived from / Declassify on).
+    const d = detectClassification('From: A\nTo: B\n\n1. Reason: the request was denied.');
+    expect(d.found).toBe(false);
+    expect(d.classReason).toBeUndefined();
+  });
 });
 
 describe('detectClassification — labels', () => {

--- a/tests/unit/detectDocumentType.test.ts
+++ b/tests/unit/detectDocumentType.test.ts
@@ -36,6 +36,32 @@ describe('detectDocumentType — strong markers (high confidence)', () => {
     expect(d.docType).toBe('mfr');
     expect(d.confidence).toBe('high');
   });
+
+  it('matches an endorsement line even with leading indentation', () => {
+    const d = detectDocumentType('        FIRST ENDORSEMENT on CO ltr 1650');
+    expect(d).toMatchObject({ docType: 'new_page_endorsement', confidence: 'high' });
+  });
+});
+
+describe('detectDocumentType — markers must be title lines, not phrases', () => {
+  it('does not read a letter that mentions an MOA in its subject as an MOA', () => {
+    const d = detectDocumentType(
+      ['From: A', 'To: B', '', 'Subj: RENEWAL OF THE MEMORANDUM OF AGREEMENT', '', '1. Body.'].join('\n')
+    );
+    expect(d.docType).toBe('naval_letter');
+    expect(d.confidence).toBe('high');
+  });
+
+  it('does not read a body reference to a memorandum as a memorandum', () => {
+    const d = detectDocumentType('From: A\n\n1. Comply with the memorandum of understanding cited.');
+    expect(d.docType).not.toBe('mou');
+    expect(d.docType).not.toBe('plain_paper_memorandum');
+  });
+
+  it('still catches an MOA whose title line carries trailing text', () => {
+    const d = detectDocumentType('MEMORANDUM OF AGREEMENT BETWEEN THE NAVY AND THE ARMY');
+    expect(d).toMatchObject({ docType: 'moa', confidence: 'high' });
+  });
 });
 
 describe('detectDocumentType — letters', () => {

--- a/tests/unit/detectDocumentType.test.ts
+++ b/tests/unit/detectDocumentType.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { detectDocumentType, IMPORTABLE_DOC_TYPES } from '@/lib/detectDocumentType';
+import { DOC_TYPE_LABELS } from '@/types/document';
+
+describe('detectDocumentType — strong markers (high confidence)', () => {
+  it('recognizes a Memorandum for the Record', () => {
+    const d = detectDocumentType('MEMORANDUM FOR THE RECORD\n\n1. This documents the meeting.');
+    expect(d).toMatchObject({ docType: 'mfr', confidence: 'high' });
+  });
+
+  it('recognizes a Memorandum of Agreement', () => {
+    const d = detectDocumentType('MEMORANDUM OF AGREEMENT BETWEEN A AND B');
+    expect(d).toMatchObject({ docType: 'moa', confidence: 'high' });
+  });
+
+  it('recognizes a Memorandum of Understanding', () => {
+    const d = detectDocumentType('MEMORANDUM OF UNDERSTANDING\n\n1. Purpose.');
+    expect(d).toMatchObject({ docType: 'mou', confidence: 'high' });
+  });
+
+  it('recognizes an endorsement by its endorsement line (word ordinal)', () => {
+    const d = detectDocumentType(
+      'FIRST ENDORSEMENT on CO ltr 1650 Ser 024 of 15 Jan 25\n\nFrom: A\nTo: B'
+    );
+    expect(d).toMatchObject({ docType: 'new_page_endorsement', confidence: 'high' });
+  });
+
+  it('recognizes an endorsement by a numeric ordinal ("2nd Endorsement")', () => {
+    const d = detectDocumentType('2nd Endorsement\n\nFrom: A\nTo: B');
+    expect(d).toMatchObject({ docType: 'new_page_endorsement', confidence: 'high' });
+  });
+
+  it('prefers the record marker over the generic memorandum branch', () => {
+    // "MEMORANDUM FOR THE RECORD" contains "MEMORANDUM" — the strong marker wins.
+    const d = detectDocumentType('MEMORANDUM FOR THE RECORD');
+    expect(d.docType).toBe('mfr');
+    expect(d.confidence).toBe('high');
+  });
+});
+
+describe('detectDocumentType — letters', () => {
+  it('recognizes a full From/To/Subj naval letter (high confidence)', () => {
+    const d = detectDocumentType(
+      ['From: Commanding Officer', 'To: Sergeant Doe', '', 'Subj: APPOINTMENT', '', '1. Body.'].join('\n')
+    );
+    expect(d).toMatchObject({ docType: 'naval_letter', confidence: 'high' });
+  });
+
+  it('recognizes a business letter by salutation + close', () => {
+    const d = detectDocumentType('Dear Senator Smith,\n\nThank you for your inquiry.\n\nSincerely,\n\nA. B. Jones');
+    expect(d).toMatchObject({ docType: 'business_letter', confidence: 'high' });
+  });
+
+  it('does not call a From/To/Subj letter a business letter', () => {
+    // Has "Dear"/"Sincerely" cues but a Subj line makes it naval, not business.
+    const d = detectDocumentType(
+      ['From: A', 'To: B', 'Subj: X', '', 'Dear Sir,', '', '1. Body.', '', 'Sincerely'].join('\n')
+    );
+    expect(d.docType).toBe('naval_letter');
+  });
+});
+
+describe('detectDocumentType — low confidence prompts', () => {
+  it('flags a generic memorandum for confirmation', () => {
+    const d = detectDocumentType('MEMORANDUM FOR ALL HANDS\n\n1. Field day is Friday.');
+    expect(d).toMatchObject({ docType: 'plain_paper_memorandum', confidence: 'low' });
+  });
+
+  it('flags partial addressing for confirmation', () => {
+    const d = detectDocumentType('From: A\n\n1. Body with no To or Subj.');
+    expect(d).toMatchObject({ docType: 'naval_letter', confidence: 'low' });
+  });
+
+  it('flags unrecognizable text for confirmation', () => {
+    const d = detectDocumentType('just some free text with no structure at all');
+    expect(d).toMatchObject({ docType: 'naval_letter', confidence: 'low' });
+  });
+});
+
+describe('detectDocumentType — contract', () => {
+  it('always returns an importable doc type', () => {
+    const samples = [
+      'MEMORANDUM FOR THE RECORD',
+      'From: A\nTo: B\nSubj: C',
+      'Dear X,\nSincerely',
+      'nothing structured',
+      'FIRST ENDORSEMENT',
+    ];
+    for (const s of samples) {
+      expect(IMPORTABLE_DOC_TYPES).toContain(detectDocumentType(s).docType as (typeof IMPORTABLE_DOC_TYPES)[number]);
+    }
+  });
+
+  it('every importable type has a UI label', () => {
+    for (const t of IMPORTABLE_DOC_TYPES) {
+      expect(DOC_TYPE_LABELS[t]).toBeTruthy();
+    }
+  });
+});

--- a/tests/unit/extractDocxMarkingText.test.ts
+++ b/tests/unit/extractDocxMarkingText.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { extractDocxMarkingText } from '@/services/docx/pandoc-converter';
+
+/**
+ * The classification banner is rendered into the Word page header/footer, which
+ * pandoc's body-only `docx → plain` read never sees. `extractDocxMarkingText`
+ * reads those parts straight from the .docx zip so the importer can recover the
+ * banner. These build minimal, docx-shaped zips to prove that extraction.
+ */
+
+// One `<w:p>` paragraph whose runs concatenate to `text`.
+const para = (runs: string[]) =>
+  `<w:p>${runs.map((r) => `<w:r><w:t xml:space="preserve">${r}</w:t></w:r>`).join('')}</w:p>`;
+
+async function makeDocx(files: Record<string, string>): Promise<Uint8Array> {
+  const zip = new JSZip();
+  for (const [name, xml] of Object.entries(files)) zip.file(name, xml);
+  return zip.generateAsync({ type: 'uint8array' });
+}
+
+describe('extractDocxMarkingText', () => {
+  it('pulls the banner from header and footer, one line each', async () => {
+    const bytes = await makeDocx({
+      'word/document.xml': `<w:document><w:body>${para(['Body text only.'])}</w:body></w:document>`,
+      'word/header1.xml': `<w:hdr>${para(['SECRET'])}</w:hdr>`,
+      'word/footer1.xml': `<w:ftr>${para(['SECRET'])}</w:ftr>`,
+    });
+    const text = await extractDocxMarkingText(bytes);
+    const lines = text.split('\n').map((l) => l.trim()).filter(Boolean);
+    expect(lines).toContain('SECRET');
+    // It reads ONLY headers/footers, never the document body.
+    expect(text).not.toMatch(/Body text only/);
+  });
+
+  it('concatenates a banner split across multiple runs', async () => {
+    // Word often splits a styled word into several <w:t> runs.
+    const bytes = await makeDocx({
+      'word/header2.xml': `<w:hdr>${para(['TOP ', 'SECRET', '//', 'SCI'])}</w:hdr>`,
+    });
+    const text = await extractDocxMarkingText(bytes);
+    expect(text.replace(/\s+/g, ' ')).toContain('TOP SECRET//SCI');
+  });
+
+  it('separates distinct header paragraphs with newlines', async () => {
+    const bytes = await makeDocx({
+      'word/header1.xml': `<w:hdr>${para(['CUI'])}${para(['Controlled by: G-2'])}</w:hdr>`,
+    });
+    const lines = (await extractDocxMarkingText(bytes)).split('\n').map((l) => l.trim());
+    expect(lines).toContain('CUI');
+    expect(lines).toContain('Controlled by: G-2');
+  });
+
+  it('returns empty string when there are no headers or footers', async () => {
+    const bytes = await makeDocx({
+      'word/document.xml': `<w:document><w:body>${para(['Just a body.'])}</w:body></w:document>`,
+    });
+    expect(await extractDocxMarkingText(bytes)).toBe('');
+  });
+
+  it('decodes XML entities in the marking text', async () => {
+    const bytes = await makeDocx({
+      'word/footer1.xml': `<w:ftr>${para(['SECRET &amp; SPECIAL'])}</w:ftr>`,
+    });
+    expect(await extractDocxMarkingText(bytes)).toContain('SECRET & SPECIAL');
+  });
+});

--- a/tests/unit/extractDocxMarkingText.test.ts
+++ b/tests/unit/extractDocxMarkingText.test.ts
@@ -64,4 +64,23 @@ describe('extractDocxMarkingText', () => {
     });
     expect(await extractDocxMarkingText(bytes)).toContain('SECRET & SPECIAL');
   });
+
+  it('does not double-unescape entities (&amp;lt; stays &lt;)', async () => {
+    // Ampersand must be decoded last: "&amp;lt;" is a literal "&lt;", not "<".
+    const bytes = await makeDocx({
+      'word/header1.xml': `<w:hdr>${para(['A &amp;lt; B'])}</w:hdr>`,
+    });
+    const text = await extractDocxMarkingText(bytes);
+    expect(text).toContain('A &lt; B');
+    expect(text).not.toContain('A < B');
+  });
+
+  it('does not let a run that contains angle brackets inject markup', async () => {
+    // Run text arrives escaped; "&lt;script&gt;" decodes to literal text, and
+    // there is no tag-stripping pass that could be bypassed.
+    const bytes = await makeDocx({
+      'word/footer1.xml': `<w:ftr>${para(['&lt;script&gt;alert(1)&lt;/script&gt;'])}</w:ftr>`,
+    });
+    expect(await extractDocxMarkingText(bytes)).toBe('<script>alert(1)</script>');
+  });
 });

--- a/tests/unit/importFormat.test.ts
+++ b/tests/unit/importFormat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { detectImportFormat, isDocxFile, DOCX_MIME } from '@/lib/importFormat';
+import { detectImportFormat, isDocxFile, isLegacyDocFile, DOCX_MIME } from '@/lib/importFormat';
 
 // detectImportFormat/isDocxFile read only name + type, so a lightweight stand-in
 // avoids constructing a real File in the node test environment.
@@ -44,5 +44,22 @@ describe('isDocxFile', () => {
     expect(isDocxFile(asFile('a.docx'))).toBe(true);
     expect(isDocxFile(asFile('a', DOCX_MIME))).toBe(true);
     expect(isDocxFile(asFile('a.pdf', 'application/pdf'))).toBe(false);
+  });
+});
+
+describe('isLegacyDocFile', () => {
+  const OLE = new Uint8Array([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+  it('recognizes a legacy .doc by extension and by the msword MIME', () => {
+    expect(isLegacyDocFile(asFile('memo.doc'))).toBe(true);
+    expect(isLegacyDocFile(asFile('memo', 'application/msword'))).toBe(true);
+  });
+  it('recognizes the OLE compound-file magic when bytes are provided', () => {
+    expect(isLegacyDocFile(asFile('memo'), OLE)).toBe(true);
+  });
+  it('does not flag a modern .docx as legacy (".doc$" excludes ".docx")', () => {
+    expect(isLegacyDocFile(asFile('memo.docx', DOCX_MIME))).toBe(false);
+  });
+  it('does not flag a PDF', () => {
+    expect(isLegacyDocFile(asFile('memo.pdf', 'application/pdf'), PDF_MAGIC)).toBe(false);
   });
 });

--- a/tests/unit/importFormat.test.ts
+++ b/tests/unit/importFormat.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { detectImportFormat, isDocxFile, DOCX_MIME } from '@/lib/importFormat';
+
+// detectImportFormat/isDocxFile read only name + type, so a lightweight stand-in
+// avoids constructing a real File in the node test environment.
+const asFile = (name: string, type = '') => ({ name, type }) as Pick<File, 'name' | 'type'>;
+const PDF_MAGIC = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]); // "%PDF-"
+const ZIP_MAGIC = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x14]); // PK\x03\x04 (docx/zip)
+const GARBAGE = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+
+describe('detectImportFormat — extension / MIME (trusted first)', () => {
+  it('routes a .docx name to docx', () => {
+    expect(detectImportFormat(asFile('letter.docx'), GARBAGE)).toBe('docx');
+  });
+  it('routes a .pdf name to pdf', () => {
+    expect(detectImportFormat(asFile('letter.pdf'), GARBAGE)).toBe('pdf');
+  });
+  it('routes by the Word MIME type when the name is unhelpful', () => {
+    expect(detectImportFormat(asFile('download', DOCX_MIME), GARBAGE)).toBe('docx');
+  });
+  it('routes by the PDF MIME type', () => {
+    expect(detectImportFormat(asFile('download', 'application/pdf'), GARBAGE)).toBe('pdf');
+  });
+});
+
+describe('detectImportFormat — magic-byte fallback', () => {
+  it('detects a PDF from %PDF when the file has no useful name or type', () => {
+    expect(detectImportFormat(asFile('', 'application/octet-stream'), PDF_MAGIC)).toBe('pdf');
+  });
+  it('detects a DOCX from the PK zip header when mislabeled', () => {
+    expect(detectImportFormat(asFile('report', ''), ZIP_MAGIC)).toBe('docx');
+  });
+  it('returns null when nothing identifies the format', () => {
+    expect(detectImportFormat(asFile('mystery.txt', 'text/plain'), GARBAGE)).toBeNull();
+  });
+  it('extension still wins over magic bytes (a named .pdf is read as PDF)', () => {
+    // Trust the user-facing extension first; magic bytes are only the fallback.
+    expect(detectImportFormat(asFile('letter.pdf'), ZIP_MAGIC)).toBe('pdf');
+  });
+});
+
+describe('isDocxFile', () => {
+  it('matches by extension and by MIME, and rejects a PDF', () => {
+    expect(isDocxFile(asFile('a.docx'))).toBe(true);
+    expect(isDocxFile(asFile('a', DOCX_MIME))).toBe(true);
+    expect(isDocxFile(asFile('a.pdf', 'application/pdf'))).toBe(false);
+  });
+});

--- a/tests/unit/parseNavalLetter.test.ts
+++ b/tests/unit/parseNavalLetter.test.ts
@@ -130,6 +130,24 @@ describe('parseNavalLetter — portion markings', () => {
     expect(p.paragraphs[0]).toEqual({ text: 'Top.', level: 0, portionMarking: 'CUI' });
     expect(p.paragraphs[1]).toEqual({ text: 'Plain sub with no mark.', level: 1 });
   });
+
+  it('captures a portion mark on a paren-numbered paragraph', () => {
+    const p = parseNavalLetter('        (1) (S) A marked subsubparagraph.');
+    expect(p.paragraphs[0]).toEqual({ text: 'A marked subsubparagraph.', level: 2, portionMarking: 'S' });
+  });
+
+  it('keeps the portion mark when the paragraph wraps across lines', () => {
+    const p = parseNavalLetter('1.  (S) This secret paragraph was wrapped\nacross two output lines.');
+    expect(p.paragraphs).toEqual([
+      { text: 'This secret paragraph was wrapped across two output lines.', level: 0, portionMarking: 'S' },
+    ]);
+  });
+
+  it('does not treat a parenthetical that is not a mark as a portion mark', () => {
+    const p = parseNavalLetter('1.  (See reference (a)) for the governing policy.');
+    expect(p.paragraphs[0].portionMarking).toBeUndefined();
+    expect(p.paragraphs[0].text).toBe('(See reference (a)) for the governing policy.');
+  });
 });
 
 describe('parseNavalLetter — paragraph levels', () => {

--- a/tests/unit/parseNavalLetter.test.ts
+++ b/tests/unit/parseNavalLetter.test.ts
@@ -69,6 +69,61 @@ describe('parseNavalLetter — full letter', () => {
   });
 });
 
+describe('parseNavalLetter — pandoc grid-table header (DOCX import)', () => {
+  // pandoc renders the letterhead / identification / From-To-Subj blocks of a
+  // DOCX letter as grid tables: indented cell text with dash separator rows.
+  // The parser must strip the rules and read the indented labels anyway.
+  const GRID_DOCX = [
+    '  ---------------- ------------------------------------- ----------------',
+    '  [image]               UNITED STATES MARINE CORPS',
+    '                            NEWBURGH, NY 12550',
+    '  ---------------- ------------------------------------- ----------------',
+    '',
+    '  ----------------------------------- -----------------------------------',
+    '                                      1650',
+    '',
+    '                                      0042',
+    '',
+    '                                      4 Jan 26',
+    '  ----------------------------------- -----------------------------------',
+    '',
+    '  ------- -----------------------------------------------------------------',
+    '  From:   Commanding Officer, Marine Innovation Unit',
+    '',
+    '  To:     Director',
+    '',
+    '  Subj:   REAL LETTERHEAD TEST',
+    '  ------- -----------------------------------------------------------------',
+    '',
+    '1.  First paragraph.',
+    '',
+    '2.  Second paragraph.',
+  ].join('\n');
+
+  it('reads the identification block from the indented grid cells', () => {
+    const p = parseNavalLetter(GRID_DOCX);
+    expect(p.ssic).toBe('1650');
+    expect(p.serial).toBe('0042');
+    expect(p.date).toBe('4 Jan 26');
+  });
+
+  it('reads indented From / To / Subj labels and drops the rule rows', () => {
+    const p = parseNavalLetter(GRID_DOCX);
+    expect(p.from).toBe('Commanding Officer, Marine Innovation Unit');
+    expect(p.to).toBe('Director');
+    // The trailing "------" rule must not be swept into the subject value.
+    expect(p.subject).toBe('REAL LETTERHEAD TEST');
+  });
+
+  it('still reads the body paragraphs', () => {
+    const p = parseNavalLetter(GRID_DOCX);
+    expect(p.paragraphs).toEqual([
+      { text: 'First paragraph.', level: 0 },
+      { text: 'Second paragraph.', level: 0 },
+    ]);
+  });
+});
+
 describe('parseNavalLetter — via addressees', () => {
   it('stores multiple via as newline-separated entries, stripping source numbering', () => {
     // The generator re-adds "(1)/(2)"; the parsed value must not bake them in.

--- a/tests/unit/parseNavalLetter.test.ts
+++ b/tests/unit/parseNavalLetter.test.ts
@@ -69,6 +69,51 @@ describe('parseNavalLetter — full letter', () => {
   });
 });
 
+describe('parseNavalLetter — via addressees', () => {
+  it('stores multiple via as newline-separated entries, stripping source numbering', () => {
+    // The generator re-adds "(1)/(2)"; the parsed value must not bake them in.
+    const p = parseNavalLetter(
+      ['From: A', 'Via:  (1) Commanding Officer', '      (2) Regional Commander', '', '1. Body.'].join('\n')
+    );
+    expect(p.via).toBe('Commanding Officer\nRegional Commander');
+  });
+
+  it('handles an inline numbered via on one line', () => {
+    const p = parseNavalLetter('From: A\nVia: (1) First Official (2) Second Official\n\n1. Body.');
+    expect(p.via).toBe('First Official\nSecond Official');
+  });
+
+  it('keeps a single via as one unnumbered line', () => {
+    const p = parseNavalLetter('From: A\nVia: Assistant Chief of Staff, G-1\n\n1. Body.');
+    expect(p.via).toBe('Assistant Chief of Staff, G-1');
+  });
+});
+
+describe('parseNavalLetter — copy to', () => {
+  it('captures a Copy to block after the signature, one recipient per line', () => {
+    const p = parseNavalLetter(
+      ['1. Body.', '', '                 R. L. SMITH', '', 'Copy to:', 'G-3/5', 'G-4', 'Regimental S-3'].join('\n')
+    );
+    expect(p.copyTos).toEqual(['G-3/5', 'G-4', 'Regimental S-3']);
+  });
+
+  it('captures an inline "Copy to: X" plus following lines', () => {
+    const p = parseNavalLetter(['1. Body.', '', 'Copy to: First Command', 'Second Command'].join('\n'));
+    expect(p.copyTos).toEqual(['First Command', 'Second Command']);
+  });
+
+  it('stops the copy-to list at a Distribution block', () => {
+    const p = parseNavalLetter(
+      ['1. Body.', '', 'Copy to:', 'Alpha Co', '', 'Distribution:', 'List B'].join('\n')
+    );
+    expect(p.copyTos).toEqual(['Alpha Co']);
+  });
+
+  it('is empty when there is no copy-to block', () => {
+    expect(parseNavalLetter('1. Body.').copyTos).toEqual([]);
+  });
+});
+
 describe('parseNavalLetter — paragraph levels', () => {
   it('maps 1. / a. / (1) / (a) to levels 0–3', () => {
     const p = parseNavalLetter(

--- a/tests/unit/parseNavalLetter.test.ts
+++ b/tests/unit/parseNavalLetter.test.ts
@@ -114,6 +114,24 @@ describe('parseNavalLetter — copy to', () => {
   });
 });
 
+describe('parseNavalLetter — portion markings', () => {
+  it('captures a leading portion mark and strips it from the text', () => {
+    const p = parseNavalLetter(
+      ['1.  (U) This paragraph is unclassified.', '', '2.  (S) This one is secret.'].join('\n')
+    );
+    expect(p.paragraphs).toEqual([
+      { text: 'This paragraph is unclassified.', level: 0, portionMarking: 'U' },
+      { text: 'This one is secret.', level: 0, portionMarking: 'S' },
+    ]);
+  });
+
+  it('captures portion marks at sub-levels and leaves unmarked paragraphs alone', () => {
+    const p = parseNavalLetter(['1.  (CUI) Top.', '    a.  Plain sub with no mark.'].join('\n'));
+    expect(p.paragraphs[0]).toEqual({ text: 'Top.', level: 0, portionMarking: 'CUI' });
+    expect(p.paragraphs[1]).toEqual({ text: 'Plain sub with no mark.', level: 1 });
+  });
+});
+
 describe('parseNavalLetter — paragraph levels', () => {
   it('maps 1. / a. / (1) / (a) to levels 0–3', () => {
     const p = parseNavalLetter(

--- a/tests/unit/parseNavalLetter.test.ts
+++ b/tests/unit/parseNavalLetter.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { parseNavalLetter } from '@/lib/parseNavalLetter';
+
+// A complete, well-formed naval letter as pdftotext would render it: the
+// identification block, the header, a two-level paragraph tree, and the
+// signature. The parser's job is to reverse this into editable fields.
+const FULL_LETTER = `
+                                                            UNITED STATES MARINE CORPS
+                                                        1ST BATTALION, 6TH MARINES
+                                                        PSC BOX 20123
+                                                        CAMP LEJEUNE, NC 28542-0123
+
+                                                                        5216
+                                                                        Ser 1710/024
+                                                                        15 Jan 25
+
+From:  Commanding Officer, 1st Battalion, 6th Marines
+To:    Sergeant J. A. Doe, USMC
+
+Subj:  APPOINTMENT AS MARINE SECURITY GUARD REPRESENTATIVE
+
+Ref:   (a) SECNAVINST 5216.5
+       (b) MCO 1500.5
+
+Encl:  (1) Duty Roster dtd 1 Jan 25
+
+1.  Per the references, you are hereby appointed as the MSG Representative.
+
+    a.  This duty is effective immediately.
+
+    b.  It is automatically revoked on transfer.
+
+2.  Direct questions to the S-1.
+
+                                                                        R. L. SMITH
+`;
+
+describe('parseNavalLetter — full letter', () => {
+  const p = parseNavalLetter(FULL_LETTER);
+
+  it('reads the identification block (SSIC / serial / date)', () => {
+    expect(p.ssic).toBe('5216');
+    expect(p.serial).toBe('1710/024');
+    expect(p.date).toBe('15 Jan 25');
+  });
+
+  it('reads From / To / Subj', () => {
+    expect(p.from).toBe('Commanding Officer, 1st Battalion, 6th Marines');
+    expect(p.to).toBe('Sergeant J. A. Doe, USMC');
+    expect(p.subject).toBe('APPOINTMENT AS MARINE SECURITY GUARD REPRESENTATIVE');
+  });
+
+  it('splits references and enclosures into titled items', () => {
+    expect(p.references).toEqual(['SECNAVINST 5216.5', 'MCO 1500.5']);
+    expect(p.enclosures).toEqual(['Duty Roster dtd 1 Jan 25']);
+  });
+
+  it('builds the paragraph tree with SECNAV levels', () => {
+    expect(p.paragraphs).toEqual([
+      { text: 'Per the references, you are hereby appointed as the MSG Representative.', level: 0 },
+      { text: 'This duty is effective immediately.', level: 1 },
+      { text: 'It is automatically revoked on transfer.', level: 1 },
+      { text: 'Direct questions to the S-1.', level: 0 },
+    ]);
+  });
+
+  it('reads the signature into initials + surname', () => {
+    expect(p.signature).toEqual({ first: 'R', middle: 'L', last: 'SMITH' });
+  });
+});
+
+describe('parseNavalLetter — paragraph levels', () => {
+  it('maps 1. / a. / (1) / (a) to levels 0–3', () => {
+    const p = parseNavalLetter(
+      ['1.  Top.', '    a.  Sub.', '        (1) Subsub.', '            (a) Deep.'].join('\n')
+    );
+    expect(p.paragraphs.map((x) => x.level)).toEqual([0, 1, 2, 3]);
+    expect(p.paragraphs.map((x) => x.text)).toEqual(['Top.', 'Sub.', 'Subsub.', 'Deep.']);
+  });
+
+  it('rejoins a paragraph wrapped across lines', () => {
+    const p = parseNavalLetter('1.  This sentence was wrapped\nacross two output lines.');
+    expect(p.paragraphs).toEqual([
+      { text: 'This sentence was wrapped across two output lines.', level: 0 },
+    ]);
+  });
+
+  it('does not read a paren item as an arabic paragraph', () => {
+    // "(1)" must be level 2, never level 0 from a naive "1." test.
+    const p = parseNavalLetter('(1) A subsubparagraph standing alone.');
+    expect(p.paragraphs[0].level).toBe(2);
+  });
+});
+
+describe('parseNavalLetter — resilience', () => {
+  it('stops the body at a Copy to / Distribution block', () => {
+    const p = parseNavalLetter(
+      ['1.  Body paragraph.', '', 'Copy to:', 'Some Command'].join('\n')
+    );
+    expect(p.paragraphs).toEqual([{ text: 'Body paragraph.', level: 0 }]);
+  });
+
+  it('handles an inline Ref list on one line', () => {
+    const p = parseNavalLetter('Ref:  (a) First (b) Second (c) Third\n\n1. Body.');
+    expect(p.references).toEqual(['First', 'Second', 'Third']);
+  });
+
+  it('reads a one-initial signature (no middle name)', () => {
+    const p = parseNavalLetter('1. Body.\n\n                 A. DOE');
+    expect(p.signature).toEqual({ first: 'A', middle: '', last: 'DOE' });
+  });
+
+  it('keeps a prefixed surname capital (McNALLY)', () => {
+    const p = parseNavalLetter('1. Body.\n\n                 P. W. McNALLY');
+    expect(p.signature).toEqual({ first: 'P', middle: 'W', last: 'McNALLY' });
+  });
+
+  it('never throws on unstructured text, and treats it as body', () => {
+    const p = parseNavalLetter('just some free text with no structure at all');
+    expect(p.from).toBeUndefined();
+    expect(p.references).toEqual([]);
+    // No numbered paragraphs → nothing captured, but no crash.
+    expect(p.paragraphs).toEqual([]);
+  });
+
+  it('accepts long-form labels (Subject:, Reference:, Enclosure:)', () => {
+    const p = parseNavalLetter(
+      ['From: A', 'Subject: THE SUBJECT', 'Reference: (a) X', 'Enclosure: (1) Y', '', '1. Body.'].join(
+        '\n'
+      )
+    );
+    expect(p.subject).toBe('THE SUBJECT');
+    expect(p.references).toEqual(['X']);
+    expect(p.enclosures).toEqual(['Y']);
+  });
+
+  it('reads a bare four-digit serial under the SSIC (DonDocs prints no "Ser")', () => {
+    // The identification block stacks SSIC / serial / date; DonDocs renders the
+    // serial as a bare "0042", which a shape-only test would drop as an SSIC.
+    const p = parseNavalLetter(['1650', '0042', '4 Jan 26', '', 'From: A', '', '1. Body.'].join('\n'));
+    expect(p.ssic).toBe('1650');
+    expect(p.serial).toBe('0042');
+    expect(p.date).toBe('4 Jan 26');
+  });
+
+  it('does not mistake a body number for an SSIC', () => {
+    // 5216-shaped numbers below the header must not be claimed as identification.
+    const p = parseNavalLetter('From: A\n\n1. Reference 5216 in the body.');
+    expect(p.ssic).toBeUndefined();
+  });
+});

--- a/tests/unit/pdfText.test.ts
+++ b/tests/unit/pdfText.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { itemsToLines, type PositionedItem } from '@/lib/pdfText';
+
+// pdf.js hands back positioned fragments; itemsToLines regroups them into
+// lines. Model fragments as {str, x, y, height}; PDF Y grows upward, so a
+// higher y is a higher line on the page.
+const item = (str: string, x: number, y: number, height = 10): PositionedItem => ({
+  str,
+  x,
+  y,
+  height,
+});
+
+describe('itemsToLines', () => {
+  it('groups fragments on the same baseline into one left-to-right line', () => {
+    // Deliberately out of reading order to prove the sort.
+    const items = [item('world', 60, 700), item('Hello ', 10, 700)];
+    expect(itemsToLines(items)).toEqual(['Hello world']);
+  });
+
+  it('orders lines top-to-bottom by descending y', () => {
+    const items = [item('second', 10, 680), item('first', 10, 700)];
+    expect(itemsToLines(items)).toEqual(['first', 'second']);
+  });
+
+  it('keeps two nearby baselines as separate lines', () => {
+    // 14pt apart with 10pt text: beyond the 0.5×height tolerance → two lines.
+    const items = [item('From:', 10, 700), item('To:', 10, 686)];
+    expect(itemsToLines(items)).toEqual(['From:', 'To:']);
+  });
+
+  it('absorbs sub-baseline jitter within the tolerance into one line', () => {
+    // A superscript-ish fragment 3pt up on a 10pt line stays on the line.
+    const items = [item('MOS', 10, 700), item('(0311)', 40, 703)];
+    expect(itemsToLines(items)).toEqual(['MOS(0311)']);
+  });
+
+  it('returns an empty array for no items', () => {
+    expect(itemsToLines([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
Requested in #203's neighborhood and asked for directly: bring an existing letter you only have as a PDF back into the editor, instead of retyping it. Save → **Import letter from PDF…** reads the PDF and loads it as a new editable naval letter.

## How it works

The whole read happens in the browser through the **pdf.js already bundled for the preview** — no upload, **no new dependency, no CDN reference** (the `check-no-cdn` build guard passes), so it holds on NMCI/air-gapped networks. There was no open-source naval-letter parser to reuse; the one reusable idea (reconstructing lines from pdf.js's positioned fragments) is ~30 lines written here rather than a vendored library.

Pipeline, in pure/testable pieces:
- **`pdfText.ts`** — pdf.js → text, regrouping positioned fragments into lines (pdf.js returns fragments, not lines). The line-grouper is exported and unit-tested without a live document.
- **`parseNavalLetter.ts`** — a pure, forgiving SECNAV parser: From/To/Via/Subj, SSIC/serial/date, Ref/Encl lists, the `1.`/`a.`/`(1)`/`(a)` paragraph tree, and the signer's name. Never throws; unstructured text yields whatever was recognizable.
- **`importLetter.ts`** — loads the parse as a **new** document (`syncCurrent` + `openLoadedAsNew`), so your current letter is preserved.
- **`ImportLetterModal`** — shows every recognized field for review **before** anything is written. A scanned/image PDF (no text layer) is reported, not silently empty.

## Scope

- **Text-based PDFs only.** OCR of scans is the deliberate next phase (a vendored Tesseract-WASM engine, per the pandoc air-gap playbook).
- Naval letters. Memos/forms can follow once the header-mapping is proven.
- Best-effort by design — hence the review step and the "check every field after importing" note.

## Verification

- **Live end-to-end round-trip**: a DonDocs-exported letter (SSIC 1650 / Ser 0042 / award request, 2 refs, 1 encl, 4 paragraphs, signer R. L. SMITH) imported back through pdf.js + the parser with **every field intact**, then populated the editor. This surfaced and fixed a real bug — the bare four-digit serial being dropped as SSIC-shaped.
- **21 unit tests** over the parser (full-letter fixture, level mapping, wrapped-line rejoin, inline/multiline ref lists, one/two-initial and prefixed-surname signatures, resilience) and the line-grouper.
- Full suite green (1783 unit tests), production build + CDN guard OK.