### PR TITLE
feat(classification): validate the banner against portion markings (1.2.109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,22 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
-## [1.2.108] — 2026-07-18
+## [1.2.109] — 2026-07-18
+
+### Added
+
+- The Classification section now **checks your markings against each other**.
+  DonDocs renders the banner and per-paragraph portion marks; it now also
+  validates that they agree, following the "highest classification wins" rule
+  (DoDM 5200.01 for classified, DoDI 5200.48 / 32 CFR 2002 for CUI). The
+  serious case it catches is **under-marking** — a paragraph marked higher than
+  the document's banner (e.g. a (S) paragraph under a CONFIDENTIAL banner),
+  flagged as an error because the overall marking must be at least the highest
+  portion. It also warns on a classified/CUI document with no portion marks,
+  on partial marking (some paragraphs marked and some not), on over-marking
+  (a banner higher than every portion), and on mixing CUI with legacy FOUO.
+  The findings appear inline in the section as you edit — advisory, never
+  blocking — and are announced to screen readers.
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dondocs",
-  "version": "1.2.108",
+  "version": "1.2.109",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dondocs",
-      "version": "1.2.108",
+      "version": "1.2.109",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.108",
+  "version": "1.2.109",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/src/components/editor/ClassificationSection.tsx
+++ b/src/components/editor/ClassificationSection.tsx
@@ -14,8 +14,9 @@ import {
   type ClassificationLevel,
   type ClassificationRestriction,
 } from '@/lib/domainClassification';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { getClassificationConfig } from '@/config/classification';
+import { validateClassificationMarkings } from '@/lib/classificationValidation';
 
 // Official CNSI/ISOO banner colors (EO 13526, 32 CFR 2001/2002, DoDM 5200.01,
 // CAPCO Register, ISOO directive). Hex codes match the dodcui.mil/ISOO table:
@@ -82,7 +83,17 @@ const DISTRIBUTION_STATEMENTS = [
 
 export function ClassificationSection() {
   const { formData, setField } = useDocumentStore();
+  const paragraphs = useDocumentStore((s) => s.paragraphs);
   const classLevel = formData.classLevel || 'unclassified';
+
+  // Banner ↔ portion-marking consistency ("highest classification wins"). An
+  // under-marked paragraph (marked higher than the banner) is the finding that
+  // most needs catching; the rest are advisory. Recomputed only when the level
+  // or paragraph markings change.
+  const markingFindings = useMemo(
+    () => validateClassificationMarkings(classLevel, paragraphs),
+    [classLevel, paragraphs]
+  );
   const [configOverride, setConfigOverride] = useState<{ restriction?: ClassificationRestriction; message?: string } | null>(null);
   const [configLoaded, setConfigLoaded] = useState(false);
 
@@ -210,6 +221,29 @@ export function ClassificationSection() {
                 </SelectContent>
               </Select>
             </div>
+
+            {/* Banner ↔ portion-marking consistency findings. aria-live so a
+                new under-marking is announced without stealing focus. */}
+            {markingFindings.length > 0 && (
+              <div className="space-y-2" aria-live="polite">
+                {markingFindings.map((finding, i) => {
+                  const accent = finding.severity === 'error' ? 'text-destructive' : 'text-warning';
+                  return (
+                    <Notice key={i} variant={finding.severity === 'error' ? 'error' : 'warning'}>
+                      <div className="flex items-start gap-2 text-sm">
+                        <AlertTriangle aria-hidden="true" className={`h-4 w-4 mt-0.5 shrink-0 ${accent}`} />
+                        <span className={accent}>
+                          <span className="sr-only">
+                            {finding.severity === 'error' ? 'Error: ' : 'Warning: '}
+                          </span>
+                          {finding.message}
+                        </span>
+                      </div>
+                    </Notice>
+                  );
+                })}
+              </div>
+            )}
 
             {/* Warning for classified documents */}
             {isClassified && (

--- a/src/lib/classificationValidation.ts
+++ b/src/lib/classificationValidation.ts
@@ -1,0 +1,126 @@
+import type { Paragraph, PortionMarking } from '@/types/document';
+
+/**
+ * Consistency checks between a document's overall classification (the banner)
+ * and its per-paragraph portion markings. The governing rule is "highest
+ * classification wins": the banner must reflect the highest portion marking in
+ * the document (DoDM 5200.01 for classified, DoDI 5200.48 / 32 CFR 2002 for
+ * CUI). DonDocs renders both markings; this validates that they agree, so a
+ * paragraph marked SECRET under an UNCLASSIFIED banner (an under-marking, the
+ * serious case) can't leave the editor unnoticed.
+ *
+ * Advisory, never blocking — the editor surfaces the findings; the drafter
+ * decides. Pure and leaf so the rules are exhaustively unit-testable.
+ */
+
+export interface ClassificationFinding {
+  severity: 'error' | 'warning';
+  message: string;
+}
+
+// Overall banner level → rank. 'custom' is the unaccredited, unclassified-only
+// path, so it ranks with unclassified; an unknown value is treated the same.
+const BANNER_RANK: Record<string, number> = {
+  unclassified: 0,
+  custom: 0,
+  cui: 1,
+  confidential: 2,
+  secret: 3,
+  top_secret: 4,
+  top_secret_sci: 5,
+};
+
+// Portion marking → rank. FOUO is legacy CUI, so it ranks with CUI. There is no
+// portion abbreviation for the SCI control system, so TS is the ceiling here.
+const PORTION_RANK: Record<PortionMarking, number> = {
+  U: 0,
+  CUI: 1,
+  FOUO: 1,
+  C: 2,
+  S: 3,
+  TS: 4,
+};
+
+const RANK_LABEL = ['UNCLASSIFIED', 'CUI', 'CONFIDENTIAL', 'SECRET', 'TOP SECRET', 'TOP SECRET//SCI'];
+
+function bannerRank(classLevel: string): number {
+  return BANNER_RANK[classLevel] ?? 0;
+}
+
+function bannerLabel(classLevel: string): string {
+  return classLevel === 'custom' ? 'the custom marking' : RANK_LABEL[bannerRank(classLevel)];
+}
+
+/** The highest portion marking present among body paragraphs, or null. */
+function highestPortion(marked: PortionMarking[]): { marking: PortionMarking; rank: number } | null {
+  let best: { marking: PortionMarking; rank: number } | null = null;
+  for (const m of marked) {
+    const rank = PORTION_RANK[m];
+    if (!best || rank > best.rank) best = { marking: m, rank };
+  }
+  return best;
+}
+
+export function validateClassificationMarkings(
+  classLevel: string,
+  paragraphs: Paragraph[]
+): ClassificationFinding[] {
+  const findings: ClassificationFinding[] = [];
+
+  // Only body paragraphs with real text carry portion markings; blank rows and
+  // headings don't count toward "every paragraph is marked".
+  const body = paragraphs.filter((p) => (p.text ?? '').trim() !== '');
+  if (body.length === 0) return findings;
+
+  const marked = body.map((p) => p.portionMarking).filter((m): m is PortionMarking => !!m);
+  const highest = highestPortion(marked);
+  const banner = bannerRank(classLevel);
+
+  // 1. Under-marking (the serious one): a portion outranks the banner. The
+  //    overall marking must be at least the highest portion.
+  if (highest && highest.rank > banner) {
+    findings.push({
+      severity: 'error',
+      message: `A paragraph is marked (${highest.marking}) — ${RANK_LABEL[highest.rank]} — but the document banner is ${bannerLabel(classLevel)}. The overall marking must be at least the highest portion.`,
+    });
+  }
+
+  // 2. A classified/CUI banner with no portion markings at all. Classified and
+  //    CUI documents must be portion-marked.
+  if (banner >= 1 && marked.length === 0) {
+    findings.push({
+      severity: 'warning',
+      message: `This document is marked ${bannerLabel(classLevel)} but no paragraphs carry a portion marking. Mark each paragraph with its classification.`,
+    });
+  }
+
+  // 3. Partial marking: some body paragraphs marked, some not. Every paragraph
+  //    must be marked, or none (an unclassified working draft).
+  if (banner >= 1 && marked.length > 0 && marked.length < body.length) {
+    findings.push({
+      severity: 'warning',
+      message: `${marked.length} of ${body.length} paragraphs are portion-marked. Mark every paragraph, not just some.`,
+    });
+  }
+
+  // 4. Over-marking: the banner outranks the highest portion. Usually the
+  //    overall marking equals the highest portion, so flag it (a warning, since
+  //    a higher banner can be legitimate — e.g. a classified reference in the
+  //    header the body doesn't repeat).
+  if (highest && banner > highest.rank && classLevel !== 'custom') {
+    findings.push({
+      severity: 'warning',
+      message: `The document banner is ${bannerLabel(classLevel)} but the highest paragraph marking is (${highest.marking}) — ${RANK_LABEL[highest.rank]}. The overall marking normally equals the highest portion.`,
+    });
+  }
+
+  // 5. Mixed CUI and legacy FOUO in the same document — pick one scheme.
+  if (marked.includes('CUI') && marked.includes('FOUO')) {
+    findings.push({
+      severity: 'warning',
+      message: 'This document mixes CUI and the legacy FOUO marking. Use one scheme — CUI supersedes FOUO.',
+    });
+  }
+
+  return findings;
+}

--- a/tests/unit/classificationValidation.test.ts
+++ b/tests/unit/classificationValidation.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { validateClassificationMarkings } from '@/lib/classificationValidation';
+import type { Paragraph, PortionMarking } from '@/types/document';
+
+const para = (text: string, portionMarking?: PortionMarking): Paragraph => ({
+  text,
+  level: 0,
+  portionMarking,
+});
+
+const severities = (classLevel: string, paragraphs: Paragraph[]) =>
+  validateClassificationMarkings(classLevel, paragraphs).map((f) => f.severity);
+
+describe('validateClassificationMarkings — under-marking (the serious case)', () => {
+  it('errors when a portion outranks an UNCLASSIFIED banner', () => {
+    const findings = validateClassificationMarkings('unclassified', [para('Body.', 'S')]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].message).toMatch(/\(S\)/);
+    expect(findings[0].message).toMatch(/UNCLASSIFIED/);
+  });
+
+  it('errors when a portion outranks a CUI banner', () => {
+    // A SECRET portion under a CUI banner is still under-marked.
+    expect(severities('cui', [para('a', 'CUI'), para('b', 'S')])).toContain('error');
+  });
+
+  it('is clean when the banner equals the highest portion', () => {
+    expect(validateClassificationMarkings('secret', [para('a', 'S'), para('b', 'C')])).toEqual([]);
+  });
+});
+
+describe('validateClassificationMarkings — missing / partial marking', () => {
+  it('warns when a classified banner has no portion markings', () => {
+    const findings = validateClassificationMarkings('secret', [para('a'), para('b')]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].message).toMatch(/no paragraphs carry a portion marking/);
+  });
+
+  it('warns when only some paragraphs are marked', () => {
+    const findings = validateClassificationMarkings('secret', [para('a', 'S'), para('b')]);
+    expect(findings.some((f) => /1 of 2 paragraphs/.test(f.message))).toBe(true);
+  });
+
+  it('does not require portion markings on an UNCLASSIFIED document', () => {
+    expect(validateClassificationMarkings('unclassified', [para('a'), para('b')])).toEqual([]);
+  });
+
+  it('ignores blank rows when counting marked vs unmarked', () => {
+    // The trailing blank paragraph must not read as an "unmarked" body paragraph.
+    expect(validateClassificationMarkings('secret', [para('a', 'S'), para('   ')])).toEqual([]);
+  });
+});
+
+describe('validateClassificationMarkings — over-marking', () => {
+  it('warns when the banner outranks every portion', () => {
+    const findings = validateClassificationMarkings('secret', [para('a', 'C'), para('b', 'C')]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('warning');
+    expect(findings[0].message).toMatch(/highest paragraph marking is \(C\)/);
+  });
+
+  it('does not over-mark-warn on the custom (unaccredited) banner', () => {
+    // 'custom' ranks with unclassified; a CUI portion under it is an
+    // under-marking error, not an over-marking warning.
+    expect(severities('custom', [para('a', 'CUI')])).toEqual(['error']);
+  });
+});
+
+describe('validateClassificationMarkings — FOUO / CUI equivalence', () => {
+  it('treats FOUO as CUI-rank (a FOUO portion under a CUI banner is consistent)', () => {
+    expect(validateClassificationMarkings('cui', [para('a', 'FOUO')])).toEqual([]);
+  });
+
+  it('warns when CUI and legacy FOUO markings are mixed', () => {
+    const findings = validateClassificationMarkings('cui', [para('a', 'CUI'), para('b', 'FOUO')]);
+    expect(findings.some((f) => /mixes CUI and the legacy FOUO/.test(f.message))).toBe(true);
+  });
+});
+
+describe('validateClassificationMarkings — no-ops', () => {
+  it('returns nothing for an empty document', () => {
+    expect(validateClassificationMarkings('secret', [])).toEqual([]);
+    expect(validateClassificationMarkings('unclassified', [para('  ')])).toEqual([]);
+  });
+
+  it('a fully consistent CUI document has no findings', () => {
+    expect(validateClassificationMarkings('cui', [para('a', 'CUI'), para('b', 'CUI')])).toEqual([]);
+  });
+});


### PR DESCRIPTION
DonDocs renders the overall classification banner and per-paragraph portion marks, but until now it never checked that the two agree. This adds that check — the natural next step for the classification engine, and the one that turns marking from "displayed" into "verified."

## The rule

"Highest classification wins" (DoDM 5200.01 for classified, DoDI 5200.48 / 32 CFR 2002 for CUI): the document's overall marking must reflect the highest portion marking present. Rendering a marking without validating it lets a real defect through — a paragraph marked SECRET under a CONFIDENTIAL banner exports with declassification metadata a level too low, and nothing flags it.

## What it checks

`validateClassificationMarkings(classLevel, paragraphs)` is a pure, leaf function returning advisory findings:

- **error — under-marking**: a portion outranks the banner (a (S) paragraph under a CONFIDENTIAL banner). The serious one.
- **warning — unmarked**: a classified/CUI banner with no portion marks at all.
- **warning — partial**: some paragraphs marked, some not.
- **warning — over-marking**: the banner outranks every portion.
- **warning — mixed**: CUI and the legacy FOUO marking in the same document.

FOUO ranks with CUI; the unaccredited 'custom' banner ranks with unclassified (so a CUI portion under it is correctly an under-marking).

## Surfacing

Findings render inline in the Classification section as you edit — advisory, never blocking — wrapped in `aria-live="polite"` so a new under-marking is announced to screen readers without stealing focus, with an `sr-only` "Error:"/"Warning:" prefix.

## Verification

- **13 unit tests** cover every rule (under/over/partial/missing marking, FOUO≡CUI, custom-banner ranking, blank-row handling, no-ops).
- **Live-verified**: on a CONFIDENTIAL letter, the missing-marking warning appeared; setting a paragraph to (S) produced the exact under-marking error and the partial-marking warning, and both reacted live to the level and portion changes. (The preview banner already auto-elevates to SECRET in that state — so the finding is catching a genuine mismatch between the shown banner and the selected level's declassification block.)
- Full suite green (1,775 unit tests), production build + CDN guard OK.