### PR TITLE
feat(ux): fuzzy command palette + design-token strays (1.2.111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 Releases before 1.2.0 predate this file and are recorded only as git tags.
 
-## [1.2.110] — 2026-07-18
+## [1.2.111] — 2026-07-19
+
+### Changed
+
+- **The command palette (⌘K) now matches on subsequences, not just substrings.**
+  Typing an acronym like "nnl" finds "New Naval Letter"; the matched letters are
+  highlighted in each result, and results are ranked by match quality (a
+  start-of-word or prefix match beats a scattered one).
+
+### Fixed
+
+- A few design-token strays: the "Clear fields" confirm button now uses the
+  shared warning color instead of a raw orange; two focus rings that were still
+  the old 2px width match the app's 3px ring; and the paragraph editor's text
+  caret is tinted to the brand color.
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dondocs",
   "private": true,
-  "version": "1.2.110",
+  "version": "1.2.111",
   "description": "Browser-based SECNAV M-5216.5 naval correspondence and forms generator.",
   "type": "module",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1893,7 +1893,7 @@ ${texFiles['body.tex'] || '% No body content'}
       {/* Skip link for keyboard navigation - WCAG 2.4.1 */}
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-md focus:outline-none focus:ring-2 focus:ring-ring"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-md focus:outline-none focus:ring-[3px] focus:ring-ring/50"
       >
         Skip to main content
       </a>

--- a/src/components/editor/DocumentTypeSelector.tsx
+++ b/src/components/editor/DocumentTypeSelector.tsx
@@ -294,7 +294,7 @@ export function DocumentTypeSelector() {
                 clearFieldsExceptLetterhead();
                 setShowClearDialog(false);
               }}
-              className="bg-orange-600 text-white hover:bg-orange-700"
+              className="bg-warning text-warning-foreground hover:bg-warning/90"
             >
               Clear fields
             </AlertDialogAction>

--- a/src/components/modals/CommandPalette.tsx
+++ b/src/components/modals/CommandPalette.tsx
@@ -3,6 +3,26 @@ import { createPortal } from 'react-dom';
 import { Search, SearchX, type LucideIcon } from 'lucide-react';
 import { Kbd } from '@/components/ui/kbd';
 import { cn } from '@/lib/utils';
+import { fuzzyMatch } from '@/lib/fuzzyMatch';
+
+/** Render `text` with the matched character positions emphasized. */
+function Highlighted({ text, indices }: { text: string; indices: number[] }) {
+  if (indices.length === 0) return <>{text}</>;
+  const hit = new Set(indices);
+  return (
+    <>
+      {Array.from(text, (ch, i) =>
+        hit.has(i) ? (
+          <span key={i} className="font-semibold text-current">
+            {ch}
+          </span>
+        ) : (
+          ch
+        )
+      )}
+    </>
+  );
+}
 
 export interface CommandItem {
   id: string;
@@ -55,14 +75,27 @@ export function CommandPalette({
     };
   }, []);
 
-  const q = query.trim().toLowerCase();
+  const q = query.trim();
+  // Subsequence-match each item against its label (then its hint), rank
+  // best-first within the group, and remember where the label matched so the
+  // matched characters can be highlighted in the row.
+  const labelHits = new Map<string, number[]>();
   const filtered = groups
-    .map((g) => ({
-      ...g,
-      items: g.items.filter(
-        (it) => !q || it.label.toLowerCase().includes(q) || it.hint?.toLowerCase().includes(q)
-      ),
-    }))
+    .map((g) => {
+      const scored = g.items
+        .map((it) => {
+          const onLabel = fuzzyMatch(it.label, q);
+          const onHint = onLabel ? null : it.hint ? fuzzyMatch(it.hint, q) : null;
+          const m = onLabel ?? onHint;
+          if (!m) return null;
+          labelHits.set(it.id, onLabel ? onLabel.indices : []);
+          return { it, score: m.score };
+        })
+        .filter((x): x is { it: CommandItem; score: number } => x !== null);
+      // Keep the authored order with no query; rank by match quality once typing.
+      if (q) scored.sort((a, b) => b.score - a.score);
+      return { ...g, items: scored.map((x) => x.it) };
+    })
     .filter((g) => g.items.length > 0);
   const flat = filtered.flatMap((g) => g.items);
   const clampedSel = Math.min(sel, Math.max(0, flat.length - 1));
@@ -189,7 +222,9 @@ export function CommandPalette({
                       )}
                     >
                       <Icon className={cn('h-4 w-4 shrink-0', active ? 'text-current' : 'text-muted-foreground')} />
-                      <span className="flex-1 truncate text-sm">{it.label}</span>
+                      <span className="flex-1 truncate text-sm">
+                        <Highlighted text={it.label} indices={labelHits.get(it.id) ?? []} />
+                      </span>
                       {it.hint && (
                         <span className={cn('text-2xs', active ? 'text-current opacity-85' : 'text-muted-foreground')}>
                           {it.hint}

--- a/src/components/ui/variable-chip-editor.tsx
+++ b/src/components/ui/variable-chip-editor.tsx
@@ -746,8 +746,8 @@ export function VariableChipEditor({
         // generator already preserves them; this just keeps the editor
         // visually faithful to what gets generated.
         class: blockMode
-          ? 'focus:outline-none whitespace-pre-wrap text-sm leading-relaxed'
-          : 'prose prose-sm dark:prose-invert max-w-none focus:outline-none px-3 py-2 whitespace-pre-wrap',
+          ? 'caret-primary focus:outline-none whitespace-pre-wrap text-sm leading-relaxed'
+          : 'prose prose-sm dark:prose-invert max-w-none caret-primary focus:outline-none px-3 py-2 whitespace-pre-wrap',
         style: blockMode ? 'min-height: 1.5em' : `min-height: ${rows * 24}px`,
       },
       // Tab key inserts 4 spaces (matching the SECNAV 0.25" / wrap-helper
@@ -964,7 +964,7 @@ export function VariableChipEditor({
   return (
     <div className={cn(
       'relative border rounded-md bg-background transition-colors overflow-hidden',
-      isFocused ? 'ring-2 ring-ring ring-offset-2' : 'border-input',
+      isFocused ? 'ring-[3px] ring-ring/50 ring-offset-2 ring-offset-background' : 'border-input',
       className
     )}>
       <EditorToolbar editor={editor} />

--- a/src/lib/fuzzyMatch.ts
+++ b/src/lib/fuzzyMatch.ts
@@ -1,0 +1,53 @@
+/**
+ * Subsequence fuzzy matching for the command palette. A query matches when its
+ * characters appear in order (not necessarily adjacent) in the target, so "nnl"
+ * finds "New Naval Letter" — substring matching returned nothing before.
+ *
+ * The score rewards the qualities that make a match feel "right": characters
+ * that land at the start of a word or the string, and contiguous runs, so an
+ * exact prefix beats a scattered subsequence. Returned `indices` are the matched
+ * character positions in the ORIGINAL string, for highlighting.
+ *
+ * Pure and leaf — unit-tested independently of the palette UI.
+ */
+
+export interface FuzzyMatch {
+  score: number;
+  /** Positions in the original string that matched, ascending. */
+  indices: number[];
+}
+
+const isBoundary = (ch: string | undefined): boolean => ch === undefined || /[\s\-_/().,:]/.test(ch);
+
+/**
+ * Match `query` against `text` as a subsequence. Returns the score and matched
+ * indices, or null if `text` doesn't contain the query characters in order. An
+ * empty query matches everything with a neutral score and no highlight.
+ */
+export function fuzzyMatch(text: string, query: string): FuzzyMatch | null {
+  const q = query.trim().toLowerCase();
+  if (!q) return { score: 0, indices: [] };
+
+  const t = text.toLowerCase();
+  const indices: number[] = [];
+  let from = 0;
+  let score = 0;
+  let prev = -2; // last matched index, for detecting contiguous runs
+
+  for (const ch of q) {
+    const at = t.indexOf(ch, from);
+    if (at === -1) return null; // not a subsequence — no match
+
+    // Quality bonuses, largest where a human would expect the strongest signal.
+    if (at === 0) score += 12; // very start of the string
+    else if (isBoundary(t[at - 1])) score += 9; // start of a word
+    if (at === prev + 1) score += 6; // contiguous with the previous match
+    score += Math.max(0, 4 - at * 0.1); // earlier in the string is a little better
+
+    indices.push(at);
+    prev = at;
+    from = at + 1;
+  }
+
+  return { score, indices };
+}

--- a/tests/unit/fuzzyMatch.test.ts
+++ b/tests/unit/fuzzyMatch.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { fuzzyMatch } from '@/lib/fuzzyMatch';
+
+describe('fuzzyMatch — subsequence matching', () => {
+  it('matches an acronym-style subsequence that substring search misses', () => {
+    const m = fuzzyMatch('New Naval Letter', 'nnl');
+    expect(m).not.toBeNull();
+    // Greedy earliest match: N(0), N(4), then the first l — the "l" in "Naval" (8).
+    expect(m!.indices).toEqual([0, 4, 8]);
+  });
+
+  it('matches a plain substring', () => {
+    const m = fuzzyMatch('Save draft', 'draf');
+    expect(m).not.toBeNull();
+    expect(m!.indices).toEqual([5, 6, 7, 8]);
+  });
+
+  it('returns null when the characters are out of order', () => {
+    expect(fuzzyMatch('Save draft', 'tfard')).toBeNull();
+  });
+
+  it('returns null when a character is absent', () => {
+    expect(fuzzyMatch('Save draft', 'savez')).toBeNull();
+  });
+
+  it('is case-insensitive', () => {
+    expect(fuzzyMatch('Export DOCX', 'docx')).not.toBeNull();
+    expect(fuzzyMatch('Export DOCX', 'DOCX')).not.toBeNull();
+  });
+
+  it('treats an empty query as a neutral match with no highlight', () => {
+    expect(fuzzyMatch('anything', '')).toEqual({ score: 0, indices: [] });
+  });
+});
+
+describe('fuzzyMatch — scoring quality', () => {
+  it('ranks a start-of-string prefix above a mid-word hit', () => {
+    const prefix = fuzzyMatch('Save draft', 'sa')!;
+    const midword = fuzzyMatch('Undo save', 'sa')!;
+    expect(prefix.score).toBeGreaterThan(midword.score);
+  });
+
+  it('ranks a contiguous run above a scattered subsequence', () => {
+    const contiguous = fuzzyMatch('letter', 'let')!;
+    const scattered = fuzzyMatch('leaflet stack', 'let')!;
+    expect(contiguous.score).toBeGreaterThan(scattered.score);
+  });
+
+  it('rewards word-boundary starts (acronym scores well)', () => {
+    const acronym = fuzzyMatch('New Naval Letter', 'nnl')!;
+    // Three word-initial hits should out-score the same letters mid-word.
+    const midword = fuzzyMatch('annulling', 'nnl')!;
+    expect(acronym.score).toBeGreaterThan(midword.score);
+  });
+});


### PR DESCRIPTION
Closes the last verified findings from the UX audit — one behavior change and three token strays, in a single sweep.

## Command palette: subsequence matching
Typing an acronym like `nnl` now finds **New Naval Letter** — previously substring matching returned nothing. Matched characters are highlighted in each row, and results are ranked by match quality (a start-of-word or prefix match outscores a scattered subsequence). Backed by a pure `fuzzyMatch()` helper with unit tests; the footer legend and match highlighting complete the palette.

## Token strays
- **"Clear fields" confirm button** → the shared `--warning` token instead of a raw `bg-orange-600`.
- **Two lingering 2px focus rings** (skip link, variable-chip editor) → the app's `ring-[3px] ring-ring/50`.
- **Paragraph-editor caret** → tinted to the brand color (`caret-primary`).

The 4 remaining `ring-2` uses (PDF page-active, guide highlight, tour spotlight, classification active-preset) are intentional decorative rings and are left as-is.

## Verify
- `tsc -b`, eslint clean; **1881 tests** (10 new for `fuzzyMatch`).
- Live: `⌘K` → `nnl` surfaces "New Naval Letter" with N/N/L highlighted and the `↵ / ↑↓ / esc` legend.

## Not in scope
The ~279-item nitpick tail from the audit is cosmetic backlog, not a single shippable change — left tracked for a future bounded pass.
